### PR TITLE
feat: Contacts sync unlink and re-sync buttons

### DIFF
--- a/openspec/changes/2026-03-20-contacts-sync/design.md
+++ b/openspec/changes/2026-03-20-contacts-sync/design.md
@@ -1,0 +1,7 @@
+# Design: contacts-sync unlink and re-sync
+
+## Unlink
+Clear `contactsUid` from the Pipelinq object by saving it with `contactsUid: null`. The Nextcloud contact is NOT deleted.
+
+## Re-sync
+Call the existing `/api/contacts-sync/write-back` endpoint to push current Pipelinq data to Nextcloud Contacts. For unlinked entities, this creates a new vCard and stores the new UID.

--- a/openspec/changes/2026-03-20-contacts-sync/proposal.md
+++ b/openspec/changes/2026-03-20-contacts-sync/proposal.md
@@ -1,0 +1,20 @@
+# Proposal: contacts-sync unlink and re-sync
+
+## Problem
+
+The contacts-sync spec identifies V1 gaps:
+1. No "Unlink" action on the sync status indicator
+2. No dedicated "Re-sync" button (sync only happens during save)
+
+## Proposed Change
+
+Add "Unlink" and "Re-sync" buttons next to the sync badge on ClientDetail and ContactDetail views.
+
+### Out of Scope
+- CATEGORIES property mapping (V1)
+- Photo/avatar sync (V1)
+- Multi-user sync isolation improvements (V1)
+
+## Impact
+- **Files modified**: 2 Vue files
+- **Risk**: Low

--- a/openspec/changes/2026-03-20-contacts-sync/specs/contacts-sync/spec.md
+++ b/openspec/changes/2026-03-20-contacts-sync/specs/contacts-sync/spec.md
@@ -1,0 +1,7 @@
+# Delta Spec: contacts-sync unlink and re-sync
+
+## Newly Implemented
+
+- **Manual Sync Trigger**: Re-sync button added to ClientDetail and ContactDetail. Calls `/api/contacts-sync/write-back` to push current data to Nextcloud Contacts.
+- **Contact Deletion Handling - Unlink**: Unlink button on both detail views clears `contactsUid` without deleting the Nextcloud contact.
+- **Sync to Contacts for unlinked**: "Sync to Contacts" button shown when entity has no `contactsUid`, creating a new vCard.

--- a/openspec/changes/2026-03-20-contacts-sync/tasks.md
+++ b/openspec/changes/2026-03-20-contacts-sync/tasks.md
@@ -1,0 +1,11 @@
+# Tasks: contacts-sync unlink and re-sync
+
+## 1. Unlink and Re-sync on ClientDetail
+- [ ] 1.1 Add Unlink and Re-sync buttons to ClientDetail sync badge area
+  - **spec_ref**: `specs/contacts-sync/spec.md#Manual Sync Trigger`
+  - **files**: `pipelinq/src/views/clients/ClientDetail.vue`
+
+## 2. Unlink and Re-sync on ContactDetail
+- [ ] 2.1 Add Unlink and Re-sync buttons to ContactDetail sync badge area
+  - **spec_ref**: `specs/contacts-sync/spec.md#Manual Sync Trigger`
+  - **files**: `pipelinq/src/views/contacts/ContactDetail.vue`

--- a/src/views/clients/ClientDetail.vue
+++ b/src/views/clients/ClientDetail.vue
@@ -38,8 +38,21 @@
 		</template>
 
 		<CnDetailCard :title="t('pipelinq', 'Client Information')">
-			<div v-if="clientData.contactsUid" class="sync-badge">
-				{{ t('pipelinq', 'Synced with Contacts') }}
+			<div v-if="clientData.contactsUid" class="sync-row">
+				<span class="sync-badge">
+					{{ t('pipelinq', 'Synced with Contacts') }}
+				</span>
+				<NcButton type="tertiary" @click="resyncToContacts">
+					{{ t('pipelinq', 'Re-sync') }}
+				</NcButton>
+				<NcButton type="tertiary" @click="unlinkContact">
+					{{ t('pipelinq', 'Unlink') }}
+				</NcButton>
+			</div>
+			<div v-else class="sync-row">
+				<NcButton type="tertiary" @click="resyncToContacts">
+					{{ t('pipelinq', 'Sync to Contacts') }}
+				</NcButton>
 			</div>
 
 			<div class="info-grid">
@@ -289,6 +302,17 @@ export default {
 				// Sync failure is non-blocking
 			}
 		},
+		async resyncToContacts() {
+			await this.syncToContacts(this.clientId)
+			await this.objectStore.fetchObject('client', this.clientId)
+		},
+		async unlinkContact() {
+			await this.objectStore.saveObject('client', {
+				...this.clientData,
+				contactsUid: null,
+			})
+			await this.objectStore.fetchObject('client', this.clientId)
+		},
 		onFormCancel() {
 			if (this.isNew) {
 				this.$router.push({ name: 'Clients' })
@@ -431,6 +455,13 @@ export default {
 	padding-left: 20px;
 }
 
+.sync-row {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	margin-bottom: 16px;
+}
+
 .sync-badge {
 	display: inline-block;
 	padding: 4px 10px;
@@ -440,6 +471,5 @@ export default {
 	border-radius: 12px;
 	font-size: 12px;
 	font-weight: 600;
-	margin-bottom: 16px;
 }
 </style>

--- a/src/views/contacts/ContactDetail.vue
+++ b/src/views/contacts/ContactDetail.vue
@@ -39,8 +39,21 @@
 		</template>
 
 		<CnDetailCard :title="t('pipelinq', 'Contact Information')">
-			<div v-if="contactData.contactsUid" class="sync-badge">
-				{{ t('pipelinq', 'Synced with Contacts') }}
+			<div v-if="contactData.contactsUid" class="sync-row">
+				<span class="sync-badge">
+					{{ t('pipelinq', 'Synced with Contacts') }}
+				</span>
+				<NcButton type="tertiary" @click="resyncToContacts">
+					{{ t('pipelinq', 'Re-sync') }}
+				</NcButton>
+				<NcButton type="tertiary" @click="unlinkContact">
+					{{ t('pipelinq', 'Unlink') }}
+				</NcButton>
+			</div>
+			<div v-else class="sync-row">
+				<NcButton type="tertiary" @click="resyncToContacts">
+					{{ t('pipelinq', 'Sync to Contacts') }}
+				</NcButton>
 			</div>
 
 			<div class="info-grid">
@@ -173,6 +186,17 @@ export default {
 				// Sync failure is non-blocking
 			}
 		},
+		async resyncToContacts() {
+			await this.syncToContacts(this.contactId)
+			await this.objectStore.fetchObject('contact', this.contactId)
+		},
+		async unlinkContact() {
+			await this.objectStore.saveObject('contact', {
+				...this.contactData,
+				contactsUid: null,
+			})
+			await this.objectStore.fetchObject('contact', this.contactId)
+		},
 		onFormCancel() {
 			if (this.isNew) {
 				this.$router.push({ name: 'Contacts' })
@@ -232,6 +256,13 @@ export default {
 	color: var(--color-primary-hover);
 }
 
+.sync-row {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	margin-bottom: 16px;
+}
+
 .sync-badge {
 	display: inline-block;
 	padding: 4px 10px;
@@ -241,6 +272,5 @@ export default {
 	border-radius: 12px;
 	font-size: 12px;
 	font-weight: 600;
-	margin-bottom: 16px;
 }
 </style>


### PR DESCRIPTION
## Summary
- Add Re-sync button to client and contact detail views to push data to Nextcloud Contacts
- Add Unlink button to remove the contactsUid link without deleting the Nextcloud contact
- Show "Sync to Contacts" button for unlinked entities to create a new vCard
- Includes OpenSpec change artifacts

## Test plan
- [ ] View a linked client (with contactsUid), verify Re-sync and Unlink buttons appear
- [ ] Click Unlink, verify badge disappears and "Sync to Contacts" button appears
- [ ] Click "Sync to Contacts" on an unlinked client, verify it creates a vCard and shows badge
- [ ] Same tests on contact detail view

Generated with [Claude Code](https://claude.com/claude-code)