### PR TITLE
feat: Client management summary statistics and @type mapping

### DIFF
--- a/openspec/changes/2026-03-20-client-management/design.md
+++ b/openspec/changes/2026-03-20-client-management/design.md
@@ -1,0 +1,32 @@
+# Design: client-management enhancements
+
+## Architecture Overview
+
+All changes are frontend-only. Data operations use the existing generic object store (`useObjectStore`) which calls OpenRegister's API. Contact sync uses the existing `/api/contacts-sync/write-back` endpoint.
+
+## Key Design Decisions
+
+### 1. Summary Statistics Card
+
+**Decision**: Add a `CnDetailCard` with computed summary stats calculated from the already-fetched `leads` and `requests` arrays in `ClientDetail.vue`.
+
+**Rationale**: The detail view already fetches linked leads and requests. Computing counts/sums from these arrays avoids additional API calls. The stats card appears between Client Information and Contacts sections.
+
+**Fields displayed**:
+- Open leads: count and total value
+- Won leads: count and total value
+- Open requests: count
+- Total value: open + won leads
+- Client since: creation date from object metadata
+
+### 2. Contact Detail Sync
+
+**Decision**: Replicate the `syncToContacts()` pattern from `ClientDetail.vue` into `ContactDetail.vue`.
+
+**Rationale**: The backend `/api/contacts-sync/write-back` endpoint already supports both `objectType=client` and `objectType=contact`. Only the frontend trigger is missing.
+
+### 3. Dynamic @type
+
+**Decision**: Set `@type` in the form data based on the selected `type` field: `person` -> `schema:Person`, `organization` -> `schema:Organization`.
+
+**Rationale**: OpenRegister uses `@type` for Schema.org compliance. The register schema defaults `@type` to `schema:Person` but this should vary by client type.

--- a/openspec/changes/2026-03-20-client-management/proposal.md
+++ b/openspec/changes/2026-03-20-client-management/proposal.md
@@ -1,0 +1,33 @@
+# Proposal: client-management enhancements
+
+## Problem
+
+The client management spec identifies several MVP gaps that remain unimplemented:
+1. No summary statistics panel on client detail view (open leads count/value, won leads count/value, open requests count)
+2. Contact person detail view does not trigger write-back sync to Nextcloud Contacts on save
+3. Contact person detail view does not show "Synced with Contacts" badge
+4. Client `@type` is not dynamically set based on `type` field (always defaults to `schema:Person`)
+
+## Proposed Change
+
+Implement the missing MVP features:
+- Add a summary statistics card to `ClientDetail.vue` showing aggregated lead/request counts and values
+- Add write-back sync to `ContactDetail.vue` on save (same pattern as ClientDetail)
+- Add sync status badge to `ContactDetail.vue`
+- Set `@type` dynamically in `ClientForm.vue` based on selected type
+
+### Out of Scope
+- Duplicate detection (V1)
+- Import/export CSV/vCard (V1)
+- KVK integration in client form (V1)
+- BSN handling (Enterprise)
+- Client hierarchy (V1)
+- Client segmentation/tagging (V1)
+- Health scoring (Enterprise)
+- GDPR data subject rights (V1)
+
+## Impact
+
+- **Files modified**: 2-3 Vue files
+- **New files**: 0
+- **Risk**: Low -- enhancing existing frontend components with additional sections

--- a/openspec/changes/2026-03-20-client-management/specs/client-management/spec.md
+++ b/openspec/changes/2026-03-20-client-management/specs/client-management/spec.md
@@ -1,0 +1,16 @@
+# Delta Spec: client-management enhancements
+
+## Changes to specs/client-management/spec.md
+
+### Updated Implementation Status
+
+The following items have been newly implemented:
+
+- **Summary statistics panel** on ClientDetail.vue: Shows open leads count + value, won leads count + value, open requests count, and total value with EUR formatting. Values computed from already-fetched related entities.
+- **Dynamic @type mapping** in ClientForm.vue: Sets `@type` to `schema:Organization` for organization clients and `schema:Person` for person clients on save.
+
+### Corrections to Previous Assessment
+
+The following items were previously listed as "NOT implemented" but were already present:
+- **Contact detail write-back sync on save**: Already implemented in `ContactDetail.vue` via `syncToContacts()` method (same pattern as ClientDetail).
+- **Contact detail sync status badge**: Already showing "Synced with Contacts" badge when `contactData.contactsUid` is set.

--- a/openspec/changes/2026-03-20-client-management/tasks.md
+++ b/openspec/changes/2026-03-20-client-management/tasks.md
@@ -1,0 +1,40 @@
+# Tasks: client-management enhancements
+
+## 1. Client Summary Statistics
+
+- [ ] 1.1 Add summary statistics card to `ClientDetail.vue`
+  - **spec_ref**: `specs/client-management/spec.md#Client Detail View`
+  - **files**: `pipelinq/src/views/clients/ClientDetail.vue`
+  - **acceptance_criteria**:
+    - GIVEN a client with linked leads and requests
+    - THEN a summary card MUST display: open leads count + value, won leads count + value, open requests count, total value
+    - AND values MUST be formatted with EUR currency
+
+## 2. Contact Sync Enhancements
+
+- [ ] 2.1 Add write-back sync on contact save in `ContactDetail.vue`
+  - **spec_ref**: `specs/contacts-sync/spec.md#Sync Trigger Behavior`
+  - **files**: `pipelinq/src/views/contacts/ContactDetail.vue`
+  - **acceptance_criteria**:
+    - GIVEN a contact person is saved
+    - THEN the system MUST POST to `/api/contacts-sync/write-back` with `objectType=contact`
+    - AND sync failure MUST NOT block the save operation
+
+- [ ] 2.2 Add sync status badge to `ContactDetail.vue`
+  - **spec_ref**: `specs/contacts-sync/spec.md#Sync Status Indicator`
+  - **files**: `pipelinq/src/views/contacts/ContactDetail.vue`
+  - **acceptance_criteria**:
+    - GIVEN a contact with `contactsUid` set
+    - THEN a "Synced with Contacts" badge MUST be displayed
+    - AND contacts without `contactsUid` MUST NOT show the badge
+
+## 3. Dynamic @type Mapping
+
+- [ ] 3.1 Set `@type` based on client type in `ClientForm.vue`
+  - **spec_ref**: `specs/client-management/spec.md#Client Creation`
+  - **files**: `pipelinq/src/views/clients/ClientForm.vue`
+  - **acceptance_criteria**:
+    - GIVEN a user creates a person client
+    - THEN `@type` MUST be set to `schema:Person`
+    - GIVEN a user creates an organization client
+    - THEN `@type` MUST be set to `schema:Organization`

--- a/src/views/clients/ClientDetail.vue
+++ b/src/views/clients/ClientDetail.vue
@@ -70,6 +70,29 @@
 			</div>
 		</CnDetailCard>
 
+		<CnDetailCard :title="t('pipelinq', 'Summary')">
+			<div class="summary-grid">
+				<div class="summary-item">
+					<span class="summary-value">{{ openLeadsCount }}</span>
+					<span class="summary-label">{{ t('pipelinq', 'Open leads') }}</span>
+					<span class="summary-sub">{{ formatCurrency(openLeadsValue) }}</span>
+				</div>
+				<div class="summary-item">
+					<span class="summary-value">{{ wonLeadsCount }}</span>
+					<span class="summary-label">{{ t('pipelinq', 'Won leads') }}</span>
+					<span class="summary-sub">{{ formatCurrency(wonLeadsValue) }}</span>
+				</div>
+				<div class="summary-item">
+					<span class="summary-value">{{ openRequestsCount }}</span>
+					<span class="summary-label">{{ t('pipelinq', 'Open requests') }}</span>
+				</div>
+				<div class="summary-item">
+					<span class="summary-value summary-value--total">{{ formatCurrency(totalValue) }}</span>
+					<span class="summary-label">{{ t('pipelinq', 'Total value') }}</span>
+				</div>
+			</div>
+		</CnDetailCard>
+
 		<CnDetailCard :title="t('pipelinq', 'Contacts')">
 			<template #actions>
 				<NcButton @click="addContact">
@@ -334,6 +357,28 @@ export default {
 				hiddenTabs: ['tasks'],
 			}
 		},
+		openLeadsCount() {
+			return this.leads.filter(l => !this.isClosedLead(l)).length
+		},
+		openLeadsValue() {
+			return this.leads
+				.filter(l => !this.isClosedLead(l))
+				.reduce((sum, l) => sum + (parseFloat(l.value) || 0), 0)
+		},
+		wonLeadsCount() {
+			return this.leads.filter(l => l.status === 'won').length
+		},
+		wonLeadsValue() {
+			return this.leads
+				.filter(l => l.status === 'won')
+				.reduce((sum, l) => sum + (parseFloat(l.value) || 0), 0)
+		},
+		openRequestsCount() {
+			return this.requests.filter(r => r.status === 'new' || r.status === 'in_progress').length
+		},
+		totalValue() {
+			return this.openLeadsValue + this.wonLeadsValue
+		},
 	},
 	async mounted() {
 		if (!this.isNew) {
@@ -463,6 +508,13 @@ export default {
 				return dateStr
 			}
 		},
+		isClosedLead(lead) {
+			return lead.status === 'won' || lead.status === 'lost'
+		},
+		formatCurrency(value) {
+			if (value === 0 || value == null) return 'EUR 0'
+			return 'EUR ' + new Intl.NumberFormat('nl-NL').format(value)
+		},
 	},
 }
 </script>
@@ -566,5 +618,42 @@ export default {
 	font-size: 12px;
 	font-weight: 600;
 	margin-bottom: 16px;
+}
+
+.summary-grid {
+	display: grid;
+	grid-template-columns: repeat(4, 1fr);
+	gap: 16px;
+}
+
+.summary-item {
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	padding: 12px;
+	border-radius: var(--border-radius-large);
+	background: var(--color-background-dark);
+}
+
+.summary-value {
+	font-size: 24px;
+	font-weight: bold;
+	color: var(--color-main-text);
+}
+
+.summary-value--total {
+	color: var(--color-primary);
+}
+
+.summary-label {
+	font-size: 13px;
+	color: var(--color-text-maxcontrast);
+	margin-top: 4px;
+}
+
+.summary-sub {
+	font-size: 12px;
+	color: var(--color-text-maxcontrast);
+	margin-top: 2px;
 }
 </style>

--- a/src/views/clients/ClientForm.vue
+++ b/src/views/clients/ClientForm.vue
@@ -211,6 +211,12 @@ export default {
 			if (this.client?.id) {
 				data.id = this.client.id
 			}
+			// Set Schema.org @type based on client type
+			if (data.type === 'organization') {
+				data['@type'] = 'schema:Organization'
+			} else {
+				data['@type'] = 'schema:Person'
+			}
 			this.$emit('save', data)
 		},
 	},


### PR DESCRIPTION
## Summary
- Add summary statistics card to client detail view showing open/won leads count and value, open requests count, and total value
- Set Schema.org @type dynamically based on client type (person/organization) in client form
- Include OpenSpec change artifacts (proposal, design, tasks, delta spec)

## Test plan
- [ ] Navigate to a client detail view with linked leads and requests
- [ ] Verify the Summary card shows correct counts and EUR-formatted values
- [ ] Create a person client and verify @type is set to schema:Person
- [ ] Create an organization client and verify @type is set to schema:Organization

Generated with [Claude Code](https://claude.com/claude-code)