### PR TITLE
feat: Add duplicate prevention to admin settings TagManager

### DIFF
--- a/l10n/en.json
+++ b/l10n/en.json
@@ -17,6 +17,7 @@
     "Address": "Address",
     "Age": "Age",
     "All": "All",
+    "An item with the name \"{name}\" already exists.": "An item with the name \"{name}\" already exists.",
     "Already linked": "Already linked",
     "Are you sure you want to delete \"{name}\"?": "Are you sure you want to delete \"{name}\"?",
     "Are you sure you want to delete \"{title}\"?": "Are you sure you want to delete \"{title}\"?",

--- a/l10n/nl.json
+++ b/l10n/nl.json
@@ -17,6 +17,7 @@
     "Address": "Adres",
     "Age": "Leeftijd",
     "All": "Alle",
+    "An item with the name \"{name}\" already exists.": "Er bestaat al een item met de naam \"{name}\".",
     "Already linked": "Reeds gekoppeld",
     "Are you sure you want to delete \"{name}\"?": "Weet u zeker dat u \"{name}\" wilt verwijderen?",
     "Are you sure you want to delete \"{title}\"?": "Weet u zeker dat u \"{title}\" wilt verwijderen?",

--- a/openspec/changes/2026-03-20-admin-settings/proposal.md
+++ b/openspec/changes/2026-03-20-admin-settings/proposal.md
@@ -1,0 +1,11 @@
+# Proposal: Admin Settings — Duplicate Prevention
+
+## Problem
+The TagManager component (used for lead sources and request channels) does not prevent duplicate entries. Users can add "website" twice without warning.
+
+## Solution
+Add client-side duplicate detection in the TagManager's saveNew and saveRename methods, comparing case-insensitively against existing tags. Display an error message when a duplicate is detected.
+
+## Scope
+- `src/views/settings/TagManager.vue` — add duplicate check
+- `l10n/en.json` and `l10n/nl.json` — add translation key for duplicate message

--- a/openspec/changes/2026-03-20-admin-settings/tasks.md
+++ b/openspec/changes/2026-03-20-admin-settings/tasks.md
@@ -1,0 +1,5 @@
+# Tasks: Admin Settings — Duplicate Prevention
+
+1. [x] Add duplicate name check in TagManager.saveNew()
+2. [x] Add duplicate name check in TagManager.saveRename()
+3. [x] Add translation keys for duplicate error message (en + nl)

--- a/src/views/settings/TagManager.vue
+++ b/src/views/settings/TagManager.vue
@@ -139,6 +139,15 @@ export default {
 			const name = this.newName.trim()
 			if (!name) return
 
+			// Check for duplicate names.
+			const duplicate = this.tags.some(
+				tag => tag.name.toLowerCase() === name.toLowerCase(),
+			)
+			if (duplicate) {
+				this.error = t('pipelinq', 'An item with the name "{name}" already exists.', { name })
+				return
+			}
+
 			this.error = null
 			try {
 				await this.$emit('add', name)
@@ -164,6 +173,15 @@ export default {
 		async saveRename(id) {
 			const name = this.editName.trim()
 			if (!name) return
+
+			// Check for duplicate names (excluding the item being renamed).
+			const duplicate = this.tags.some(
+				tag => tag.id !== id && tag.name.toLowerCase() === name.toLowerCase(),
+			)
+			if (duplicate) {
+				this.error = t('pipelinq', 'An item with the name "{name}" already exists.', { name })
+				return
+			}
 
 			this.error = null
 			try {


### PR DESCRIPTION
## Summary
- Add case-insensitive duplicate name detection to TagManager component
- Prevents duplicate lead sources and request channels from being created
- Displays translated error message when a duplicate name is detected
- Duplicate check applies to both add and rename operations

## Test plan
- [ ] Try adding a lead source that already exists (e.g., "website") - should show error
- [ ] Try renaming a lead source to an existing name - should show error
- [ ] Try adding a source with different casing (e.g., "Website" when "website" exists) - should show error
- [ ] Verify error message displays in Dutch when using nl locale