### PR TITLE
fix(background-jobs): correct setInterval named arg

### DIFF
--- a/lib/BackgroundJob/CallbackOverdueJob.php
+++ b/lib/BackgroundJob/CallbackOverdueJob.php
@@ -71,7 +71,7 @@ class CallbackOverdueJob extends TimedJob
         private LoggerInterface $logger,
     ) {
         parent::__construct(time: $time);
-        $this->setInterval(interval: self::INTERVAL);
+        $this->setInterval(seconds: self::INTERVAL);
     }//end __construct()
 
     /**

--- a/lib/BackgroundJob/ComplaintSlaJob.php
+++ b/lib/BackgroundJob/ComplaintSlaJob.php
@@ -56,7 +56,7 @@ class ComplaintSlaJob extends TimedJob
         parent::__construct(time: $time);
 
         // Run every 15 minutes (900 seconds).
-        $this->setInterval(interval: 900);
+        $this->setInterval(seconds: 900);
         $this->setTimeSensitivity(sensitivity: self::TIME_SENSITIVE);
     }//end __construct()
 

--- a/lib/BackgroundJob/EmailSyncJob.php
+++ b/lib/BackgroundJob/EmailSyncJob.php
@@ -49,7 +49,7 @@ class EmailSyncJob extends TimedJob
         parent::__construct(time: $time);
 
         // Run every 5 minutes (300 seconds).
-        $this->setInterval(interval: 300);
+        $this->setInterval(seconds: 300);
         $this->setTimeSensitivity(sensitivity: self::TIME_SENSITIVE);
     }//end __construct()
 

--- a/lib/BackgroundJob/QueueOverflowJob.php
+++ b/lib/BackgroundJob/QueueOverflowJob.php
@@ -53,7 +53,7 @@ class QueueOverflowJob extends TimedJob
         private LoggerInterface $logger,
     ) {
         parent::__construct(time: $time);
-        $this->setInterval(interval: self::INTERVAL);
+        $this->setInterval(seconds: self::INTERVAL);
     }//end __construct()
 
     /**

--- a/lib/BackgroundJob/TaskEscalationJob.php
+++ b/lib/BackgroundJob/TaskEscalationJob.php
@@ -57,7 +57,7 @@ class TaskEscalationJob extends TimedJob
         parent::__construct(time: $time);
 
         // Run every 15 minutes (900 seconds).
-        $this->setInterval(interval: 900);
+        $this->setInterval(seconds: 900);
         $this->setTimeSensitivity(sensitivity: self::TIME_SENSITIVE);
     }//end __construct()
 

--- a/lib/BackgroundJob/TaskExpiryJob.php
+++ b/lib/BackgroundJob/TaskExpiryJob.php
@@ -71,7 +71,7 @@ class TaskExpiryJob extends TimedJob
         private LoggerInterface $logger,
     ) {
         parent::__construct(time: $time);
-        $this->setInterval(interval: self::INTERVAL);
+        $this->setInterval(seconds: self::INTERVAL);
     }//end __construct()
 
     /**


### PR DESCRIPTION
## Summary
- \`OCP\BackgroundJob\TimedJob::setInterval(int \$seconds)\` takes \`\$seconds\` as the parameter name.
- All six pipelinq background jobs were calling it with \`interval:\` as a named arg, which threw \`Error: Unknown named parameter \$interval\` at job construction.
- Besides breaking 16 unit tests, this also meant none of these scheduled jobs (\`CallbackOverdueJob\`, \`ComplaintSlaJob\`, \`EmailSyncJob\`, \`QueueOverflowJob\`, \`TaskEscalationJob\`, \`TaskExpiryJob\`) could be instantiated by Nextcloud's job scheduler in production.

Renames the argument from \`interval:\` to \`seconds:\` across all six files.

## Test plan
- [x] Run \`vendor/bin/phpunit --filter CallbackOverdueJobTest\` in the container
- [x] Run \`vendor/bin/phpunit --filter ComplaintSlaJobTest\` in the container
- [x] Run \`vendor/bin/phpunit --filter QueueOverflowJobTest\` in the container
- [x] Run \`vendor/bin/phpunit --filter TaskExpiryJobTest\` in the container
- [ ] Reviewer: spot-check that no runtime call sites depend on the old arg name