### PR TITLE
feat: Integrate product revenue and prospect widgets into dashboard

### DIFF
--- a/openspec/changes/2026-03-20-dashboard/proposal.md
+++ b/openspec/changes/2026-03-20-dashboard/proposal.md
@@ -1,0 +1,10 @@
+# Proposal: Dashboard Widget Integration
+
+## Problem
+ProspectWidget and ProductRevenue components exist but are not integrated into the main Dashboard layout.
+
+## Solution
+Add both widgets to the Dashboard's CnDashboardPage grid layout as new widget definitions with render slots. Place them in a new row below the client overview.
+
+## Scope
+- `src/views/Dashboard.vue` — add imports, components, widget defs, layout entries, and render slots

--- a/openspec/changes/2026-03-20-dashboard/tasks.md
+++ b/openspec/changes/2026-03-20-dashboard/tasks.md
@@ -1,0 +1,7 @@
+# Tasks: Dashboard Widget Integration
+
+1. [x] Add ProductRevenue and ProspectWidget imports to Dashboard.vue
+2. [x] Register both as components
+3. [x] Add widget definitions for 'top-products' and 'prospect-discovery'
+4. [x] Add layout entries in DEFAULT_LAYOUT (row below client overview)
+5. [x] Add render slots (#widget-top-products and #widget-prospect-discovery)

--- a/src/views/Dashboard.vue
+++ b/src/views/Dashboard.vue
@@ -167,6 +167,16 @@
 				</div>
 			</template>
 
+			<!-- Top Products widget -->
+			<template #widget-top-products>
+				<ProductRevenue />
+			</template>
+
+			<!-- Prospect Discovery widget -->
+			<template #widget-prospect-discovery>
+				<ProspectWidget />
+			</template>
+
 			<!-- Empty state override with welcome message -->
 			<template #empty>
 				<div v-if="isEmpty" class="welcome-message">
@@ -211,6 +221,8 @@ import FileDocument from 'vue-material-design-icons/FileDocument.vue'
 import CurrencyEur from 'vue-material-design-icons/CurrencyEur.vue'
 import AlertCircle from 'vue-material-design-icons/AlertCircle.vue'
 import { useObjectStore } from '../store/modules/object.js'
+import ProductRevenue from '../components/ProductRevenue.vue'
+import ProspectWidget from '../components/ProspectWidget.vue'
 import LeadCreateDialog from './leads/LeadCreateDialog.vue'
 import RequestCreateDialog from './requests/RequestCreateDialog.vue'
 import ClientCreateDialog from './clients/ClientCreateDialog.vue'
@@ -234,6 +246,8 @@ const DEFAULT_LAYOUT = [
 	{ id: 5, widgetId: 'deals-by-stage', gridX: 0, gridY: 2, gridWidth: 6, gridHeight: 4 },
 	{ id: 6, widgetId: 'my-work', gridX: 6, gridY: 2, gridWidth: 6, gridHeight: 4 },
 	{ id: 7, widgetId: 'client-overview', gridX: 0, gridY: 6, gridWidth: 12, gridHeight: 3 },
+	{ id: 8, widgetId: 'top-products', gridX: 0, gridY: 9, gridWidth: 6, gridHeight: 4 },
+	{ id: 9, widgetId: 'prospect-discovery', gridX: 6, gridY: 9, gridWidth: 6, gridHeight: 4 },
 ]
 
 export default {
@@ -244,6 +258,8 @@ export default {
 		CnStatsBlock,
 		Plus,
 		Refresh,
+		ProductRevenue,
+		ProspectWidget,
 		LeadCreateDialog,
 		RequestCreateDialog,
 		ClientCreateDialog,
@@ -292,6 +308,8 @@ export default {
 				{ id: 'deals-by-stage', title: t('pipelinq', 'Requests by Status'), type: 'custom' },
 				{ id: 'my-work', title: t('pipelinq', 'My Work'), type: 'custom' },
 				{ id: 'client-overview', title: t('pipelinq', 'Client Overview'), type: 'custom' },
+				{ id: 'top-products', title: t('pipelinq', 'Top Products by Pipeline Value'), type: 'custom' },
+				{ id: 'prospect-discovery', title: t('pipelinq', 'Prospect Discovery'), type: 'custom' },
 			]
 		},
 


### PR DESCRIPTION
## Summary
- Add ProductRevenue widget to dashboard showing top 3 products by pipeline value
- Add ProspectWidget to dashboard showing companies matching the ICP profile
- Both widgets placed in a new row below client overview (6 columns each)
- Widget definitions and layout entries added to CnDashboardPage grid

## Test plan
- [ ] Verify "Top Products by Pipeline Value" widget appears in dashboard
- [ ] Verify "Prospect Discovery" widget appears in dashboard
- [ ] Verify both widgets load data correctly
- [ ] Verify dashboard layout remains stable with 9 widgets