### PR TITLE
feat: Implement prospect-discovery spec (scoring, exclusion, breakdown)

### DIFF
--- a/lib/Service/ProspectDiscoveryService.php
+++ b/lib/Service/ProspectDiscoveryService.php
@@ -260,9 +260,34 @@ class ProspectDiscoveryService
                 return [];
             }
 
-            // Use the OpenRegister API internally via curl to get clients.
-            // This is a simplification; in production, inject ObjectService.
-            return [];
+            $url = \OC::$server->getURLGenerator()->getAbsoluteURL(
+                "/apps/openregister/api/objects/{$register}/{$schema}?_limit=500"
+            );
+
+            $client   = \OC::$server->getHTTPClientService()->newClient();
+            $response = $client->get(
+                $url,
+                [
+                    'headers'   => [
+                        'OCS-APIREQUEST' => 'true',
+                        'requesttoken'   => \OC::$server->getCsrfTokenManager()->getToken()->getEncryptedValue(),
+                    ],
+                    'nextcloud' => ['allow_local_address' => true],
+                ]
+            );
+
+            $data    = json_decode($response->getBody(), true);
+            $results = $data['results'] ?? $data ?? [];
+            $names   = [];
+
+            foreach ($results as $item) {
+                $name = trim($item['name'] ?? '');
+                if ($name !== '') {
+                    $names[] = strtolower($name);
+                }
+            }
+
+            return $names;
         } catch (\Exception $e) {
             $this->logger->warning(
                 message: 'Failed to fetch existing clients for exclusion',

--- a/lib/Service/ProspectScoringService.php
+++ b/lib/Service/ProspectScoringService.php
@@ -25,11 +25,16 @@ namespace OCA\Pipelinq\Service;
  * Calculates fit scores based on ICP criteria.
  *
  * Score breakdown (max 100):
- * - SBI code match: 30 points
+ * - SBI code match: 30 points (exact) or 15 points (prefix)
  * - Employee count match: 25 points
- * - Location (province) match: 20 points
+ * - Location (province or city) match: 20 points
  * - Legal form match: 15 points
  * - Active registration: 10 points
+ * - Keyword match: +10 per keyword, max +20
+ *
+ * Total capped at 100.
+ *
+ * @SuppressWarnings(PHPMD.CyclomaticComplexity) — scoring method with multiple branches
  */
 class ProspectScoringService
 {
@@ -49,9 +54,10 @@ class ProspectScoringService
             'locationMatch'  => 0,
             'legalFormMatch' => 0,
             'activeMatch'    => 0,
+            'keywordMatch'   => 0,
         ];
 
-        // SBI code match (30 points).
+        // SBI code match (30 exact / 15 prefix).
         $breakdown['sbiMatch'] = $this->scoreSbi(
             sbiCode: $prospect['sbiCode'] ?? '',
             targetCodes: $criteria['sbiCodes'] ?? []
@@ -64,10 +70,12 @@ class ProspectScoringService
             max: $criteria['employeeCountMax'] ?? 0
         );
 
-        // Location match (20 points).
+        // Location match — province OR city (20 points).
         $breakdown['locationMatch'] = $this->scoreLocation(
             province: $prospect['address']['province'] ?? '',
-            targetProvinces: $criteria['provinces'] ?? []
+            targetProvinces: $criteria['provinces'] ?? [],
+            city: $prospect['address']['city'] ?? '',
+            targetCities: $criteria['cities'] ?? []
         );
 
         // Legal form match (15 points).
@@ -84,7 +92,14 @@ class ProspectScoringService
             $breakdown['activeMatch'] = 10;
         }
 
-        $prospect['fitScore']     = array_sum(array: $breakdown);
+        // Keyword match (+10 per keyword, max +20).
+        $breakdown['keywordMatch'] = $this->scoreKeywords(
+            tradeName: $prospect['tradeName'] ?? '',
+            sbiDescription: $prospect['sbiDescription'] ?? '',
+            keywords: $criteria['keywords'] ?? []
+        );
+
+        $prospect['fitScore']     = min(100, array_sum(array: $breakdown));
         $prospect['fitBreakdown'] = $breakdown;
 
         return $prospect;
@@ -117,12 +132,12 @@ class ProspectScoringService
     }//end scoreAll()
 
     /**
-     * Score SBI code match.
+     * Score SBI code match with exact vs prefix differentiation.
      *
      * @param string $sbiCode     The prospect's SBI code.
      * @param array  $targetCodes The target SBI codes.
      *
-     * @return int The SBI score (0 or 30).
+     * @return int The SBI score (0, 15, or 30).
      */
     private function scoreSbi(string $sbiCode, array $targetCodes): int
     {
@@ -130,13 +145,22 @@ class ProspectScoringService
             return 0;
         }
 
+        $bestScore = 0;
+
         foreach ($targetCodes as $target) {
-            if (str_starts_with(haystack: $sbiCode, needle: (string) $target) === true) {
+            $target = (string) $target;
+            if ($sbiCode === $target) {
+                // Exact match — 30 points (max possible).
                 return 30;
+            }
+
+            if (str_starts_with(haystack: $sbiCode, needle: $target) === true) {
+                // Prefix match — 15 points.
+                $bestScore = max($bestScore, 15);
             }
         }
 
-        return 0;
+        return $bestScore;
     }//end scoreSbi()
 
     /**
@@ -170,23 +194,38 @@ class ProspectScoringService
     }//end scoreEmployeeCount()
 
     /**
-     * Score location match.
+     * Score location match — province OR city (either triggers 20 points).
      *
      * @param string $province        The prospect's province.
      * @param array  $targetProvinces The target provinces.
+     * @param string $city            The prospect's city.
+     * @param array  $targetCities    The target cities.
      *
      * @return int The location score (0 or 20).
      */
-    private function scoreLocation(string $province, array $targetProvinces): int
-    {
-        if (count($targetProvinces) === 0 || $province === '') {
-            return 0;
+    private function scoreLocation(
+        string $province,
+        array $targetProvinces,
+        string $city='',
+        array $targetCities=[]
+    ): int {
+        // Check province match.
+        if (count($targetProvinces) > 0 && $province !== '') {
+            $normalised = strtolower(string: trim(string: $province));
+            foreach ($targetProvinces as $target) {
+                if (strtolower(string: trim(string: (string) $target)) === $normalised) {
+                    return 20;
+                }
+            }
         }
 
-        $normalised = strtolower(string: trim(string: $province));
-        foreach ($targetProvinces as $target) {
-            if (strtolower(string: trim(string: (string) $target)) === $normalised) {
-                return 20;
+        // Check city match (OR logic).
+        if (count($targetCities) > 0 && $city !== '') {
+            $normalisedCity = strtolower(string: trim(string: $city));
+            foreach ($targetCities as $targetCity) {
+                if (strtolower(string: trim(string: (string) $targetCity)) === $normalisedCity) {
+                    return 20;
+                }
             }
         }
 
@@ -216,4 +255,37 @@ class ProspectScoringService
 
         return 0;
     }//end scoreLegalForm()
+
+    /**
+     * Score keyword matches in trade name and SBI description.
+     *
+     * Awards +10 per keyword match, capped at +20.
+     *
+     * @param string $tradeName      The prospect's trade name.
+     * @param string $sbiDescription The prospect's SBI activity description.
+     * @param array  $keywords       The ICP keyword list.
+     *
+     * @return int The keyword score (0, 10, or 20).
+     */
+    private function scoreKeywords(string $tradeName, string $sbiDescription, array $keywords): int
+    {
+        if (count($keywords) === 0) {
+            return 0;
+        }
+
+        $searchText = strtolower(string: $tradeName.' '.$sbiDescription);
+        $score      = 0;
+
+        foreach ($keywords as $keyword) {
+            $keyword = strtolower(string: trim(string: (string) $keyword));
+            if ($keyword !== '' && str_contains(haystack: $searchText, needle: $keyword) === true) {
+                $score += 10;
+                if ($score >= 20) {
+                    return 20;
+                }
+            }
+        }
+
+        return $score;
+    }//end scoreKeywords()
 }//end class

--- a/openspec/changes/2026-03-20-prospect-discovery/design.md
+++ b/openspec/changes/2026-03-20-prospect-discovery/design.md
@@ -1,0 +1,36 @@
+# Design: prospect-discovery scoring improvements and client exclusion
+
+## SBI Exact vs Prefix Scoring
+
+In `scoreSbi()`:
+- First check for exact match (full code equals target): 30 points
+- Then check for prefix match (code starts with target but is not equal): 15 points
+- Return highest score found across all target codes
+
+## Keyword Scoring
+
+Add `scoreKeywords()` method:
+- Takes prospect's `tradeName` and `sbiDescription` as combined searchable text
+- Takes ICP `keywords` array
+- For each keyword, case-insensitive substring match awards +10
+- Maximum total: +20 (capped)
+- Score capped at 100 overall
+
+## City Matching
+
+Extend `scoreLocation()` to accept `$city` and `$targetCities` params:
+- Province match OR city match awards 20 points
+- City match takes precedence over province mismatch
+
+## Client Exclusion via HTTP API
+
+Replace empty stub in `getExistingClientNames()` with actual OpenRegister API call:
+- Use `OC::$server->getHTTPClientService()` to call `/apps/openregister/api/objects/{register}/{schema}?_limit=500`
+- Extract `name` field from each client object
+- Return lowercased names for fuzzy matching
+
+## Score Breakdown Tooltip
+
+In ProspectCard.vue:
+- Add hover tooltip on the fit score badge showing breakdown
+- Show each category with points awarded vs max possible

--- a/openspec/changes/2026-03-20-prospect-discovery/proposal.md
+++ b/openspec/changes/2026-03-20-prospect-discovery/proposal.md
@@ -1,0 +1,30 @@
+# Proposal: prospect-discovery scoring improvements and client exclusion
+
+## Problem
+
+The prospect-discovery spec identifies gaps in scoring and client exclusion:
+1. SBI scoring gives 30 points for prefix match but does not distinguish exact (30) vs prefix-only (15)
+2. Keyword scoring not implemented (+10 per keyword, max +20)
+3. City matching not implemented in scoring (only province)
+4. Client exclusion stub returns empty array -- never actually excludes existing clients
+5. Score breakdown not visible to users on prospect cards
+
+## Proposed Change
+
+1. Fix SBI scoring: exact match = 30, prefix-only = 15
+2. Add keyword scoring to ProspectScoringService
+3. Add city matching to location scoring (OR with province)
+4. Wire up client exclusion via OpenRegister HTTP API
+5. Add score breakdown tooltip to ProspectCard.vue
+
+### Out of Scope
+- Prospect enrichment (website, LinkedIn)
+- Prospect list management
+- Outreach tracking
+- Bulk import/export
+- Market segment analysis
+- GDPR retention policies
+
+## Impact
+- **Files modified**: 3 (ProspectScoringService.php, ProspectDiscoveryService.php, ProspectCard.vue)
+- **Risk**: Low — scoring improvements are isolated, client exclusion adds API call

--- a/openspec/changes/2026-03-20-prospect-discovery/specs/prospect-discovery/spec.md
+++ b/openspec/changes/2026-03-20-prospect-discovery/specs/prospect-discovery/spec.md
@@ -1,0 +1,9 @@
+# Delta Spec: prospect-discovery scoring improvements and client exclusion
+
+## Newly Implemented
+
+- **SBI exact vs prefix scoring**: `scoreSbi()` now distinguishes exact match (30 points) from prefix-only match (15 points). Iterates target codes, tracks highest score.
+- **Keyword scoring**: New `scoreKeywords()` method awards +10 per keyword match (case-insensitive substring in tradeName or sbiDescription), capped at +20. Added to breakdown as `keywordMatch`.
+- **City-level location scoring**: `scoreLocation()` accepts city and target cities. Province match OR city match awards 20 points.
+- **Existing client exclusion**: `getExistingClientNames()` now calls OpenRegister API to fetch all clients and returns lowercased names for exclusion matching.
+- **Score breakdown tooltip**: ProspectCard.vue shows hover tooltip on fit score badge with per-category score breakdown.

--- a/openspec/changes/2026-03-20-prospect-discovery/tasks.md
+++ b/openspec/changes/2026-03-20-prospect-discovery/tasks.md
@@ -1,0 +1,26 @@
+# Tasks: prospect-discovery scoring improvements and client exclusion
+
+## 1. SBI exact vs prefix scoring
+- [ ] 1.1 Differentiate exact match (30) from prefix-only match (15)
+  - **spec_ref**: `specs/prospect-discovery/spec.md#Exact vs prefix SBI scoring differentiation`
+  - **files**: `pipelinq/lib/Service/ProspectScoringService.php`
+
+## 2. Keyword scoring
+- [ ] 2.1 Add scoreKeywords() with +10 per keyword, max +20
+  - **spec_ref**: `specs/prospect-discovery/spec.md#Keyword scoring in trade name`
+  - **files**: `pipelinq/lib/Service/ProspectScoringService.php`
+
+## 3. City matching
+- [ ] 3.1 Add city matching to scoreLocation() (OR with province)
+  - **spec_ref**: `specs/prospect-discovery/spec.md#City-level location scoring`
+  - **files**: `pipelinq/lib/Service/ProspectScoringService.php`
+
+## 4. Client exclusion wiring
+- [ ] 4.1 Implement getExistingClientNames() via OpenRegister HTTP API
+  - **spec_ref**: `specs/prospect-discovery/spec.md#Exclude by company name`
+  - **files**: `pipelinq/lib/Service/ProspectDiscoveryService.php`
+
+## 5. Score breakdown tooltip
+- [ ] 5.1 Add hover tooltip showing score breakdown on ProspectCard
+  - **spec_ref**: `specs/prospect-discovery/spec.md#Score breakdown visibility`
+  - **files**: `pipelinq/src/components/ProspectCard.vue`

--- a/src/components/ProspectCard.vue
+++ b/src/components/ProspectCard.vue
@@ -2,7 +2,10 @@
 	<div class="prospect-card" tabindex="0" @keyup.enter="$emit('create-lead', prospect)">
 		<div class="prospect-card__header">
 			<span class="prospect-card__name">{{ prospect.tradeName }}</span>
-			<span class="prospect-card__score" :class="scoreClass">
+			<span
+				class="prospect-card__score"
+				:class="scoreClass"
+				:title="scoreTooltip">
 				{{ prospect.fitScore }}%
 			</span>
 		</div>
@@ -19,6 +22,10 @@
 			<div v-if="prospect.address && prospect.address.city" class="prospect-card__detail">
 				<span class="detail-label">{{ t('pipelinq', 'Location') }}</span>
 				<span>{{ prospect.address.city }}{{ prospect.address.province ? ', ' + prospect.address.province : '' }}</span>
+			</div>
+			<div v-if="prospect.legalForm" class="prospect-card__detail">
+				<span class="detail-label">{{ t('pipelinq', 'Legal form') }}</span>
+				<span>{{ prospect.legalForm }}</span>
 			</div>
 			<div class="prospect-card__detail">
 				<span class="detail-label">{{ t('pipelinq', 'KVK') }}</span>
@@ -57,6 +64,21 @@ export default {
 			if (score >= 40) return 'score--medium'
 			return 'score--low'
 		},
+		scoreTooltip() {
+			const b = this.prospect.fitBreakdown
+			if (!b) return ''
+
+			const lines = []
+			lines.push(t('pipelinq', 'SBI match: {pts}/{max}', { pts: b.sbiMatch || 0, max: 30 }))
+			lines.push(t('pipelinq', 'Employees: {pts}/{max}', { pts: b.employeeMatch || 0, max: 25 }))
+			lines.push(t('pipelinq', 'Location: {pts}/{max}', { pts: b.locationMatch || 0, max: 20 }))
+			lines.push(t('pipelinq', 'Legal form: {pts}/{max}', { pts: b.legalFormMatch || 0, max: 15 }))
+			lines.push(t('pipelinq', 'Active: {pts}/{max}', { pts: b.activeMatch || 0, max: 10 }))
+			if (b.keywordMatch !== undefined) {
+				lines.push(t('pipelinq', 'Keywords: {pts}/{max}', { pts: b.keywordMatch || 0, max: 20 }))
+			}
+			return lines.join('\n')
+		},
 	},
 }
 </script>
@@ -93,6 +115,7 @@ export default {
 	border-radius: 12px;
 	font-size: 12px;
 	font-weight: 700;
+	cursor: help;
 }
 
 .score--high {


### PR DESCRIPTION
## Summary
- Fix SBI scoring to differentiate exact match (30pts) from prefix-only (15pts)
- Add keyword scoring (+10 per keyword in trade name / SBI description, max +20)
- Add city-level matching in location scoring (OR logic with province)
- Wire up existing client exclusion via OpenRegister HTTP API (was a stub returning empty array)
- Add score breakdown tooltip on ProspectCard fit score badge
- Add legal form display to prospect cards

Closes #37

## Test plan
- [ ] Verify SBI exact match scores 30, prefix-only scores 15
- [ ] Verify keyword matching awards points correctly
- [ ] Verify city match works even when province doesn't match
- [ ] Verify existing clients are excluded from prospect results
- [ ] Hover over fit score badge to see breakdown tooltip