### PR TITLE
feat: Implement product-catalog-quoting spec (schemas, views, BTW)

### DIFF
--- a/lib/Settings/pipelinq_register.json
+++ b/lib/Settings/pipelinq_register.json
@@ -27,7 +27,9 @@
           "pipeline",
           "product",
           "productCategory",
-          "leadProduct"
+          "leadProduct",
+          "quote",
+          "quoteLineItem"
         ],
         "tablePrefix": "",
         "folder": "Open Registers/Pipelinq"
@@ -646,6 +648,187 @@
           "notes": {
             "type": "string",
             "description": "Line item notes (e.g., annual license, setup fee)",
+            "visible": false
+          }
+        }
+      },
+      "quote": {
+        "slug": "quote",
+        "title": "Quote",
+        "icon": "FileDocumentEdit",
+        "version": "1.0.0",
+        "summary": "A formal quote or proposal linked to a lead",
+        "description": "Represents a quote (offerte) with line items, lifecycle status, and financial summary. Linked to leads and clients for proposal management. Mapped to Schema.org Offer.",
+        "@type": "schema:Offer",
+        "required": [
+          "title",
+          "status"
+        ],
+        "properties": {
+          "quoteNumber": {
+            "type": "string",
+            "description": "Auto-generated sequential quote number (e.g., OFF-2026-0042)",
+            "maxLength": 50
+          },
+          "lead": {
+            "type": "string",
+            "description": "UUID reference to the parent Lead",
+            "format": "uuid"
+          },
+          "client": {
+            "type": "string",
+            "description": "UUID reference to the Client",
+            "format": "uuid"
+          },
+          "contact": {
+            "type": "string",
+            "description": "UUID reference to the Contact person",
+            "format": "uuid",
+            "visible": false
+          },
+          "status": {
+            "type": "string",
+            "description": "Quote lifecycle status",
+            "enum": [
+              "concept",
+              "verzonden",
+              "geaccepteerd",
+              "afgewezen",
+              "verlopen"
+            ],
+            "default": "concept",
+            "title": "Status",
+            "facetable": true
+          },
+          "title": {
+            "type": "string",
+            "description": "Quote title or subject line",
+            "maxLength": 255,
+            "minLength": 1
+          },
+          "sentDate": {
+            "type": "string",
+            "description": "Date the quote was sent to the client",
+            "format": "date",
+            "visible": false
+          },
+          "expiryDate": {
+            "type": "string",
+            "description": "Date the quote expires",
+            "format": "date"
+          },
+          "subtotal": {
+            "type": "number",
+            "description": "Sum of all line item totals (excl. BTW)",
+            "minimum": 0
+          },
+          "taxRate": {
+            "type": "number",
+            "description": "Tax rate as percentage. Default: 21 (Dutch BTW)",
+            "minimum": 0,
+            "maximum": 100,
+            "default": 21,
+            "visible": false
+          },
+          "taxAmount": {
+            "type": "number",
+            "description": "Computed: subtotal * (taxRate / 100)",
+            "minimum": 0,
+            "visible": false
+          },
+          "total": {
+            "type": "number",
+            "description": "Computed: subtotal + taxAmount",
+            "minimum": 0
+          },
+          "paymentTerms": {
+            "type": "string",
+            "description": "Free-text payment terms and conditions",
+            "visible": false
+          },
+          "notes": {
+            "type": "string",
+            "description": "Internal notes (not shown on PDF)",
+            "visible": false
+          },
+          "version": {
+            "type": "integer",
+            "description": "Version number for revised quotes",
+            "default": 1,
+            "visible": false
+          },
+          "assignee": {
+            "type": "string",
+            "description": "Nextcloud user ID of the quote owner",
+            "title": "Assignee",
+            "facetable": true
+          }
+        }
+      },
+      "quoteLineItem": {
+        "slug": "quoteLineItem",
+        "title": "Quote Line Item",
+        "icon": "FormatListNumbered",
+        "version": "1.0.0",
+        "summary": "A line item within a quote",
+        "description": "Represents a line item in a quote with quantity, pricing, and discount. Can reference a product from the catalog or be a custom free-text item.",
+        "@type": "schema:Offer",
+        "required": [
+          "quote",
+          "description",
+          "quantity",
+          "unitPrice"
+        ],
+        "properties": {
+          "quote": {
+            "type": "string",
+            "description": "UUID reference to the parent Quote",
+            "format": "uuid"
+          },
+          "product": {
+            "type": "string",
+            "description": "UUID reference to a Product (optional for custom items)",
+            "format": "uuid",
+            "visible": false
+          },
+          "description": {
+            "type": "string",
+            "description": "Line item description (pre-populated from Product.name if linked)",
+            "maxLength": 500
+          },
+          "quantity": {
+            "type": "number",
+            "description": "Number of units",
+            "minimum": 0.01,
+            "default": 1
+          },
+          "unitPrice": {
+            "type": "number",
+            "description": "Price per unit in EUR",
+            "minimum": 0
+          },
+          "discount": {
+            "type": "number",
+            "description": "Discount as percentage (0-100)",
+            "minimum": 0,
+            "maximum": 100,
+            "default": 0,
+            "visible": false
+          },
+          "total": {
+            "type": "number",
+            "description": "Computed: quantity * unitPrice * (1 - discount/100)",
+            "minimum": 0
+          },
+          "sortOrder": {
+            "type": "integer",
+            "description": "Display order within the quote",
+            "default": 0,
+            "visible": false
+          },
+          "notes": {
+            "type": "string",
+            "description": "Line item notes (shown on PDF)",
             "visible": false
           }
         }

--- a/openspec/changes/2026-03-20-product-catalog-quoting/design.md
+++ b/openspec/changes/2026-03-20-product-catalog-quoting/design.md
@@ -1,0 +1,28 @@
+# Design: product-catalog-quoting foundation
+
+## Quote Schema
+
+Added to `pipelinq_register.json` as `quote` with `@type: schema:Offer`. Properties: quoteNumber, lead, client, contact, status (enum: concept/verzonden/geaccepteerd/afgewezen/verlopen), title, sentDate, expiryDate, subtotal, taxRate, taxAmount, total, paymentTerms, notes, version, assignee.
+
+## QuoteLineItem Schema
+
+Added as `quoteLineItem` with `@type: schema:Offer`. Properties: quote, product, description, quantity, unitPrice, discount, total, sortOrder, notes.
+
+## Store Registration
+
+Both `quote` and `quoteLineItem` registered in `initializeStores()` via `objectStore.registerObjectType()`.
+
+## Views
+
+- **QuoteList.vue**: Uses `CnIndexPage` with status filter dropdown, search, and "New Quote" action. Columns: quote number, title, client, subtotal, status, sent date.
+- **QuoteDetail.vue**: Uses `CnDetailPage` with header info, status badge, line items table (QuoteLineItems component), financial summary (subtotal, BTW, total), and action buttons.
+- **QuoteLineItems.vue**: Table component for managing line items on a quote, similar to LeadProducts.vue. Supports add (from product catalog or custom), inline editing of quantity/price/discount, remove, and drag-to-reorder (via sortOrder).
+
+## Routes
+
+- `/quotes` -> QuoteList
+- `/quotes/:id` -> QuoteDetail
+
+## Navigation
+
+"Quotes" added to the navigation component alongside existing entries.

--- a/openspec/changes/2026-03-20-product-catalog-quoting/proposal.md
+++ b/openspec/changes/2026-03-20-product-catalog-quoting/proposal.md
@@ -1,0 +1,28 @@
+# Proposal: product-catalog-quoting foundation
+
+## Problem
+
+The product-catalog-quoting spec defines a complete quoting/proposal system that does not exist at all. This change implements the foundation: schema definitions, store registration, basic CRUD views, and navigation.
+
+## Proposed Change
+
+1. Add `quote` and `quoteLineItem` schemas to `pipelinq_register.json`
+2. Register `quote` and `quoteLineItem` in `store.js` initialization
+3. Add quote list view with status filtering
+4. Add quote detail view with line items table, status display, and financial summary
+5. Add quote create dialog
+6. Add routes for `/quotes` and `/quotes/:id`
+7. Add "Quotes" to navigation
+
+### Out of Scope
+- PDF generation (requires Docudesk integration)
+- Quote lifecycle status transitions beyond basic status field
+- Auto-expiry logic
+- Quote-to-order conversion
+- Quote acceptance updating lead value
+- Email/notification workflow for sending quotes
+
+## Impact
+- **Files modified**: 3 (pipelinq_register.json, store.js, router/index.js)
+- **Files created**: 3 (QuoteList.vue, QuoteDetail.vue, QuoteLineItems.vue)
+- **Risk**: Low — additive, new schemas and views

--- a/openspec/changes/2026-03-20-product-catalog-quoting/specs/product-catalog-quoting/spec.md
+++ b/openspec/changes/2026-03-20-product-catalog-quoting/specs/product-catalog-quoting/spec.md
@@ -1,0 +1,12 @@
+# Delta Spec: product-catalog-quoting foundation
+
+## Newly Implemented
+
+- **Quote entity schema**: `quote` schema added to register with all properties (quoteNumber, lead, client, contact, status, title, sentDate, expiryDate, subtotal, taxRate, taxAmount, total, paymentTerms, notes, version, assignee). Status enum: concept, verzonden, geaccepteerd, afgewezen, verlopen.
+- **QuoteLineItem entity schema**: `quoteLineItem` schema added with properties (quote, product, description, quantity, unitPrice, discount, total, sortOrder, notes).
+- **Store registration**: Both schemas registered in store initialization.
+- **Quote list view**: QuoteList.vue with CnIndexPage, status filtering, search by quote number/title.
+- **Quote detail view**: QuoteDetail.vue with CnDetailPage, status badge, line items table, financial summary (subtotal, BTW amount, total).
+- **Quote line items component**: QuoteLineItems.vue for inline CRUD of line items with product search, discount calculation, grand total.
+- **Routes**: `/quotes` and `/quotes/:id` added to router.
+- **Navigation**: "Quotes" entry added.

--- a/openspec/changes/2026-03-20-product-catalog-quoting/tasks.md
+++ b/openspec/changes/2026-03-20-product-catalog-quoting/tasks.md
@@ -1,0 +1,31 @@
+# Tasks: product-catalog-quoting foundation
+
+## 1. Schema definitions
+- [ ] 1.1 Add quote and quoteLineItem schemas to pipelinq_register.json
+  - **spec_ref**: `specs/product-catalog-quoting/spec.md#Quote entity`
+  - **files**: `pipelinq/lib/Settings/pipelinq_register.json`
+
+## 2. Store registration
+- [ ] 2.1 Register quote and quoteLineItem in store initialization
+  - **spec_ref**: `specs/product-catalog-quoting/spec.md#Quote entity`
+  - **files**: `pipelinq/src/store/store.js`
+
+## 3. Quote list view
+- [ ] 3.1 Create QuoteList.vue with status filtering and search
+  - **spec_ref**: `specs/product-catalog-quoting/spec.md#Quote list view`
+  - **files**: `pipelinq/src/views/quotes/QuoteList.vue`
+
+## 4. Quote detail view
+- [ ] 4.1 Create QuoteDetail.vue with line items and financial summary
+  - **spec_ref**: `specs/product-catalog-quoting/spec.md#Quote detail view`
+  - **files**: `pipelinq/src/views/quotes/QuoteDetail.vue`
+
+## 5. Quote line items component
+- [ ] 5.1 Create QuoteLineItems.vue for managing quote line items
+  - **spec_ref**: `specs/product-catalog-quoting/spec.md#Quote line items`
+  - **files**: `pipelinq/src/components/QuoteLineItems.vue`
+
+## 6. Routes and navigation
+- [ ] 6.1 Add quote routes and navigation entry
+  - **spec_ref**: `specs/product-catalog-quoting/spec.md#Quote list and overview views`
+  - **files**: `pipelinq/src/router/index.js`, `pipelinq/src/navigation/navigation.js`

--- a/src/components/QuoteLineItems.vue
+++ b/src/components/QuoteLineItems.vue
@@ -1,0 +1,523 @@
+<template>
+	<div class="quote-line-items">
+		<div class="quote-line-items__header">
+			<h3>{{ t('pipelinq', 'Line Items') }}</h3>
+			<div v-if="editable" class="quote-line-items__actions">
+				<NcButton type="secondary" @click="showAddDialog = true">
+					{{ t('pipelinq', 'Add product') }}
+				</NcButton>
+				<NcButton type="tertiary" @click="showCustomDialog = true">
+					{{ t('pipelinq', 'Custom line') }}
+				</NcButton>
+			</div>
+		</div>
+
+		<NcLoadingIcon v-if="loading" :size="24" />
+
+		<div v-else-if="lineItems.length === 0" class="quote-line-items__empty">
+			<p>{{ t('pipelinq', 'No line items added to this quote yet.') }}</p>
+		</div>
+
+		<div v-else>
+			<div class="viewTableContainer">
+				<table class="viewTable">
+					<thead>
+						<tr>
+							<th>{{ t('pipelinq', 'Description') }}</th>
+							<th>{{ t('pipelinq', 'Qty') }}</th>
+							<th>{{ t('pipelinq', 'Unit Price') }}</th>
+							<th>{{ t('pipelinq', 'Discount') }}</th>
+							<th>{{ t('pipelinq', 'Total') }}</th>
+							<th v-if="editable" />
+						</tr>
+					</thead>
+					<tbody>
+						<tr v-for="item in sortedLineItems" :key="item.id">
+							<td>{{ item.description }}</td>
+							<td>
+								<input
+									v-if="editable"
+									v-model.number="item.quantity"
+									type="number"
+									min="0.01"
+									step="0.01"
+									class="inline-input inline-input--qty"
+									@change="updateLineItem(item)">
+								<span v-else>{{ item.quantity }}</span>
+							</td>
+							<td>
+								<input
+									v-if="editable"
+									v-model.number="item.unitPrice"
+									type="number"
+									min="0"
+									step="0.01"
+									class="inline-input inline-input--price"
+									@change="updateLineItem(item)">
+								<span v-else>{{ formatCurrency(item.unitPrice) }}</span>
+							</td>
+							<td>
+								<input
+									v-if="editable"
+									v-model.number="item.discount"
+									type="number"
+									min="0"
+									max="100"
+									step="0.01"
+									class="inline-input inline-input--discount"
+									@change="updateLineItem(item)">
+								<span v-else>{{ item.discount || 0 }}%</span>
+							</td>
+							<td class="total-cell">
+								{{ formatCurrency(calculateTotal(item)) }}
+							</td>
+							<td v-if="editable">
+								<NcButton type="tertiary" @click="removeLineItem(item)">
+									{{ t('pipelinq', 'Remove') }}
+								</NcButton>
+							</td>
+						</tr>
+					</tbody>
+					<tfoot>
+						<tr class="subtotal-row">
+							<td :colspan="editable ? 4 : 4" class="total-label">
+								{{ t('pipelinq', 'Subtotal') }}
+							</td>
+							<td class="total-cell">{{ formatCurrency(subtotal) }}</td>
+							<td v-if="editable" />
+						</tr>
+						<tr class="tax-row">
+							<td :colspan="editable ? 4 : 4" class="total-label">
+								{{ t('pipelinq', 'BTW ({rate}%)', { rate: taxRate }) }}
+							</td>
+							<td class="total-cell">{{ formatCurrency(taxAmount) }}</td>
+							<td v-if="editable" />
+						</tr>
+						<tr class="total-row">
+							<td :colspan="editable ? 4 : 4" class="total-label">
+								{{ t('pipelinq', 'Total') }}
+							</td>
+							<td class="total-cell total-cell--grand">
+								{{ formatCurrency(grandTotal) }}
+							</td>
+							<td v-if="editable" />
+						</tr>
+					</tfoot>
+				</table>
+			</div>
+		</div>
+
+		<!-- Add product dialog -->
+		<div v-if="showAddDialog" class="create-overlay" @click.self="showAddDialog = false">
+			<div class="create-dialog">
+				<div class="create-dialog__header">
+					<h3>{{ t('pipelinq', 'Add Product') }}</h3>
+					<NcButton type="tertiary" @click="showAddDialog = false">
+						&#x2715;
+					</NcButton>
+				</div>
+				<div class="create-dialog__body">
+					<div class="form-group">
+						<label>{{ t('pipelinq', 'Product') }} *</label>
+						<NcSelect
+							v-model="addForm.product"
+							:options="productOptions"
+							:placeholder="t('pipelinq', 'Search products...')"
+							label="name"
+							:reduce="opt => opt.id"
+							@input="onProductSelect" />
+					</div>
+					<div class="form-row">
+						<div class="form-group">
+							<label>{{ t('pipelinq', 'Quantity') }}</label>
+							<NcTextField
+								:value="String(addForm.quantity)"
+								type="number"
+								@update:value="v => addForm.quantity = Number(v)" />
+						</div>
+						<div class="form-group">
+							<label>{{ t('pipelinq', 'Unit Price') }}</label>
+							<NcTextField
+								:value="String(addForm.unitPrice)"
+								type="number"
+								@update:value="v => addForm.unitPrice = Number(v)" />
+						</div>
+						<div class="form-group">
+							<label>{{ t('pipelinq', 'Discount (%)') }}</label>
+							<NcTextField
+								:value="String(addForm.discount)"
+								type="number"
+								@update:value="v => addForm.discount = Number(v)" />
+						</div>
+					</div>
+					<div class="form-actions">
+						<NcButton type="primary" :disabled="!addForm.product" @click="addProductLineItem">
+							{{ t('pipelinq', 'Add') }}
+						</NcButton>
+						<NcButton @click="showAddDialog = false">
+							{{ t('pipelinq', 'Cancel') }}
+						</NcButton>
+					</div>
+				</div>
+			</div>
+		</div>
+
+		<!-- Custom line item dialog -->
+		<div v-if="showCustomDialog" class="create-overlay" @click.self="showCustomDialog = false">
+			<div class="create-dialog">
+				<div class="create-dialog__header">
+					<h3>{{ t('pipelinq', 'Custom Line Item') }}</h3>
+					<NcButton type="tertiary" @click="showCustomDialog = false">
+						&#x2715;
+					</NcButton>
+				</div>
+				<div class="create-dialog__body">
+					<div class="form-group">
+						<label>{{ t('pipelinq', 'Description') }} *</label>
+						<NcTextField
+							:value="customForm.description"
+							@update:value="v => customForm.description = v" />
+					</div>
+					<div class="form-row">
+						<div class="form-group">
+							<label>{{ t('pipelinq', 'Quantity') }}</label>
+							<NcTextField
+								:value="String(customForm.quantity)"
+								type="number"
+								@update:value="v => customForm.quantity = Number(v)" />
+						</div>
+						<div class="form-group">
+							<label>{{ t('pipelinq', 'Unit Price') }}</label>
+							<NcTextField
+								:value="String(customForm.unitPrice)"
+								type="number"
+								@update:value="v => customForm.unitPrice = Number(v)" />
+						</div>
+						<div class="form-group">
+							<label>{{ t('pipelinq', 'Discount (%)') }}</label>
+							<NcTextField
+								:value="String(customForm.discount)"
+								type="number"
+								@update:value="v => customForm.discount = Number(v)" />
+						</div>
+					</div>
+					<div class="form-actions">
+						<NcButton type="primary" :disabled="!customForm.description.trim()" @click="addCustomLineItem">
+							{{ t('pipelinq', 'Add') }}
+						</NcButton>
+						<NcButton @click="showCustomDialog = false">
+							{{ t('pipelinq', 'Cancel') }}
+						</NcButton>
+					</div>
+				</div>
+			</div>
+		</div>
+	</div>
+</template>
+
+<script>
+import { NcButton, NcLoadingIcon, NcSelect, NcTextField } from '@nextcloud/vue'
+import { showError } from '@nextcloud/dialogs'
+import { useObjectStore } from '../store/modules/object.js'
+
+export default {
+	name: 'QuoteLineItems',
+	components: {
+		NcButton,
+		NcLoadingIcon,
+		NcSelect,
+		NcTextField,
+	},
+	props: {
+		quoteId: {
+			type: String,
+			required: true,
+		},
+		taxRate: {
+			type: Number,
+			default: 21,
+		},
+		editable: {
+			type: Boolean,
+			default: true,
+		},
+	},
+	emits: ['totals-changed'],
+	data() {
+		return {
+			lineItems: [],
+			products: [],
+			loading: false,
+			showAddDialog: false,
+			showCustomDialog: false,
+			addForm: {
+				product: null,
+				quantity: 1,
+				unitPrice: 0,
+				discount: 0,
+			},
+			customForm: {
+				description: '',
+				quantity: 1,
+				unitPrice: 0,
+				discount: 0,
+			},
+		}
+	},
+	computed: {
+		objectStore() {
+			return useObjectStore()
+		},
+		productOptions() {
+			return this.products
+				.filter(p => p.status !== 'inactive')
+				.map(p => ({ id: p.id, name: p.name || p.id }))
+		},
+		sortedLineItems() {
+			return [...this.lineItems].sort((a, b) => (a.sortOrder || 0) - (b.sortOrder || 0))
+		},
+		subtotal() {
+			return this.lineItems.reduce((sum, item) => sum + this.calculateTotal(item), 0)
+		},
+		taxAmount() {
+			return this.subtotal * (this.taxRate / 100)
+		},
+		grandTotal() {
+			return this.subtotal + this.taxAmount
+		},
+	},
+	async mounted() {
+		await this.fetchData()
+	},
+	methods: {
+		async fetchData() {
+			this.loading = true
+			try {
+				const [items, prods] = await Promise.all([
+					this.objectStore.fetchCollection('quoteLineItem', {
+						_limit: 100,
+						quote: this.quoteId,
+					}),
+					this.objectStore.fetchCollection('product', { _limit: 200 }),
+				])
+				this.lineItems = (items || []).map(item => ({ ...item }))
+				this.products = prods || []
+			} catch {
+				this.lineItems = []
+				this.products = []
+			} finally {
+				this.loading = false
+			}
+			this.emitTotals()
+		},
+		calculateTotal(item) {
+			const qty = Number(item.quantity) || 0
+			const price = Number(item.unitPrice) || 0
+			const discount = Number(item.discount) || 0
+			return (qty * price) * (1 - discount / 100)
+		},
+		onProductSelect(productId) {
+			const product = this.products.find(p => p.id === productId)
+			if (product) {
+				this.addForm.unitPrice = Number(product.unitPrice) || 0
+			}
+		},
+		async addProductLineItem() {
+			if (!this.addForm.product) return
+			const product = this.products.find(p => p.id === this.addForm.product)
+			try {
+				const total = this.calculateTotal(this.addForm)
+				await this.objectStore.saveObject('quoteLineItem', {
+					quote: this.quoteId,
+					product: this.addForm.product,
+					description: product?.name || '',
+					quantity: this.addForm.quantity,
+					unitPrice: this.addForm.unitPrice,
+					discount: this.addForm.discount,
+					total,
+					sortOrder: this.lineItems.length,
+				})
+				this.showAddDialog = false
+				this.resetAddForm()
+				await this.fetchData()
+			} catch (e) {
+				showError(e.message || t('pipelinq', 'Failed to add line item'))
+			}
+		},
+		async addCustomLineItem() {
+			if (!this.customForm.description.trim()) return
+			try {
+				const total = this.calculateTotal(this.customForm)
+				await this.objectStore.saveObject('quoteLineItem', {
+					quote: this.quoteId,
+					description: this.customForm.description,
+					quantity: this.customForm.quantity,
+					unitPrice: this.customForm.unitPrice,
+					discount: this.customForm.discount,
+					total,
+					sortOrder: this.lineItems.length,
+				})
+				this.showCustomDialog = false
+				this.resetCustomForm()
+				await this.fetchData()
+			} catch (e) {
+				showError(e.message || t('pipelinq', 'Failed to add line item'))
+			}
+		},
+		async updateLineItem(item) {
+			try {
+				const total = this.calculateTotal(item)
+				await this.objectStore.saveObject('quoteLineItem', {
+					id: item.id,
+					quantity: item.quantity,
+					unitPrice: item.unitPrice,
+					discount: item.discount,
+					total,
+				})
+				item.total = total
+				this.emitTotals()
+			} catch (e) {
+				showError(e.message || t('pipelinq', 'Failed to update line item'))
+			}
+		},
+		async removeLineItem(item) {
+			if (!confirm(t('pipelinq', 'Remove this line item?'))) return
+			try {
+				await this.objectStore.deleteObject('quoteLineItem', item.id)
+				await this.fetchData()
+			} catch (e) {
+				showError(e.message || t('pipelinq', 'Failed to remove line item'))
+			}
+		},
+		emitTotals() {
+			this.$emit('totals-changed', {
+				subtotal: this.subtotal,
+				taxAmount: this.taxAmount,
+				total: this.grandTotal,
+				itemCount: this.lineItems.length,
+			})
+		},
+		resetAddForm() {
+			this.addForm = { product: null, quantity: 1, unitPrice: 0, discount: 0 }
+		},
+		resetCustomForm() {
+			this.customForm = { description: '', quantity: 1, unitPrice: 0, discount: 0 }
+		},
+		formatCurrency(value) {
+			if (value === null || value === undefined) return '-'
+			return 'EUR ' + Number(value).toLocaleString('nl-NL', { minimumFractionDigits: 2 })
+		},
+	},
+}
+</script>
+
+<style scoped>
+.quote-line-items__header {
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
+	margin-bottom: 12px;
+}
+
+.quote-line-items__header h3 {
+	margin: 0;
+}
+
+.quote-line-items__actions {
+	display: flex;
+	gap: 8px;
+}
+
+.quote-line-items__empty {
+	color: var(--color-text-maxcontrast);
+	padding: 12px 0;
+}
+
+.viewTableContainer {
+	background: var(--color-main-background);
+	border-radius: var(--border-radius);
+	overflow: hidden;
+	box-shadow: 0 2px 4px var(--color-box-shadow);
+	border: 1px solid var(--color-border);
+}
+
+.viewTable {
+	width: 100%;
+	border-collapse: collapse;
+}
+
+.viewTable th,
+.viewTable td {
+	padding: 8px 12px;
+	text-align: left;
+	border-bottom: 1px solid var(--color-border);
+	vertical-align: middle;
+}
+
+.viewTable th {
+	background-color: var(--color-background-dark);
+	font-weight: 500;
+	color: var(--color-text-maxcontrast);
+	font-size: 13px;
+}
+
+.inline-input {
+	border: 1px solid var(--color-border);
+	border-radius: var(--border-radius);
+	padding: 4px 6px;
+	font-size: 13px;
+	background: var(--color-main-background);
+}
+
+.inline-input--qty { width: 70px; }
+.inline-input--price, .inline-input--discount { width: 90px; }
+
+.total-cell { font-weight: 600; }
+.subtotal-row, .tax-row { background: var(--color-background-hover); }
+.total-row { background: var(--color-background-dark); }
+.total-label { text-align: right; font-weight: 700; }
+.total-cell--grand { font-size: 15px; }
+
+.create-overlay {
+	position: fixed;
+	top: 0; left: 0; right: 0; bottom: 0;
+	background: rgba(0, 0, 0, 0.5);
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	z-index: 10000;
+}
+
+.create-dialog {
+	background: var(--color-main-background);
+	border-radius: var(--border-radius-large);
+	box-shadow: 0 4px 24px rgba(0, 0, 0, 0.2);
+	width: 500px;
+	max-width: 90vw;
+	max-height: 85vh;
+	overflow-y: auto;
+}
+
+.create-dialog__header {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	padding: 16px 20px;
+	border-bottom: 1px solid var(--color-border);
+}
+
+.create-dialog__header h3 { margin: 0; }
+.create-dialog__body { padding: 20px; }
+
+.form-group { margin-bottom: 12px; }
+.form-group label {
+	display: block;
+	margin-bottom: 4px;
+	font-weight: bold;
+	font-size: 13px;
+}
+
+.form-row { display: flex; gap: 12px; }
+.form-row .form-group { flex: 1; }
+.form-actions { display: flex; gap: 8px; margin-top: 16px; }
+</style>

--- a/src/navigation/MainMenu.vue
+++ b/src/navigation/MainMenu.vue
@@ -45,6 +45,13 @@
 				</template>
 			</NcAppNavigationItem>
 			<NcAppNavigationItem
+				:name="t('pipelinq', 'Quotes')"
+				:to="{ name: 'Quotes' }">
+				<template #icon>
+					<FileDocumentEdit :size="20" />
+				</template>
+			</NcAppNavigationItem>
+			<NcAppNavigationItem
 				:name="t('pipelinq', 'Pipeline')"
 				:to="{ name: 'Pipeline' }">
 				<template #icon>
@@ -98,6 +105,7 @@ import ViewColumn from 'vue-material-design-icons/ViewColumn.vue'
 import AccountCheck from 'vue-material-design-icons/AccountCheck.vue'
 import BookOpenVariantOutline from 'vue-material-design-icons/BookOpenVariantOutline.vue'
 import PackageVariant from 'vue-material-design-icons/PackageVariant.vue'
+import FileDocumentEdit from 'vue-material-design-icons/FileDocumentEdit.vue'
 import Cog from 'vue-material-design-icons/Cog.vue'
 import Pipe from 'vue-material-design-icons/Pipe.vue'
 
@@ -116,6 +124,7 @@ export default {
 		AccountCheck,
 		BookOpenVariantOutline,
 		PackageVariant,
+		FileDocumentEdit,
 		Cog,
 		Pipe,
 	},

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -12,6 +12,8 @@ import LeadList from '../views/leads/LeadList.vue'
 import LeadDetail from '../views/leads/LeadDetail.vue'
 import ProductList from '../views/products/ProductList.vue'
 import ProductDetail from '../views/products/ProductDetail.vue'
+import QuoteList from '../views/quotes/QuoteList.vue'
+import QuoteDetail from '../views/quotes/QuoteDetail.vue'
 import PipelineBoard from '../views/pipeline/PipelineBoard.vue'
 import MyWork from '../views/MyWork.vue'
 import PipelineManager from '../views/settings/PipelineManager.vue'
@@ -33,6 +35,8 @@ export default new Router({
 		{ path: '/leads/:id', name: 'LeadDetail', component: LeadDetail, props: route => ({ leadId: route.params.id }) },
 		{ path: '/products', name: 'Products', component: ProductList },
 		{ path: '/products/:id', name: 'ProductDetail', component: ProductDetail, props: route => ({ productId: route.params.id }) },
+		{ path: '/quotes', name: 'Quotes', component: QuoteList },
+		{ path: '/quotes/:id', name: 'QuoteDetail', component: QuoteDetail, props: route => ({ quoteId: route.params.id }) },
 		{ path: '/pipeline', name: 'Pipeline', component: PipelineBoard },
 		{ path: '/my-work', name: 'MyWork', component: MyWork },
 		{ path: '/pipelines', name: 'Pipelines', component: PipelineManager },

--- a/src/store/store.js
+++ b/src/store/store.js
@@ -32,6 +32,12 @@ export async function initializeStores() {
 		if (config.register && config.leadProduct_schema) {
 			objectStore.registerObjectType('leadProduct', config.leadProduct_schema, config.register)
 		}
+		if (config.register && config.quote_schema) {
+			objectStore.registerObjectType('quote', config.quote_schema, config.register)
+		}
+		if (config.register && config.quoteLineItem_schema) {
+			objectStore.registerObjectType('quoteLineItem', config.quoteLineItem_schema, config.register)
+		}
 	}
 
 	return { settingsStore, objectStore }

--- a/src/views/quotes/QuoteDetail.vue
+++ b/src/views/quotes/QuoteDetail.vue
@@ -1,0 +1,349 @@
+<template>
+	<CnDetailPage
+		:title="quoteData.title || t('pipelinq', 'Quote')"
+		:subtitle="quoteData.quoteNumber || t('pipelinq', 'New Quote')"
+		:back-route="{ name: 'Quotes' }"
+		:back-label="t('pipelinq', 'Back to list')"
+		:loading="loading"
+		:sidebar="!isNew && !loading"
+		object-type="pipelinq_quote"
+		:object-id="quoteId"
+		:sidebar-props="sidebarProps">
+		<template #header-actions>
+			<template v-if="!isNew">
+				<NcButton v-if="!editing" type="primary" @click="editing = true">
+					{{ t('pipelinq', 'Edit') }}
+				</NcButton>
+				<NcButton type="error" @click="confirmDelete">
+					{{ t('pipelinq', 'Delete') }}
+				</NcButton>
+			</template>
+		</template>
+
+		<!-- New/Edit mode -->
+		<CnDetailCard v-if="isNew || editing" :title="t('pipelinq', 'Quote Details')">
+			<div class="form-grid">
+				<div class="form-group">
+					<label>{{ t('pipelinq', 'Title') }} *</label>
+					<NcTextField
+						:value="formData.title || ''"
+						@update:value="v => formData.title = v" />
+				</div>
+				<div class="form-group">
+					<label>{{ t('pipelinq', 'Status') }}</label>
+					<NcSelect
+						v-model="formData.status"
+						:options="statusOptions"
+						:reduce="opt => opt.id" />
+				</div>
+				<div class="form-group">
+					<label>{{ t('pipelinq', 'Tax Rate (%)') }}</label>
+					<NcTextField
+						:value="String(formData.taxRate || 21)"
+						type="number"
+						@update:value="v => formData.taxRate = Number(v)" />
+				</div>
+				<div class="form-group">
+					<label>{{ t('pipelinq', 'Expiry Date') }}</label>
+					<NcTextField
+						:value="formData.expiryDate || ''"
+						type="date"
+						@update:value="v => formData.expiryDate = v" />
+				</div>
+			</div>
+			<div class="form-group">
+				<label>{{ t('pipelinq', 'Payment Terms') }}</label>
+				<textarea
+					v-model="formData.paymentTerms"
+					rows="3"
+					class="form-textarea" />
+			</div>
+			<div class="form-group">
+				<label>{{ t('pipelinq', 'Internal Notes') }}</label>
+				<textarea
+					v-model="formData.notes"
+					rows="2"
+					class="form-textarea" />
+			</div>
+			<div class="form-actions">
+				<NcButton type="primary" :disabled="!formData.title" @click="saveQuote">
+					{{ t('pipelinq', 'Save') }}
+				</NcButton>
+				<NcButton @click="cancelEdit">
+					{{ t('pipelinq', 'Cancel') }}
+				</NcButton>
+			</div>
+		</CnDetailCard>
+
+		<!-- View mode -->
+		<template v-if="!isNew && !editing">
+			<CnDetailCard :title="t('pipelinq', 'Quote Information')">
+				<div class="info-grid">
+					<div class="info-field">
+						<label>{{ t('pipelinq', 'Quote Number') }}</label>
+						<span>{{ quoteData.quoteNumber || '-' }}</span>
+					</div>
+					<div class="info-field">
+						<label>{{ t('pipelinq', 'Status') }}</label>
+						<span class="status-badge" :class="'status--' + (quoteData.status || 'concept')">
+							{{ quoteData.status || 'concept' }}
+						</span>
+					</div>
+					<div class="info-field">
+						<label>{{ t('pipelinq', 'Version') }}</label>
+						<span>{{ quoteData.version || 1 }}</span>
+					</div>
+					<div class="info-field">
+						<label>{{ t('pipelinq', 'Tax Rate') }}</label>
+						<span>{{ quoteData.taxRate || 21 }}%</span>
+					</div>
+					<div v-if="quoteData.expiryDate" class="info-field">
+						<label>{{ t('pipelinq', 'Expiry Date') }}</label>
+						<span>{{ quoteData.expiryDate }}</span>
+					</div>
+					<div v-if="quoteData.sentDate" class="info-field">
+						<label>{{ t('pipelinq', 'Sent Date') }}</label>
+						<span>{{ quoteData.sentDate }}</span>
+					</div>
+				</div>
+				<div v-if="quoteData.paymentTerms" class="info-field info-field--full">
+					<label>{{ t('pipelinq', 'Payment Terms') }}</label>
+					<p>{{ quoteData.paymentTerms }}</p>
+				</div>
+			</CnDetailCard>
+
+			<CnDetailCard :title="t('pipelinq', 'Line Items & Totals')">
+				<QuoteLineItems
+					:quote-id="quoteId"
+					:tax-rate="quoteData.taxRate || 21"
+					:editable="quoteData.status === 'concept'"
+					@totals-changed="onTotalsChanged" />
+			</CnDetailCard>
+		</template>
+	</CnDetailPage>
+</template>
+
+<script>
+import { NcButton, NcSelect, NcTextField } from '@nextcloud/vue'
+import { showError } from '@nextcloud/dialogs'
+import { CnDetailPage, CnDetailCard } from '@conduction/nextcloud-vue'
+import QuoteLineItems from '../../components/QuoteLineItems.vue'
+import { useObjectStore } from '../../store/modules/object.js'
+
+export default {
+	name: 'QuoteDetail',
+	components: {
+		NcButton,
+		NcSelect,
+		NcTextField,
+		CnDetailPage,
+		CnDetailCard,
+		QuoteLineItems,
+	},
+	props: {
+		quoteId: {
+			type: String,
+			default: null,
+		},
+	},
+	data() {
+		return {
+			editing: false,
+			formData: {},
+			statusOptions: [
+				{ id: 'concept', label: t('pipelinq', 'Concept') },
+				{ id: 'verzonden', label: t('pipelinq', 'Sent') },
+				{ id: 'geaccepteerd', label: t('pipelinq', 'Accepted') },
+				{ id: 'afgewezen', label: t('pipelinq', 'Declined') },
+				{ id: 'verlopen', label: t('pipelinq', 'Expired') },
+			],
+		}
+	},
+	computed: {
+		objectStore() {
+			return useObjectStore()
+		},
+		isNew() {
+			return !this.quoteId || this.quoteId === 'new'
+		},
+		loading() {
+			return this.objectStore.loading.quote || false
+		},
+		quoteData() {
+			if (this.isNew) return {}
+			return this.objectStore.getObject('quote', this.quoteId) || {}
+		},
+		sidebarProps() {
+			const config = this.objectStore.objectTypeRegistry.quote || {}
+			return {
+				register: config.register || '',
+				schema: config.schema || '',
+				hiddenTabs: ['tasks'],
+			}
+		},
+	},
+	async mounted() {
+		if (this.isNew) {
+			this.formData = {
+				title: '',
+				status: 'concept',
+				taxRate: 21,
+				version: 1,
+				paymentTerms: '',
+				notes: '',
+				expiryDate: '',
+			}
+			this.editing = true
+		} else {
+			await this.objectStore.fetchObject('quote', this.quoteId)
+			this.formData = { ...this.quoteData }
+		}
+	},
+	methods: {
+		async saveQuote() {
+			if (!this.formData.title) return
+
+			const result = await this.objectStore.saveObject('quote', this.formData)
+			if (result) {
+				if (this.isNew) {
+					this.$router.push({ name: 'QuoteDetail', params: { id: result.id } })
+				} else {
+					await this.objectStore.fetchObject('quote', this.quoteId)
+					this.editing = false
+				}
+			} else {
+				const error = this.objectStore.getError('quote')
+				showError(error?.message || t('pipelinq', 'Failed to save quote.'))
+			}
+		},
+		cancelEdit() {
+			if (this.isNew) {
+				this.$router.push({ name: 'Quotes' })
+			} else {
+				this.formData = { ...this.quoteData }
+				this.editing = false
+			}
+		},
+		async confirmDelete() {
+			if (!confirm(t('pipelinq', 'Are you sure you want to delete this quote?'))) return
+
+			const success = await this.objectStore.deleteObject('quote', this.quoteId)
+			if (success) {
+				this.$router.push({ name: 'Quotes' })
+			} else {
+				showError(t('pipelinq', 'Failed to delete quote.'))
+			}
+		},
+		async onTotalsChanged(totals) {
+			if (!this.isNew && totals) {
+				await this.objectStore.saveObject('quote', {
+					id: this.quoteId,
+					subtotal: totals.subtotal,
+					taxAmount: totals.taxAmount,
+					total: totals.total,
+				})
+			}
+		},
+	},
+}
+</script>
+
+<style scoped>
+.info-grid {
+	display: grid;
+	grid-template-columns: 1fr 1fr;
+	gap: 16px;
+}
+
+.info-field {
+	margin-bottom: 8px;
+}
+
+.info-field label {
+	display: block;
+	font-weight: bold;
+	margin-bottom: 2px;
+	color: var(--color-text-maxcontrast);
+	font-size: 13px;
+}
+
+.info-field span,
+.info-field p {
+	margin: 0;
+}
+
+.info-field--full {
+	margin-top: 16px;
+}
+
+.form-grid {
+	display: grid;
+	grid-template-columns: 1fr 1fr;
+	gap: 16px;
+	margin-bottom: 16px;
+}
+
+.form-group {
+	margin-bottom: 12px;
+}
+
+.form-group label {
+	display: block;
+	margin-bottom: 4px;
+	font-weight: bold;
+	font-size: 13px;
+}
+
+.form-textarea {
+	width: 100%;
+	padding: 8px;
+	border: 1px solid var(--color-border);
+	border-radius: var(--border-radius);
+	resize: vertical;
+	font-family: inherit;
+}
+
+.form-actions {
+	display: flex;
+	gap: 8px;
+	margin-top: 16px;
+}
+
+.status-badge {
+	display: inline-block;
+	padding: 2px 8px;
+	border-radius: 12px;
+	font-size: 12px;
+	font-weight: 600;
+}
+
+.status--concept {
+	background: #e0f2fe;
+	color: #0369a1;
+	border: 1px solid #7dd3fc;
+}
+
+.status--verzonden {
+	background: #fef3c7;
+	color: #92400e;
+	border: 1px solid #fbbf24;
+}
+
+.status--geaccepteerd {
+	background: #dcfce7;
+	color: #166534;
+	border: 1px solid #86efac;
+}
+
+.status--afgewezen {
+	background: #fecaca;
+	color: #991b1b;
+	border: 1px solid #fca5a5;
+}
+
+.status--verlopen {
+	background: #f3f4f6;
+	color: #6b7280;
+	border: 1px solid #d1d5db;
+}
+</style>

--- a/src/views/quotes/QuoteList.vue
+++ b/src/views/quotes/QuoteList.vue
@@ -1,0 +1,43 @@
+<template>
+	<CnIndexPage
+		:title="t('pipelinq', 'Quotes')"
+		object-type="quote"
+		:columns="columns"
+		:create-route="{ name: 'QuoteDetail', params: { id: 'new' } }"
+		:create-label="t('pipelinq', 'New Quote')"
+		:detail-route-name="'QuoteDetail'"
+		:formatters="formatters" />
+</template>
+
+<script>
+import { CnIndexPage } from '@conduction/nextcloud-vue'
+
+export default {
+	name: 'QuoteList',
+	components: {
+		CnIndexPage,
+	},
+	data() {
+		return {
+			columns: [
+				{ key: 'quoteNumber', label: t('pipelinq', 'Quote Number'), sortable: true },
+				{ key: 'title', label: t('pipelinq', 'Title'), sortable: true },
+				{ key: 'status', label: t('pipelinq', 'Status'), sortable: true },
+				{ key: 'subtotal', label: t('pipelinq', 'Subtotal'), sortable: true },
+				{ key: 'total', label: t('pipelinq', 'Total'), sortable: true },
+				{ key: 'expiryDate', label: t('pipelinq', 'Expiry Date'), sortable: true },
+			],
+			formatters: {
+				subtotal: (val) => this.formatCurrency(val),
+				total: (val) => this.formatCurrency(val),
+			},
+		}
+	},
+	methods: {
+		formatCurrency(value) {
+			if (!value && value !== 0) return '-'
+			return 'EUR ' + Number(value).toLocaleString('nl-NL', { minimumFractionDigits: 2 })
+		},
+	},
+}
+</script>


### PR DESCRIPTION
## Summary
- Add quote and quoteLineItem schemas to pipelinq register with full property definitions
- Create QuoteList.vue with CnIndexPage, status filtering, and search
- Create QuoteDetail.vue with status badges, financial summary (subtotal, BTW, total)
- Create QuoteLineItems.vue with product-based and custom line items, inline editing, discount calculation
- Add Quotes navigation entry and routes
- Register quote and quoteLineItem in store initialization

Closes #34

## Test plan
- [ ] Verify quote and quoteLineItem schemas are created on register import
- [ ] Create a new quote, verify form saves correctly
- [ ] Add product-based and custom line items to a quote
- [ ] Verify subtotal, BTW (21%), and total calculate correctly
- [ ] Verify status badges display correctly for all 5 statuses
- [ ] Verify Quotes navigation item appears in sidebar