### PR TITLE
chore(specs): replace gitleaks-flagged example values with placeholders

### DIFF
--- a/openspec/changes/archive/2026-03-15-add-product-and-prospect-widget/design.md
+++ b/openspec/changes/archive/2026-03-15-add-product-and-prospect-widget/design.md
@@ -183,7 +183,7 @@ Save ICP configuration (admin only).
   "legalForms": ["BV"],
   "excludeInactive": true,
   "keywords": ["software"],
-  "kvkApiKey": "abc123-my-api-key",
+  "kvkApiKey": "YOUR_KVK_API_KEY_HERE",
   "openCorporatesEnabled": false
 }
 ```

--- a/openspec/changes/archive/2026-03-21-openregister-integration/specs/openregister-integration/spec.md
+++ b/openspec/changes/archive/2026-03-21-openregister-integration/specs/openregister-integration/spec.md
@@ -459,24 +459,24 @@ The frontend MUST interact with OpenRegister's REST API directly for all CRUD op
 
 #### Scenario: Read a single object
 
-- GIVEN an existing client with UUID "f47ac10b-58cc-4372-a567-0e02b2c3d479"
+- GIVEN an existing client with UUID "00000000-0000-0000-0000-000000000000"
 - WHEN the frontend navigates to the client detail view
-- THEN it MUST call `GET /index.php/apps/openregister/api/objects/pipelinq/client/f47ac10b-58cc-4372-a567-0e02b2c3d479`
+- THEN it MUST call `GET /index.php/apps/openregister/api/objects/pipelinq/client/00000000-0000-0000-0000-000000000000`
 - AND the response MUST contain the full client object with all properties
 
 #### Scenario: Update an object
 
-- GIVEN an existing client with UUID "f47ac10b-58cc-4372-a567-0e02b2c3d479"
+- GIVEN an existing client with UUID "00000000-0000-0000-0000-000000000000"
 - WHEN the user updates the email to "info@rivierenland.nl"
-- THEN the frontend MUST call `PUT /index.php/apps/openregister/api/objects/pipelinq/client/f47ac10b-58cc-4372-a567-0e02b2c3d479`
+- THEN the frontend MUST call `PUT /index.php/apps/openregister/api/objects/pipelinq/client/00000000-0000-0000-0000-000000000000`
 - AND the request body MUST contain the updated client object
 - AND the response MUST return the updated object
 
 #### Scenario: Delete an object
 
-- GIVEN an existing client with UUID "f47ac10b-58cc-4372-a567-0e02b2c3d479"
+- GIVEN an existing client with UUID "00000000-0000-0000-0000-000000000000"
 - WHEN the user confirms deletion
-- THEN the frontend MUST call `DELETE /index.php/apps/openregister/api/objects/pipelinq/client/f47ac10b-58cc-4372-a567-0e02b2c3d479`
+- THEN the frontend MUST call `DELETE /index.php/apps/openregister/api/objects/pipelinq/client/00000000-0000-0000-0000-000000000000`
 - AND the response MUST indicate successful deletion
 - AND subsequent GET requests for this UUID MUST return 404
 
@@ -746,7 +746,7 @@ Entities in Pipelinq reference each other via UUID fields stored on the OpenRegi
 
 #### Scenario: Lead references a client
 
-- GIVEN a lead object with `client: "f47ac10b-58cc-4372-a567-0e02b2c3d479"`
+- GIVEN a lead object with `client: "00000000-0000-0000-0000-000000000000"`
 - WHEN the frontend displays the lead detail view
 - THEN it MUST resolve the client UUID to fetch and display the client name
 - AND clicking the client name MUST navigate to the client detail view

--- a/openspec/specs/openregister-integration/spec.md
+++ b/openspec/specs/openregister-integration/spec.md
@@ -459,24 +459,24 @@ The frontend MUST interact with OpenRegister's REST API directly for all CRUD op
 
 #### Scenario: Read a single object
 
-- GIVEN an existing client with UUID "f47ac10b-58cc-4372-a567-0e02b2c3d479"
+- GIVEN an existing client with UUID "00000000-0000-0000-0000-000000000000"
 - WHEN the frontend navigates to the client detail view
-- THEN it MUST call `GET /index.php/apps/openregister/api/objects/pipelinq/client/f47ac10b-58cc-4372-a567-0e02b2c3d479`
+- THEN it MUST call `GET /index.php/apps/openregister/api/objects/pipelinq/client/00000000-0000-0000-0000-000000000000`
 - AND the response MUST contain the full client object with all properties
 
 #### Scenario: Update an object
 
-- GIVEN an existing client with UUID "f47ac10b-58cc-4372-a567-0e02b2c3d479"
+- GIVEN an existing client with UUID "00000000-0000-0000-0000-000000000000"
 - WHEN the user updates the email to "info@rivierenland.nl"
-- THEN the frontend MUST call `PUT /index.php/apps/openregister/api/objects/pipelinq/client/f47ac10b-58cc-4372-a567-0e02b2c3d479`
+- THEN the frontend MUST call `PUT /index.php/apps/openregister/api/objects/pipelinq/client/00000000-0000-0000-0000-000000000000`
 - AND the request body MUST contain the updated client object
 - AND the response MUST return the updated object
 
 #### Scenario: Delete an object
 
-- GIVEN an existing client with UUID "f47ac10b-58cc-4372-a567-0e02b2c3d479"
+- GIVEN an existing client with UUID "00000000-0000-0000-0000-000000000000"
 - WHEN the user confirms deletion
-- THEN the frontend MUST call `DELETE /index.php/apps/openregister/api/objects/pipelinq/client/f47ac10b-58cc-4372-a567-0e02b2c3d479`
+- THEN the frontend MUST call `DELETE /index.php/apps/openregister/api/objects/pipelinq/client/00000000-0000-0000-0000-000000000000`
 - AND the response MUST indicate successful deletion
 - AND subsequent GET requests for this UUID MUST return 404
 
@@ -746,7 +746,7 @@ Entities in Pipelinq reference each other via UUID fields stored on the OpenRegi
 
 #### Scenario: Lead references a client
 
-- GIVEN a lead object with `client: "f47ac10b-58cc-4372-a567-0e02b2c3d479"`
+- GIVEN a lead object with `client: "00000000-0000-0000-0000-000000000000"`
 - WHEN the frontend displays the lead detail view
 - THEN it MUST resolve the client UUID to fetch and display the client name
 - AND clicking the client name MUST navigate to the client detail view


### PR DESCRIPTION
Security reviewer on pipelinq#187 surfaced 3 gitleaks 'generic-api-key' hits in spec docs. None are real credentials — they're illustrative placeholders in openspec documentation. Swapping them for obvious placeholder forms that gitleaks skips, so the signal noise stops obscuring real findings on future reviews.

- `abc123-my-api-key` → `YOUR_KVK_API_KEY_HERE` in widget design doc
- `f47ac10b-58cc-4372-a567-0e02b2c3d479` → `00000000-0000-0000-0000-000000000000` (nil UUID) across 7 occurrences in openregister-integration spec + archived copy