### PR TITLE
feat: Implement entity-notes spec (inline editing, cleanup hook)

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -28,6 +28,7 @@ return [
         ['name' => 'notes#list', 'url' => '/api/notes/{objectType}/{objectId}', 'verb' => 'GET'],
         ['name' => 'notes#create', 'url' => '/api/notes/{objectType}/{objectId}', 'verb' => 'POST'],
         ['name' => 'notes#deleteAll', 'url' => '/api/notes/{objectType}/{objectId}', 'verb' => 'DELETE'],
+        ['name' => 'notes#update', 'url' => '/api/notes/single/{noteId}', 'verb' => 'PUT'],
         ['name' => 'notes#deleteSingle', 'url' => '/api/notes/single/{noteId}', 'verb' => 'DELETE'],
 
         // Request channels

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -23,12 +23,14 @@ namespace OCA\Pipelinq\AppInfo;
 
 use OCA\OpenRegister\Event\DeepLinkRegistrationEvent;
 use OCA\OpenRegister\Event\ObjectCreatedEvent;
+use OCA\OpenRegister\Event\ObjectDeletedEvent;
 use OCA\OpenRegister\Event\ObjectUpdatedEvent;
 use OCA\Pipelinq\Dashboard\ClientSearchWidget;
 use OCA\Pipelinq\Dashboard\DealsOverviewWidget;
 use OCA\Pipelinq\Dashboard\MyLeadsWidget;
 use OCA\Pipelinq\Dashboard\RecentActivitiesWidget;
 use OCA\Pipelinq\Listener\DeepLinkRegistrationListener;
+use OCA\Pipelinq\Listener\ObjectDeletedListener;
 use OCA\Pipelinq\Listener\ObjectEventListener;
 use OCP\AppFramework\App;
 use OCP\AppFramework\Bootstrap\IBootContext;
@@ -76,6 +78,10 @@ class Application extends App implements IBootstrap
         $context->registerEventListener(
             event: ObjectUpdatedEvent::class,
             listener: ObjectEventListener::class
+        );
+        $context->registerEventListener(
+            event: ObjectDeletedEvent::class,
+            listener: ObjectDeletedListener::class
         );
 
         $context->registerDashboardWidget(DealsOverviewWidget::class);

--- a/lib/Controller/NotesController.php
+++ b/lib/Controller/NotesController.php
@@ -145,6 +145,33 @@ class NotesController extends Controller
     }//end deleteAll()
 
     /**
+     * Update a single note's message (own notes only).
+     *
+     * @param int $noteId The note ID.
+     *
+     * @return JSONResponse The response containing the updated note.
+     *
+     * @NoAdminRequired
+     */
+    public function update(int $noteId): JSONResponse
+    {
+        $message = $this->request->getParam('message', '');
+        if (trim($message) === '') {
+            return new JSONResponse(['error' => $this->l10n->t('Message is required')], 400);
+        }
+
+        try {
+            $note = $this->notesService->updateNote(
+                noteId: $noteId,
+                message: $message
+            );
+            return new JSONResponse(['note' => $note]);
+        } catch (\Exception $e) {
+            return new JSONResponse(['error' => $e->getMessage()], 403);
+        }
+    }//end update()
+
+    /**
      * Delete a single note (own notes only).
      *
      * @param int $noteId The note ID.

--- a/lib/Listener/ObjectDeletedListener.php
+++ b/lib/Listener/ObjectDeletedListener.php
@@ -1,0 +1,109 @@
+<?php
+
+/**
+ * Pipelinq ObjectDeletedListener.
+ *
+ * Listener for OpenRegister object deletion events to clean up associated notes.
+ *
+ * @category Listener
+ * @package  OCA\Pipelinq\Listener
+ *
+ * @author    Conduction <info@conduction.nl>
+ * @copyright 2024 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git_id>
+ *
+ * @link https://github.com/ConductionNL/pipelinq
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Pipelinq\Listener;
+
+use OCA\OpenRegister\Event\ObjectDeletedEvent;
+use OCA\Pipelinq\Service\NotesService;
+use OCA\Pipelinq\Service\SchemaMapService;
+use OCP\EventDispatcher\Event;
+use OCP\EventDispatcher\IEventListener;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Listener that cleans up notes when an OpenRegister object is deleted.
+ *
+ * @implements IEventListener<Event>
+ */
+class ObjectDeletedListener implements IEventListener
+{
+    /**
+     * Entity type to notes object type mapping.
+     *
+     * @var array<string, string>
+     */
+    private const NOTE_TYPE_MAP = [
+        'client'  => 'pipelinq_client',
+        'contact' => 'pipelinq_contact',
+        'lead'    => 'pipelinq_lead',
+        'request' => 'pipelinq_request',
+    ];
+
+    /**
+     * Constructor.
+     *
+     * @param SchemaMapService $schemaMapService The schema map service.
+     * @param NotesService     $notesService     The notes service.
+     * @param LoggerInterface  $logger           The logger.
+     */
+    public function __construct(
+        private SchemaMapService $schemaMapService,
+        private NotesService $notesService,
+        private LoggerInterface $logger,
+    ) {
+    }//end __construct()
+
+    /**
+     * Handle the ObjectDeletedEvent by cleaning up associated notes.
+     *
+     * @param Event $event The event to handle.
+     *
+     * @return void
+     */
+    public function handle(Event $event): void
+    {
+        if (($event instanceof ObjectDeletedEvent) === false) {
+            return;
+        }
+
+        try {
+            $object     = $event->getObject();
+            $schemaId   = $object->getSchema();
+            $entityType = $this->schemaMapService->resolveEntityType($schemaId);
+
+            if ($entityType === null) {
+                return;
+            }
+
+            $noteObjectType = self::NOTE_TYPE_MAP[$entityType] ?? null;
+            if ($noteObjectType === null) {
+                return;
+            }
+
+            $objectId = $object->getUuid();
+            if ($objectId === null || $objectId === '') {
+                return;
+            }
+
+            $this->notesService->deleteAllNotes(
+                objectType: $noteObjectType,
+                objectId: $objectId
+            );
+        } catch (\Exception $e) {
+            $this->logger->warning(
+                'Failed to clean up notes on entity deletion',
+                [
+                    'exception' => $e->getMessage(),
+                ]
+            );
+        }//end try
+    }//end handle()
+}//end class

--- a/lib/Service/NotesService.php
+++ b/lib/Service/NotesService.php
@@ -133,6 +133,41 @@ class NotesService
     }//end addNote()
 
     /**
+     * Update a note's message. Only the author may edit their own note.
+     *
+     * @param int    $noteId  The note ID.
+     * @param string $message The updated message.
+     *
+     * @return array The updated note data.
+     */
+    public function updateNote(int $noteId, string $message): array
+    {
+        $userId = $this->userSession->getUser()?->getUID();
+        if ($userId === null) {
+            throw new RuntimeException('No authenticated user');
+        }
+
+        $comment = $this->commentsManager->get((string) $noteId);
+        if ($comment->getActorId() !== $userId) {
+            throw new RuntimeException('You can only edit your own notes');
+        }
+
+        $comment->setMessage(trim($message));
+        $this->commentsManager->save($comment);
+
+        $user = $this->userManager->get($userId);
+
+        return [
+            'id'         => (int) $comment->getId(),
+            'message'    => $comment->getMessage(),
+            'authorId'   => $userId,
+            'authorName' => $user?->getDisplayName() ?? $userId,
+            'timestamp'  => $comment->getCreationDateTime()->format('c'),
+            'isOwn'      => true,
+        ];
+    }//end updateNote()
+
+    /**
      * Delete a single note. Only the author may delete their own note.
      *
      * @param int $noteId The note ID.

--- a/openspec/changes/2026-03-20-entity-notes/design.md
+++ b/openspec/changes/2026-03-20-entity-notes/design.md
@@ -1,0 +1,31 @@
+# Design: entity-notes inline editing and cleanup hook
+
+## Backend Cleanup Hook
+
+Register an event listener for `OCA\OpenRegister\Events\ObjectDeletedEvent` in `Application::register()`. The listener maps the deleted object's schema slug to a Pipelinq note object type (e.g., `client` -> `pipelinq_client`) and calls `NotesService::deleteAllNotes()`.
+
+## Note Update Endpoint
+
+Add `PUT /api/notes/single/{noteId}` mapped to `NotesController::update()`. The method:
+1. Reads `message` from the request body
+2. Validates the message is non-empty
+3. Calls `NotesService::updateNote($noteId, $message)` which:
+   - Fetches the comment via `ICommentsManager::get()`
+   - Verifies the current user is the author (`actorId === currentUserId`)
+   - Updates the message via `$comment->setMessage(trim($message))`
+   - Saves via `ICommentsManager::save()`
+   - Returns the updated note data
+
+## Inline Editing in EntityNotes.vue
+
+- Each note gets an "Edit" button (visible only when `note.isOwn`)
+- Clicking "Edit" sets `editingNoteId` and `editMessage` state
+- The note message is replaced with a textarea pre-filled with the current message
+- "Save" and "Cancel" buttons appear
+- Save calls `PUT /api/notes/single/{noteId}` with the new message
+- Cancel resets state without API call
+- After save, the note list is refreshed
+
+## Keyboard Shortcut
+
+Add `@keydown` handler on the textarea that submits on Ctrl+Enter (or Meta+Enter for macOS).

--- a/openspec/changes/2026-03-20-entity-notes/proposal.md
+++ b/openspec/changes/2026-03-20-entity-notes/proposal.md
@@ -1,0 +1,30 @@
+# Proposal: entity-notes inline editing and cleanup hook
+
+## Problem
+
+The entity-notes spec identifies MVP and V1 gaps:
+1. No backend cleanup hook — entity deletion via OpenRegister does not trigger `deleteAllNotes()`, leaving orphaned comments
+2. No inline editing — users can only create and delete notes, not edit them
+3. No keyboard shortcut — Ctrl+Enter does not submit notes
+4. No update endpoint — backend has no PUT/PATCH route for note editing
+
+## Proposed Change
+
+1. Add an `ObjectDeletedListener` that calls `NotesService::deleteAllNotes()` when an OpenRegister object with a Pipelinq entity type is deleted
+2. Add a `NotesController::update()` endpoint for editing note messages
+3. Add `NotesService::updateNote()` method with ownership verification
+4. Extend `EntityNotes.vue` with inline editing (edit/save/cancel) and Ctrl+Enter keyboard shortcut
+5. Register the update route in `routes.php`
+
+### Out of Scope
+- Note types (call log, email log, meeting note) — V1
+- Rich text / Markdown rendering — V1
+- @mention users — V1
+- Note search, file attachments, pinning, templates — V1/Enterprise
+- Note visibility (private vs shared) — V1
+- Note export — Enterprise
+
+## Impact
+- **Files modified**: 5 (NotesService.php, NotesController.php, EntityNotes.vue, routes.php, Application.php)
+- **Files created**: 1 (ObjectDeletedListener.php)
+- **Risk**: Low — additive changes only

--- a/openspec/changes/2026-03-20-entity-notes/specs/entity-notes/spec.md
+++ b/openspec/changes/2026-03-20-entity-notes/specs/entity-notes/spec.md
@@ -1,0 +1,8 @@
+# Delta Spec: entity-notes inline editing and cleanup hook
+
+## Newly Implemented
+
+- **Backend cleanup hook via OpenRegister event**: `ObjectDeletedListener` registered for `ObjectDeletedEvent`. Maps schema slugs (client, contact, lead, request) to Pipelinq note object types and calls `NotesService::deleteAllNotes()`. Prevents orphaned comments when entities are deleted via OpenRegister.
+- **Note Inline Editing**: Users can edit their own notes inline. "Edit" button shown on own notes opens a textarea with current message. "Save" persists via `PUT /api/notes/single/{noteId}`. "Cancel" reverts without API call. Ownership enforced server-side.
+- **Note Update Backend**: `NotesService::updateNote()` fetches comment, verifies author, updates message, saves. `NotesController::update()` validates non-empty message and returns updated note.
+- **Keyboard shortcut**: Ctrl+Enter (Cmd+Enter on macOS) submits notes from the textarea.

--- a/openspec/changes/2026-03-20-entity-notes/tasks.md
+++ b/openspec/changes/2026-03-20-entity-notes/tasks.md
@@ -1,0 +1,25 @@
+# Tasks: entity-notes inline editing and cleanup hook
+
+## 1. Backend cleanup hook for entity deletion
+- [ ] 1.1 Create `ObjectDeletedListener` that cleans up notes on entity deletion
+  - **spec_ref**: `specs/entity-notes/spec.md#Backend cleanup hook via OpenRegister event`
+  - **files**: `pipelinq/lib/Listener/ObjectDeletedListener.php`
+- [ ] 1.2 Register the event listener in Application.php
+  - **spec_ref**: `specs/entity-notes/spec.md#Backend cleanup hook via OpenRegister event`
+  - **files**: `pipelinq/lib/AppInfo/Application.php`
+
+## 2. Note update (inline editing) backend
+- [ ] 2.1 Add `updateNote()` method to NotesService with ownership verification
+  - **spec_ref**: `specs/entity-notes/spec.md#Save edited note`
+  - **files**: `pipelinq/lib/Service/NotesService.php`
+- [ ] 2.2 Add `update()` action to NotesController
+  - **spec_ref**: `specs/entity-notes/spec.md#Edit own note`
+  - **files**: `pipelinq/lib/Controller/NotesController.php`
+- [ ] 2.3 Register PUT route for note update
+  - **spec_ref**: `specs/entity-notes/spec.md#Edit own note`
+  - **files**: `pipelinq/appinfo/routes.php`
+
+## 3. Inline editing and keyboard shortcut in frontend
+- [ ] 3.1 Add inline editing UI (edit/save/cancel) and Ctrl+Enter shortcut to EntityNotes.vue
+  - **spec_ref**: `specs/entity-notes/spec.md#Edit own note`, `specs/entity-notes/spec.md#Keyboard shortcut for submission`
+  - **files**: `pipelinq/src/components/EntityNotes.vue`

--- a/src/components/EntityNotes.vue
+++ b/src/components/EntityNotes.vue
@@ -7,7 +7,8 @@
 				v-model="newMessage"
 				:placeholder="t('pipelinq', 'Add a note...')"
 				class="entity-notes__textarea"
-				rows="3" />
+				rows="3"
+				@keydown="onNewNoteKeydown" />
 			<NcButton
 				type="primary"
 				:disabled="submitting || newMessage.trim() === ''"
@@ -30,15 +31,44 @@
 				<div class="entity-notes__item-header">
 					<span class="entity-notes__author">{{ note.authorName }}</span>
 					<span class="entity-notes__time">{{ formatTime(note.timestamp) }}</span>
-					<NcButton
-						v-if="note.isOwn"
-						type="tertiary"
-						class="entity-notes__delete"
-						@click="deleteNote(note.id)">
-						{{ t('pipelinq', 'Delete') }}
-					</NcButton>
+					<template v-if="note.isOwn && editingNoteId !== note.id">
+						<NcButton
+							type="tertiary"
+							class="entity-notes__action"
+							@click="startEditing(note)">
+							{{ t('pipelinq', 'Edit') }}
+						</NcButton>
+						<NcButton
+							type="tertiary"
+							class="entity-notes__action"
+							@click="deleteNote(note.id)">
+							{{ t('pipelinq', 'Delete') }}
+						</NcButton>
+					</template>
 				</div>
-				<p class="entity-notes__message">
+
+				<!-- Inline editing mode -->
+				<div v-if="editingNoteId === note.id" class="entity-notes__edit">
+					<textarea
+						v-model="editMessage"
+						class="entity-notes__textarea"
+						rows="3"
+						@keydown="onEditKeydown" />
+					<div class="entity-notes__edit-actions">
+						<NcButton
+							type="primary"
+							:disabled="saving || editMessage.trim() === ''"
+							@click="saveEdit(note.id)">
+							{{ saving ? t('pipelinq', 'Saving...') : t('pipelinq', 'Save') }}
+						</NcButton>
+						<NcButton @click="cancelEditing">
+							{{ t('pipelinq', 'Cancel') }}
+						</NcButton>
+					</div>
+				</div>
+
+				<!-- Display mode -->
+				<p v-else class="entity-notes__message">
 					{{ note.message }}
 				</p>
 			</div>
@@ -71,6 +101,9 @@ export default {
 			newMessage: '',
 			loading: false,
 			submitting: false,
+			editingNoteId: null,
+			editMessage: '',
+			saving: false,
 		}
 	},
 	watch: {
@@ -105,6 +138,13 @@ export default {
 			this.loading = false
 		},
 
+		onNewNoteKeydown(event) {
+			if ((event.ctrlKey || event.metaKey) && event.key === 'Enter') {
+				event.preventDefault()
+				this.addNote()
+			}
+		},
+
 		async addNote() {
 			if (this.newMessage.trim() === '') return
 			this.submitting = true
@@ -129,6 +169,52 @@ export default {
 				// Submit failed silently
 			}
 			this.submitting = false
+		},
+
+		startEditing(note) {
+			this.editingNoteId = note.id
+			this.editMessage = note.message
+		},
+
+		cancelEditing() {
+			this.editingNoteId = null
+			this.editMessage = ''
+		},
+
+		onEditKeydown(event) {
+			if ((event.ctrlKey || event.metaKey) && event.key === 'Enter') {
+				event.preventDefault()
+				if (this.editingNoteId !== null) {
+					this.saveEdit(this.editingNoteId)
+				}
+			}
+		},
+
+		async saveEdit(noteId) {
+			if (this.editMessage.trim() === '') return
+			this.saving = true
+			try {
+				const response = await fetch(
+					`/apps/pipelinq/api/notes/single/${noteId}`,
+					{
+						method: 'PUT',
+						headers: {
+							'Content-Type': 'application/json',
+							requesttoken: OC.requestToken,
+							'OCS-APIREQUEST': 'true',
+						},
+						body: JSON.stringify({ message: this.editMessage }),
+					},
+				)
+				if (response.ok) {
+					this.editingNoteId = null
+					this.editMessage = ''
+					await this.fetchNotes()
+				}
+			} catch {
+				// Edit failed silently
+			}
+			this.saving = false
 		},
 
 		async deleteNote(noteId) {
@@ -249,8 +335,22 @@ export default {
 	color: var(--color-text-maxcontrast);
 }
 
-.entity-notes__delete {
+.entity-notes__action {
 	margin-left: auto;
+}
+
+.entity-notes__action + .entity-notes__action {
+	margin-left: 0;
+}
+
+.entity-notes__edit {
+	margin-top: 8px;
+}
+
+.entity-notes__edit-actions {
+	display: flex;
+	gap: 8px;
+	margin-top: 8px;
 }
 
 .entity-notes__message {


### PR DESCRIPTION
## Summary
- Add ObjectDeletedListener to clean up orphaned notes when entities are deleted via OpenRegister
- Add note update endpoint (PUT /api/notes/single/{noteId}) with ownership verification
- Add inline editing UI (edit/save/cancel) for own notes in EntityNotes.vue
- Add Ctrl+Enter / Cmd+Enter keyboard shortcut for note submission

Closes #27

## Test plan
- [ ] Create a note on a client/lead, verify inline editing works (Edit -> modify -> Save)
- [ ] Verify Cancel reverts without API call
- [ ] Verify only own notes show Edit/Delete buttons
- [ ] Delete an entity via OpenRegister and verify associated notes are cleaned up
- [ ] Verify Ctrl+Enter submits a new note