### PR TITLE
test: fix pre-existing broken unit tests blocking Hydra pipeline

### DIFF
--- a/tests/Unit/Service/NoteEventServiceTest.php
+++ b/tests/Unit/Service/NoteEventServiceTest.php
@@ -84,15 +84,20 @@ class NoteEventServiceTest extends TestCase
     /**
      * Test type map contains expected types.
      *
+     * Each known pipelinq_* objectType should be handled without throwing
+     * and without logging a warning — fetchEntityData returns null when
+     * register/schema settings are empty (the default in this test), and
+     * triggerNoteEvents returns early on null entity data.
+     *
      * @return void
      */
     public function testTypeMapContainsExpectedTypes(): void
     {
-        // Trigger with known type but let it fail gracefully.
-        // The method will try to fetchEntityData which calls OC server,
-        // but it should catch the exception and log a warning.
-        $this->logger->expects($this->once())->method('warning');
+        $this->logger->expects($this->never())->method('warning');
 
-        $this->service->triggerNoteEvents('pipelinq_client', '123');
+        $this->service->triggerNoteEvents(objectType: 'pipelinq_client', objectId: '123');
+        $this->service->triggerNoteEvents(objectType: 'pipelinq_contact', objectId: '123');
+        $this->service->triggerNoteEvents(objectType: 'pipelinq_lead', objectId: '123');
+        $this->service->triggerNoteEvents(objectType: 'pipelinq_request', objectId: '123');
     }//end testTypeMapContainsExpectedTypes()
 }//end class

--- a/tests/Unit/Service/ProspectDiscoveryServiceTest.php
+++ b/tests/Unit/Service/ProspectDiscoveryServiceTest.php
@@ -62,6 +62,16 @@ class ProspectDiscoveryServiceTest extends TestCase
         $logger          = $this->createMock(LoggerInterface::class);
 
         $settings->method('getConfigValue')->willReturn('');
+        // createLeadFromProspect calls getObjectStoreConfig() which needs
+        // register + client_schema + lead_schema set, otherwise the method
+        // returns early with ['error' => ...]. Stub a minimal valid config
+        // so the happy-path tests can exercise the leadData/clientData
+        // construction.
+        $settings->method('getSettings')->willReturn([
+            'register'      => 'pipelinq',
+            'client_schema' => 'client',
+            'lead_schema'   => 'lead',
+        ]);
 
         $this->service = new ProspectDiscoveryService(
             $this->icpConfig,


### PR DESCRIPTION
Two unit tests on development have standing failures that propagate into every fresh build. Today's Hydra convergence attempt had 5 PRs escalated at the applier gate with identical 3 failures. Fixing the tests unblocks convergence. See commit message.