### PR TITLE
feat: Deal won/lost notifications and activity events

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -104,6 +104,7 @@ Vrij en open source onder de AGPL-licentie.
             <setting>OCA\Pipelinq\Activity\Setting\AssignmentSetting</setting>
             <setting>OCA\Pipelinq\Activity\Setting\StageStatusSetting</setting>
             <setting>OCA\Pipelinq\Activity\Setting\NoteSetting</setting>
+            <setting>OCA\Pipelinq\Activity\Setting\DealSetting</setting>
         </settings>
         <filters>
             <filter>OCA\Pipelinq\Activity\Filter</filter>

--- a/lib/Activity/Provider.php
+++ b/lib/Activity/Provider.php
@@ -45,6 +45,8 @@ class Provider implements IProvider
         'request_created',
         'request_status_changed',
         'note_added',
+        'lead_won',
+        'lead_lost',
     ];
 
     /**

--- a/lib/Activity/ProviderSubjectHandler.php
+++ b/lib/Activity/ProviderSubjectHandler.php
@@ -37,6 +37,7 @@ class ProviderSubjectHandler
         'lead_created'    => ['Lead created: %s', 'Lead created: {title}'],
         'lead_assigned'   => ['Lead assigned: %s', 'Lead assigned: {title}'],
         'request_created' => ['Request created: %s', 'Request created: {title}'],
+        'lead_lost'       => ['Deal lost: %s', 'Deal lost: {title}'],
     ];
 
     /**
@@ -88,6 +89,16 @@ class ProviderSubjectHandler
                 title: $title,
                 status: ($params['status'] ?? ''),
                 richParams: $richParams
+            );
+            return;
+        }
+
+        if ($subject === 'lead_won') {
+            $value = $params['value'] ?? '';
+            $event->setParsedSubject($l->t('Deal won: %1$s (EUR %2$s)', [$title, $value]));
+            $event->setRichSubject(
+                subject: $l->t('Deal won: {title} (EUR %1$s)', [$value]),
+                parameters: $richParams
             );
             return;
         }

--- a/lib/Activity/Setting/DealSetting.php
+++ b/lib/Activity/Setting/DealSetting.php
@@ -1,0 +1,131 @@
+<?php
+
+/**
+ * Pipelinq DealSetting.
+ *
+ * Activity setting for deal won and lost notifications.
+ *
+ * @category Activity
+ * @package  OCA\Pipelinq\Activity\Setting
+ *
+ * @author    Conduction Development Team <dev@conductio.nl>
+ * @copyright 2024 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git_id>
+ *
+ * @link https://pipelinq.nl
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Pipelinq\Activity\Setting;
+
+use OCP\Activity\ActivitySettings;
+use OCP\IL10N;
+
+/**
+ * Activity setting for deal won/lost events.
+ */
+class DealSetting extends ActivitySettings
+{
+    /**
+     * Constructor.
+     *
+     * @param IL10N $l The localization service.
+     */
+    public function __construct(
+        private IL10N $l,
+    ) {
+    }//end __construct()
+
+    /**
+     * Get the identifier for this setting.
+     *
+     * @return string The setting identifier.
+     */
+    public function getIdentifier(): string
+    {
+        return 'pipelinq_deals';
+    }//end getIdentifier()
+
+    /**
+     * Get the name for this setting.
+     *
+     * @return string The setting name.
+     */
+    public function getName(): string
+    {
+        return $this->l->t('Deal won & lost');
+    }//end getName()
+
+    /**
+     * Get the group identifier for this setting.
+     *
+     * @return string The group identifier.
+     */
+    public function getGroupIdentifier(): string
+    {
+        return 'pipelinq';
+    }//end getGroupIdentifier()
+
+    /**
+     * Get the group name for this setting.
+     *
+     * @return string The group name.
+     */
+    public function getGroupName(): string
+    {
+        return $this->l->t('Pipelinq');
+    }//end getGroupName()
+
+    /**
+     * Get the priority for this setting.
+     *
+     * @return int The priority.
+     */
+    public function getPriority(): int
+    {
+        return 51;
+    }//end getPriority()
+
+    /**
+     * Whether the user can change the stream setting.
+     *
+     * @return bool True if changeable.
+     */
+    public function canChangeStream(): bool
+    {
+        return true;
+    }//end canChangeStream()
+
+    /**
+     * Whether the stream is enabled by default.
+     *
+     * @return bool True if enabled by default.
+     */
+    public function isDefaultEnabledStream(): bool
+    {
+        return true;
+    }//end isDefaultEnabledStream()
+
+    /**
+     * Whether the user can change the mail setting.
+     *
+     * @return bool True if changeable.
+     */
+    public function canChangeMail(): bool
+    {
+        return true;
+    }//end canChangeMail()
+
+    /**
+     * Whether mail is enabled by default.
+     *
+     * @return bool True if enabled by default.
+     */
+    public function isDefaultEnabledMail(): bool
+    {
+        return true;
+    }//end isDefaultEnabledMail()
+}//end class

--- a/lib/Notification/Notifier.php
+++ b/lib/Notification/Notifier.php
@@ -169,6 +169,26 @@ class Notifier implements INotifier
                         );
                 break;
 
+            case 'lead_won':
+                $value = $params['value'] ?? '';
+                $notification->setParsedSubject($l->t('Deal won: %1$s (EUR %2$s)', [$title, $value]));
+                $notification->setRichSubject(
+                        subject: $l->t('Deal won: {title} (EUR %1$s)', [$value]),
+                        parameters: $richParams
+                        );
+                break;
+
+            case 'lead_lost':
+                $this->applySimpleSubject(
+                    notification: $notification,
+                    l: $l,
+                    parsedKey: 'Deal lost: %s',
+                    richKey: 'Deal lost: {title}',
+                    title: $title,
+                    richParams: $richParams
+                );
+                break;
+
             default:
                 throw new UnknownNotificationException();
         }//end switch

--- a/lib/Service/ActivityService.php
+++ b/lib/Service/ActivityService.php
@@ -202,6 +202,61 @@ class ActivityService
     }//end publishNoteAdded()
 
     /**
+     * Publish a deal won event.
+     *
+     * @param string  $title        The lead title.
+     * @param string  $value        The deal value.
+     * @param string  $objectId     The object ID.
+     * @param ?string $affectedUser The affected user or null.
+     *
+     * @return void
+     */
+    public function publishDealWon(
+        string $title,
+        string $value,
+        string $objectId,
+        ?string $affectedUser=null
+    ): void {
+        $this->publish(
+            subject: 'lead_won',
+            type: 'pipelinq_deals',
+            parameters: [
+                'title' => $title,
+                'value' => $value,
+            ],
+            objectType: 'lead',
+            objectId: $objectId,
+            affectedUser: $affectedUser
+        );
+    }//end publishDealWon()
+
+    /**
+     * Publish a deal lost event.
+     *
+     * @param string  $title        The lead title.
+     * @param string  $objectId     The object ID.
+     * @param ?string $affectedUser The affected user or null.
+     *
+     * @return void
+     */
+    public function publishDealLost(
+        string $title,
+        string $objectId,
+        ?string $affectedUser=null
+    ): void {
+        $this->publish(
+            subject: 'lead_lost',
+            type: 'pipelinq_deals',
+            parameters: [
+                'title' => $title,
+            ],
+            objectType: 'lead',
+            objectId: $objectId,
+            affectedUser: $affectedUser
+        );
+    }//end publishDealLost()
+
+    /**
      * Publish an activity event.
      *
      * @param string  $subject      The activity subject.

--- a/lib/Service/NotificationService.php
+++ b/lib/Service/NotificationService.php
@@ -43,6 +43,8 @@ class NotificationService
         'lead_stage_changed'     => 'notify_stage_status',
         'request_status_changed' => 'notify_stage_status',
         'note_added'             => 'notify_notes',
+        'lead_won'               => 'notify_deals',
+        'lead_lost'              => 'notify_deals',
     ];
 
     /**
@@ -203,6 +205,65 @@ class NotificationService
             objectId: $objectId
         );
     }//end notifyNoteAdded()
+
+    /**
+     * Notify a user about a deal being won.
+     *
+     * @param string $title          The lead title.
+     * @param string $value          The deal value.
+     * @param string $assigneeUserId The assignee user ID.
+     * @param string $objectId       The object ID.
+     * @param string $author         The author user ID.
+     *
+     * @return void
+     */
+    public function notifyDealWon(
+        string $title,
+        string $value,
+        string $assigneeUserId,
+        string $objectId,
+        string $author
+    ): void {
+        $this->send(
+            subject: 'lead_won',
+            parameters: [
+                'title'  => $title,
+                'value'  => $value,
+                'author' => $author,
+            ],
+            userId: $assigneeUserId,
+            objectType: 'lead',
+            objectId: $objectId
+        );
+    }//end notifyDealWon()
+
+    /**
+     * Notify a user about a deal being lost.
+     *
+     * @param string $title          The lead title.
+     * @param string $assigneeUserId The assignee user ID.
+     * @param string $objectId       The object ID.
+     * @param string $author         The author user ID.
+     *
+     * @return void
+     */
+    public function notifyDealLost(
+        string $title,
+        string $assigneeUserId,
+        string $objectId,
+        string $author
+    ): void {
+        $this->send(
+            subject: 'lead_lost',
+            parameters: [
+                'title'  => $title,
+                'author' => $author,
+            ],
+            userId: $assigneeUserId,
+            objectType: 'lead',
+            objectId: $objectId
+        );
+    }//end notifyDealLost()
 
     /**
      * Send a notification to a user.

--- a/lib/Service/ObjectEventDispatcher.php
+++ b/lib/Service/ObjectEventDispatcher.php
@@ -165,6 +165,63 @@ class ObjectEventDispatcher
     }//end dispatchStatusChange()
 
     /**
+     * Dispatch deal won events for a lead.
+     *
+     * @param string $title    The lead title.
+     * @param string $value    The deal value.
+     * @param string $objectId The object ID.
+     * @param string $assignee The current assignee.
+     *
+     * @return void
+     */
+    public function dispatchDealWon(string $title, string $value, string $objectId, string $assignee): void
+    {
+        $this->activityService->publishDealWon(
+            title: $title,
+            value: $value,
+            objectId: $objectId,
+            affectedUser: $this->nullIfEmpty(value: $assignee)
+        );
+
+        if ($assignee !== '') {
+            $this->notifyService->notifyDealWon(
+                title: $title,
+                value: $value,
+                assigneeUserId: $assignee,
+                objectId: $objectId,
+                author: $this->getCurrentUser()
+            );
+        }
+    }//end dispatchDealWon()
+
+    /**
+     * Dispatch deal lost events for a lead.
+     *
+     * @param string $title    The lead title.
+     * @param string $objectId The object ID.
+     * @param string $assignee The current assignee.
+     *
+     * @return void
+     */
+    public function dispatchDealLost(string $title, string $objectId, string $assignee): void
+    {
+        $this->activityService->publishDealLost(
+            title: $title,
+            objectId: $objectId,
+            affectedUser: $this->nullIfEmpty(value: $assignee)
+        );
+
+        if ($assignee !== '') {
+            $this->notifyService->notifyDealLost(
+                title: $title,
+                assigneeUserId: $assignee,
+                objectId: $objectId,
+                author: $this->getCurrentUser()
+            );
+        }
+    }//end dispatchDealLost()
+
+    /**
      * Return null if the value is empty, otherwise return the value.
      *
      * @param string $value The value to check.

--- a/lib/Service/ObjectUpdateDiffService.php
+++ b/lib/Service/ObjectUpdateDiffService.php
@@ -85,6 +85,30 @@ class ObjectUpdateDiffService
             return;
         }
 
+        // Detect deal won or lost based on stage name.
+        $wonNames  = ['won', 'gewonnen', 'closed won'];
+        $lostNames = ['lost', 'verloren', 'closed lost'];
+        $stageLower = strtolower($newStage);
+
+        if (in_array($stageLower, $wonNames, true) === true) {
+            $dispatcher->dispatchDealWon(
+                title: $title,
+                value: (string) ($newData['value'] ?? '0'),
+                objectId: $objectId,
+                assignee: $assignee
+            );
+            return;
+        }
+
+        if (in_array($stageLower, $lostNames, true) === true) {
+            $dispatcher->dispatchDealLost(
+                title: $title,
+                objectId: $objectId,
+                assignee: $assignee
+            );
+            return;
+        }
+
         $dispatcher->dispatchStageChange(
             title: $title,
             objectId: $objectId,


### PR DESCRIPTION
## Summary
- Adds distinct `lead_won` and `lead_lost` notification subjects (previously deal outcomes used generic `lead_stage_changed`)
- Creates `DealSetting` activity setting so users can toggle deal won/lost notifications independently
- Detects won/lost stages automatically by matching stage names (won, gewonnen, lost, verloren, closed won, closed lost)

## Test plan
- [ ] Move a lead to "Won" stage and verify the assignee receives a "Deal won: {title} (EUR {value})" notification
- [ ] Move a lead to "Lost" stage and verify the assignee receives a "Deal lost: {title}" notification
- [ ] Check Activity settings shows "Deal won & lost" toggle under Pipelinq group
- [ ] Verify deal won/lost events appear in the Activity stream
- [ ] Verify self-action suppression (moving your own lead to Won should not notify yourself)