### PR TITLE
feat: Implement product-catalog spec (margin, safe delete, active filter)

### DIFF
--- a/openspec/changes/2026-03-20-product-catalog/design.md
+++ b/openspec/changes/2026-03-20-product-catalog/design.md
@@ -1,0 +1,28 @@
+# Design: product-catalog margin display, safe delete, and active filter
+
+## Margin Display
+
+Add a "Margin" row in the ProductDetail.vue info grid. When `cost` is set and > 0:
+- Show margin EUR: `unitPrice - cost`
+- Show margin %: `((unitPrice - cost) / unitPrice * 100).toFixed(1)`
+- Color: green for positive margin, red for negative
+
+## Safe Delete with Linked Leads Check
+
+In `confirmDelete()`:
+1. Check if `linkedLeads.length > 0`
+2. If yes, show a warning dialog with count of linked leads
+3. Offer "Set to inactive" as primary action, "Delete anyway" as secondary
+4. "Set to inactive" sets `status: 'inactive'` and redirects to list
+
+## Active-Only Product Filter in Lead Dialog
+
+In LeadProducts.vue `productOptions` computed:
+- Filter `this.products` to only include products where `status !== 'inactive'`
+- This ensures inactive products don't appear in the "Add Product" dropdown
+
+## Inactive Product Visual Marking
+
+In LeadProducts.vue line items table:
+- Check each line item's product status by looking up the product in `this.products`
+- If product status is 'inactive', add a visual badge "(inactive)" with greyed-out styling

--- a/openspec/changes/2026-03-20-product-catalog/proposal.md
+++ b/openspec/changes/2026-03-20-product-catalog/proposal.md
@@ -1,0 +1,27 @@
+# Proposal: product-catalog margin display, safe delete, and active filter
+
+## Problem
+
+The product-catalog spec identifies V1 gaps:
+1. No margin calculation display on product detail page (unitPrice - cost, margin %)
+2. Deleting a product linked to leads uses simple confirm() without checking for linked leads
+3. Lead product dialog shows inactive products — should filter to active only
+4. Inactive products on existing leads are not visually distinguished
+
+## Proposed Change
+
+1. Add margin display to ProductDetail.vue showing margin EUR and margin % when cost is set
+2. Enhance `confirmDelete()` to check for linked LeadProduct items and warn/offer to deactivate instead
+3. Filter LeadProducts.vue product dropdown to only show active products
+4. Add visual marking for inactive products in existing lead line items
+
+### Out of Scope
+- Product image upload UI
+- Product import/export (CSV)
+- Product bundling (Enterprise)
+- Category hierarchy tree UI
+- Category-level revenue aggregation
+
+## Impact
+- **Files modified**: 2 (ProductDetail.vue, LeadProducts.vue)
+- **Risk**: Low — additive UI changes only

--- a/openspec/changes/2026-03-20-product-catalog/specs/product-catalog/spec.md
+++ b/openspec/changes/2026-03-20-product-catalog/specs/product-catalog/spec.md
@@ -1,0 +1,8 @@
+# Delta Spec: product-catalog margin display, safe delete, and active filter
+
+## Newly Implemented
+
+- **Margin calculation display**: ProductDetail.vue shows margin (unitPrice - cost) and margin percentage when cost is set. Positive margins styled green, negative red.
+- **Delete product linked to leads**: ProductDetail.vue checks for linked LeadProduct items before deletion. Warns user with lead count and offers "Set to inactive" as primary action alternative.
+- **Only active products in lead dialog**: LeadProducts.vue filters product dropdown to only show products with `status !== 'inactive'`.
+- **Inactive product visual marking on leads**: LeadProducts.vue shows "(inactive)" badge next to product names in line items where the product has been deactivated.

--- a/openspec/changes/2026-03-20-product-catalog/tasks.md
+++ b/openspec/changes/2026-03-20-product-catalog/tasks.md
@@ -1,0 +1,21 @@
+# Tasks: product-catalog margin display, safe delete, and active filter
+
+## 1. Margin calculation display
+- [ ] 1.1 Add margin EUR and margin % to ProductDetail.vue info grid
+  - **spec_ref**: `specs/product-catalog/spec.md#Margin calculation display`
+  - **files**: `pipelinq/src/views/products/ProductDetail.vue`
+
+## 2. Safe delete with linked leads check
+- [ ] 2.1 Enhance confirmDelete() to check linkedLeads and offer deactivation
+  - **spec_ref**: `specs/product-catalog/spec.md#Delete a product linked to leads`
+  - **files**: `pipelinq/src/views/products/ProductDetail.vue`
+
+## 3. Active-only filter in lead product dialog
+- [ ] 3.1 Filter product dropdown to active products only in LeadProducts.vue
+  - **spec_ref**: `specs/product-catalog/spec.md#Only active products in lead dialog`
+  - **files**: `pipelinq/src/components/LeadProducts.vue`
+
+## 4. Inactive product visual marking on leads
+- [ ] 4.1 Add inactive badge to line items with inactive products
+  - **spec_ref**: `specs/product-catalog/spec.md#Inactive product on existing lead`
+  - **files**: `pipelinq/src/components/LeadProducts.vue`

--- a/src/components/LeadProducts.vue
+++ b/src/components/LeadProducts.vue
@@ -28,7 +28,12 @@
 					</thead>
 					<tbody>
 						<tr v-for="item in lineItems" :key="item.id">
-							<td>{{ getProductName(item.product) }}</td>
+							<td :class="{ 'product-inactive': isProductInactive(item.product) }">
+								{{ getProductName(item.product) }}
+								<span v-if="isProductInactive(item.product)" class="inactive-badge">
+									{{ t('pipelinq', '(inactive)') }}
+								</span>
+							</td>
 							<td>
 								<input
 									v-model.number="item.quantity"
@@ -196,7 +201,9 @@ export default {
 			return useObjectStore()
 		},
 		productOptions() {
-			return this.products.map(p => ({ id: p.id, name: p.name || p.id }))
+			return this.products
+				.filter(p => p.status !== 'inactive')
+				.map(p => ({ id: p.id, name: p.name || p.id }))
 		},
 		grandTotal() {
 			return this.lineItems.reduce((sum, item) => sum + this.calculateTotal(item), 0)
@@ -233,6 +240,10 @@ export default {
 		getProductName(productId) {
 			const product = this.products.find(p => p.id === productId)
 			return product?.name || productId || '-'
+		},
+		isProductInactive(productId) {
+			const product = this.products.find(p => p.id === productId)
+			return product?.status === 'inactive'
 		},
 		calculateTotal(item) {
 			const qty = Number(item.quantity) || 0
@@ -482,5 +493,15 @@ export default {
 	display: flex;
 	gap: 8px;
 	margin-top: 16px;
+}
+
+.product-inactive {
+	color: var(--color-text-maxcontrast);
+}
+
+.inactive-badge {
+	font-size: 11px;
+	font-style: italic;
+	color: var(--color-text-maxcontrast);
 }
 </style>

--- a/src/views/products/ProductDetail.vue
+++ b/src/views/products/ProductDetail.vue
@@ -73,6 +73,12 @@
 					<label>{{ t('pipelinq', 'Category') }}</label>
 					<span>{{ categoryName || '-' }}</span>
 				</div>
+				<div v-if="hasMargin" class="info-field">
+					<label>{{ t('pipelinq', 'Margin') }}</label>
+					<span :class="marginClass">
+						{{ formatCurrency(marginAmount) }} ({{ marginPercentage }}%)
+					</span>
+				</div>
 			</div>
 			<div v-if="productData.description" class="info-field info-field--full">
 				<label>{{ t('pipelinq', 'Description') }}</label>
@@ -154,6 +160,22 @@ export default {
 			if (this.isNew) return {}
 			return this.objectStore.getObject('product', this.productId) || {}
 		},
+		hasMargin() {
+			const cost = Number(this.productData.cost)
+			const price = Number(this.productData.unitPrice)
+			return cost > 0 && price > 0
+		},
+		marginAmount() {
+			return Number(this.productData.unitPrice) - Number(this.productData.cost)
+		},
+		marginPercentage() {
+			const price = Number(this.productData.unitPrice)
+			if (price === 0) return '0.0'
+			return ((this.marginAmount / price) * 100).toFixed(1)
+		},
+		marginClass() {
+			return this.marginAmount >= 0 ? 'margin--positive' : 'margin--negative'
+		},
 		sidebarProps() {
 			const config = this.objectStore.objectTypeRegistry.product || {}
 			return {
@@ -192,14 +214,38 @@ export default {
 			}
 		},
 		async confirmDelete() {
-			if (confirm(t('pipelinq', 'Are you sure you want to delete this product?'))) {
-				const success = await this.objectStore.deleteObject('product', this.productId)
-				if (success) {
-					this.$router.push({ name: 'Products' })
-				} else {
-					const error = this.objectStore.getError('product')
-					showError(error?.message || t('pipelinq', 'Failed to delete product.'))
+			if (this.linkedLeads.length > 0) {
+				const count = this.linkedLeads.length
+				const message = t('pipelinq', 'This product is linked to {count} lead(s). Do you want to set it to inactive instead of deleting?', { count })
+				const choice = confirm(message + '\n\n' + t('pipelinq', 'OK = Set to inactive, Cancel = Delete anyway'))
+				if (choice) {
+					// Set to inactive
+					const result = await this.objectStore.saveObject('product', {
+						id: this.productId,
+						status: 'inactive',
+					})
+					if (result) {
+						await this.objectStore.fetchObject('product', this.productId)
+						this.editing = false
+					} else {
+						showError(t('pipelinq', 'Failed to deactivate product.'))
+					}
+					return
 				}
+				// User chose "Cancel" = delete anyway, ask for final confirmation
+				if (!confirm(t('pipelinq', 'Are you sure you want to permanently delete this product?'))) {
+					return
+				}
+			} else if (!confirm(t('pipelinq', 'Are you sure you want to delete this product?'))) {
+				return
+			}
+
+			const success = await this.objectStore.deleteObject('product', this.productId)
+			if (success) {
+				this.$router.push({ name: 'Products' })
+			} else {
+				const error = this.objectStore.getError('product')
+				showError(error?.message || t('pipelinq', 'Failed to delete product.'))
 			}
 		},
 		async fetchRelated() {
@@ -332,5 +378,15 @@ export default {
 	text-align: center;
 	color: var(--color-text-maxcontrast);
 	padding: 20px;
+}
+
+.margin--positive {
+	color: #166534;
+	font-weight: 600;
+}
+
+.margin--negative {
+	color: #dc2626;
+	font-weight: 600;
 }
 </style>


### PR DESCRIPTION
## Summary
- Add margin calculation (EUR + percentage) to product detail page when cost is set
- Enhance product deletion to check for linked lead products and offer deactivation as alternative
- Filter lead product dialog to show only active products
- Mark inactive products in existing lead line items with visual "(inactive)" badge

Closes #30

## Test plan
- [ ] Create product with cost, verify margin display shows correct values
- [ ] Try to delete a product linked to leads, verify warning and deactivation option
- [ ] Set a product to inactive, verify it disappears from "Add Product" dropdown
- [ ] Verify existing line items with inactive products show "(inactive)" badge