### PR TITLE
feat: Add unit tests for OpenRegister integration services

### DIFF
--- a/openspec/changes/2026-03-20-openregister-integration/proposal.md
+++ b/openspec/changes/2026-03-20-openregister-integration/proposal.md
@@ -1,0 +1,13 @@
+# Proposal: OpenRegister Integration Tests
+
+## Problem
+The ConfigFileLoaderService and SettingsMapBuilder services lack unit test coverage. These are critical for the register initialization flow.
+
+## Solution
+Add unit tests for both services covering the key scenarios from the spec:
+- SettingsMapBuilder: schema slug map building, register ID extraction, view ID extraction
+- ConfigFileLoaderService: sourceType handling, file-not-found exception
+
+## Scope
+- `tests/Unit/Service/SettingsMapBuilderTest.php` — new test file
+- `tests/Unit/Service/ConfigFileLoaderServiceTest.php` — new test file

--- a/openspec/changes/2026-03-20-openregister-integration/tasks.md
+++ b/openspec/changes/2026-03-20-openregister-integration/tasks.md
@@ -1,0 +1,4 @@
+# Tasks: OpenRegister Integration Tests
+
+1. [x] Write SettingsMapBuilderTest (slug map, register ID, view ID, edge cases)
+2. [x] Write ConfigFileLoaderServiceTest (sourceType handling, file-not-found)

--- a/tests/Unit/Service/ConfigFileLoaderServiceTest.php
+++ b/tests/Unit/Service/ConfigFileLoaderServiceTest.php
@@ -1,0 +1,97 @@
+<?php
+
+/**
+ * Unit tests for ConfigFileLoaderService.
+ *
+ * @category Test
+ * @package  OCA\Pipelinq\Tests\Unit\Service
+ *
+ * @author    Conduction Development Team <dev@conductio.nl>
+ * @copyright 2024 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://pipelinq.nl
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Pipelinq\Tests\Unit\Service;
+
+use OCA\Pipelinq\Service\ConfigFileLoaderService;
+use OCP\App\IAppManager;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests for ConfigFileLoaderService.
+ */
+class ConfigFileLoaderServiceTest extends TestCase
+{
+    /**
+     * Test that ensureSourceType adds sourceType when missing.
+     *
+     * @return void
+     */
+    public function testEnsureSourceTypeAddsWhenMissing(): void
+    {
+        $appManager = $this->createMock(IAppManager::class);
+        $service    = new ConfigFileLoaderService($appManager);
+
+        $data   = ['openapi' => '3.0.0'];
+        $result = $service->ensureSourceType($data);
+
+        $this->assertArrayHasKey('x-openregister', $result);
+        $this->assertEquals('local', $result['x-openregister']['sourceType']);
+    }//end testEnsureSourceTypeAddsWhenMissing()
+
+    /**
+     * Test that ensureSourceType preserves existing sourceType.
+     *
+     * @return void
+     */
+    public function testEnsureSourceTypePreservesExisting(): void
+    {
+        $appManager = $this->createMock(IAppManager::class);
+        $service    = new ConfigFileLoaderService($appManager);
+
+        $data   = ['x-openregister' => ['sourceType' => 'remote']];
+        $result = $service->ensureSourceType($data);
+
+        $this->assertEquals('remote', $result['x-openregister']['sourceType']);
+    }//end testEnsureSourceTypePreservesExisting()
+
+    /**
+     * Test that ensureSourceType handles empty x-openregister block.
+     *
+     * @return void
+     */
+    public function testEnsureSourceTypeWithEmptyBlock(): void
+    {
+        $appManager = $this->createMock(IAppManager::class);
+        $service    = new ConfigFileLoaderService($appManager);
+
+        $data   = ['x-openregister' => []];
+        $result = $service->ensureSourceType($data);
+
+        $this->assertEquals('local', $result['x-openregister']['sourceType']);
+    }//end testEnsureSourceTypeWithEmptyBlock()
+
+    /**
+     * Test that loadConfigurationFile throws when file not found.
+     *
+     * @return void
+     */
+    public function testLoadConfigurationFileThrowsWhenNotFound(): void
+    {
+        $appManager = $this->createMock(IAppManager::class);
+        $appManager->method('getAppPath')->willReturn('/nonexistent/path');
+
+        $service = new ConfigFileLoaderService($appManager);
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Configuration file not found');
+
+        $service->loadConfigurationFile();
+    }//end testLoadConfigurationFileThrowsWhenNotFound()
+}//end class

--- a/tests/Unit/Service/SettingsMapBuilderTest.php
+++ b/tests/Unit/Service/SettingsMapBuilderTest.php
@@ -1,0 +1,189 @@
+<?php
+
+/**
+ * Unit tests for SettingsMapBuilder.
+ *
+ * @category Test
+ * @package  OCA\Pipelinq\Tests\Unit\Service
+ *
+ * @author    Conduction Development Team <dev@conductio.nl>
+ * @copyright 2024 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://pipelinq.nl
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Pipelinq\Tests\Unit\Service;
+
+use OCA\Pipelinq\Service\SettingsMapBuilder;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests for SettingsMapBuilder.
+ */
+class SettingsMapBuilderTest extends TestCase
+{
+    /**
+     * The service under test.
+     *
+     * @var SettingsMapBuilder
+     */
+    private SettingsMapBuilder $builder;
+
+    /**
+     * Set up the test.
+     *
+     * @return void
+     */
+    protected function setUp(): void
+    {
+        $this->builder = new SettingsMapBuilder();
+    }//end setUp()
+
+    /**
+     * Test that buildSchemaSlugMap extracts slug-to-ID mappings from plain arrays.
+     *
+     * @return void
+     */
+    public function testBuildSchemaSlugMapFromArrays(): void
+    {
+        $schemas = [
+            ['slug' => 'client', 'id' => 10, 'title' => 'Client'],
+            ['slug' => 'lead', 'id' => 20, 'title' => 'Lead'],
+            ['slug' => 'contact', 'id' => 30, 'title' => 'Contact'],
+        ];
+
+        $map = $this->builder->buildSchemaSlugMap($schemas);
+
+        $this->assertArrayHasKey('client', $map);
+        $this->assertArrayHasKey('lead', $map);
+        $this->assertArrayHasKey('contact', $map);
+        $this->assertEquals(10, $map['client']);
+        $this->assertEquals(20, $map['lead']);
+        $this->assertEquals(30, $map['contact']);
+    }//end testBuildSchemaSlugMapFromArrays()
+
+    /**
+     * Test that buildSchemaSlugMap uses uuid if id is missing.
+     *
+     * @return void
+     */
+    public function testBuildSchemaSlugMapUsesUuid(): void
+    {
+        $schemas = [
+            ['slug' => 'product', 'uuid' => 'abc-123', 'title' => 'Product'],
+        ];
+
+        $map = $this->builder->buildSchemaSlugMap($schemas);
+
+        $this->assertArrayHasKey('product', $map);
+        $this->assertEquals('abc-123', $map['product']);
+    }//end testBuildSchemaSlugMapUsesUuid()
+
+    /**
+     * Test that buildSchemaSlugMap handles empty input.
+     *
+     * @return void
+     */
+    public function testBuildSchemaSlugMapEmpty(): void
+    {
+        $map = $this->builder->buildSchemaSlugMap([]);
+
+        $this->assertEmpty($map);
+    }//end testBuildSchemaSlugMapEmpty()
+
+    /**
+     * Test that findRegisterIdBySlug returns the pipelinq register ID.
+     *
+     * @return void
+     */
+    public function testFindRegisterIdBySlug(): void
+    {
+        $registers = [
+            ['slug' => 'other', 'id' => 1],
+            ['slug' => 'pipelinq', 'id' => 42],
+        ];
+
+        $result = $this->builder->findRegisterIdBySlug($registers);
+
+        $this->assertEquals(42, $result);
+    }//end testFindRegisterIdBySlug()
+
+    /**
+     * Test that findRegisterIdBySlug returns null when not found.
+     *
+     * @return void
+     */
+    public function testFindRegisterIdBySlugNotFound(): void
+    {
+        $registers = [
+            ['slug' => 'other', 'id' => 1],
+        ];
+
+        $result = $this->builder->findRegisterIdBySlug($registers);
+
+        $this->assertNull($result);
+    }//end testFindRegisterIdBySlugNotFound()
+
+    /**
+     * Test that findRegisterIdBySlug handles empty registers.
+     *
+     * @return void
+     */
+    public function testFindRegisterIdBySlugEmpty(): void
+    {
+        $result = $this->builder->findRegisterIdBySlug([]);
+
+        $this->assertNull($result);
+    }//end testFindRegisterIdBySlugEmpty()
+
+    /**
+     * Test that findDefaultViewId returns default view ID.
+     *
+     * @return void
+     */
+    public function testFindDefaultViewId(): void
+    {
+        $views = [
+            ['id' => 1, 'isDefault' => false],
+            ['id' => 7, 'isDefault' => true],
+        ];
+
+        $result = $this->builder->findDefaultViewId($views);
+
+        $this->assertEquals(7, $result);
+    }//end testFindDefaultViewId()
+
+    /**
+     * Test that findDefaultViewId falls back to first view.
+     *
+     * @return void
+     */
+    public function testFindDefaultViewIdFallback(): void
+    {
+        $views = [
+            ['id' => 5, 'isDefault' => false],
+            ['id' => 8, 'isDefault' => false],
+        ];
+
+        $result = $this->builder->findDefaultViewId($views);
+
+        $this->assertEquals(5, $result);
+    }//end testFindDefaultViewIdFallback()
+
+    /**
+     * Test that findDefaultViewId returns null for empty views.
+     *
+     * @return void
+     */
+    public function testFindDefaultViewIdEmpty(): void
+    {
+        $result = $this->builder->findDefaultViewId([]);
+
+        $this->assertNull($result);
+    }//end testFindDefaultViewIdEmpty()
+}//end class


### PR DESCRIPTION
## Summary
- Add `SettingsMapBuilderTest` with 7 test methods covering schema slug map building, register ID extraction, and default view ID resolution
- Add `ConfigFileLoaderServiceTest` with 4 test methods covering sourceType handling and file-not-found exception
- Tests cover key scenarios from the openregister-integration spec

## Test plan
- [ ] Run `vendor/bin/phpunit tests/Unit/Service/SettingsMapBuilderTest.php`
- [ ] Run `vendor/bin/phpunit tests/Unit/Service/ConfigFileLoaderServiceTest.php`
- [ ] Verify all 11 tests pass