### PR TITLE
docs(adr): foundation cleanup — adr-000 reframe + adr-001 cross-ref fix

### DIFF
--- a/openspec/architecture/adr-000-data-model.md
+++ b/openspec/architecture/adr-000-data-model.md
@@ -1,5 +1,18 @@
 # Data Model — Pipelinq
 
+> **Note:** despite the `adr-000-` filename, this is **not** an ADR — it's
+> the per-app entity catalogue. The OR-contract paragraphs below are a
+> reminder of the platform's authoritative ADRs (hydra
+> [ADR-001 Data layer](../../../hydra/openspec/architecture/adr-001-data-layer.md)
+> and
+> [ADR-022 Apps consume OR abstractions](../../../hydra/openspec/architecture/adr-022-apps-consume-or-abstractions.md)),
+> not duplicates or override decisions. Any architecture decision
+> specific to pipelinq belongs in a properly-numbered file
+> (`adr-001-international-first-dutch-mapping.md` is a real example;
+> further per-app ADRs follow the same pattern). Filename rename to
+> `data-model.md` (no `adr-` prefix) is queued — see pipelinq's
+> adoption change.
+
 **App:** Pipelinq — CRM and customer interaction
 **Platform:** OpenRegister (register/schema/object pattern)
 **Entities:** 26

--- a/openspec/architecture/adr-001-international-first-dutch-mapping.md
+++ b/openspec/architecture/adr-001-international-first-dutch-mapping.md
@@ -23,7 +23,7 @@ Industry CRM standards (schema.org, vCard, iCalendar) are well-documented, widel
 
 - Spec authors MUST use schema.org/vCard property names in requirements (e.g., `fn` not `naam`, `email` not `emailadres`).
 - Design documents for Dutch API features MUST include a mapping table (schema.org property → Dutch API field).
-- This extends company-wide ADR-006 (Schema Standards) with Pipelinq-specific vocabulary choices.
+- This extends company-wide ADR-011 (Schema Standards) with Pipelinq-specific vocabulary choices.
 
 ## Exceptions
 


### PR DESCRIPTION
## Summary

Phase 1 of the OR-abstraction audit (2026-05-03). Two doc-only fixes:

- `adr-001-international-first-dutch-mapping.md` — cross-reference fix: hydra ADR-006 (now Metrics) → ADR-011 (Schema Standards). Reference rotted in the hydra ADR renumbering.
- `adr-000-data-model.md` — added a non-ADR header citing hydra ADR-001 + ADR-022 so the OR-contract reminder isn't mistaken for a duplicate ADR (the anti-pattern hydra ADR-022 was written to prevent). Filename rename to `data-model.md` is queued for the pipelinq adoption change.

## Test plan

- [x] No code changes
- [x] hydra ADR-011 (schema standards) verified to exist
- [x] hydra ADR-022 cross-link resolves