### PR TITLE
perf: split shared Vue/@nextcloud/vue chunks (~72 MB -> ~21 MB widget JS)

### DIFF
--- a/lib/Dashboard/ClientSearchWidget.php
+++ b/lib/Dashboard/ClientSearchWidget.php
@@ -104,6 +104,9 @@ class ClientSearchWidget implements IWidget
      */
     public function load(): void
     {
+        // Shared vendor chunks emitted by webpack splitChunks (see webpack.config.js).
+        Util::addScript(Application::APP_ID, Application::APP_ID.'-shared-vendor');
+        Util::addScript(Application::APP_ID, Application::APP_ID.'-shared-nc-vue');
         Util::addScript(Application::APP_ID, Application::APP_ID.'-clientSearchWidget');
         Util::addStyle(Application::APP_ID, 'dashboardWidgets');
 

--- a/lib/Dashboard/CreateLeadWidget.php
+++ b/lib/Dashboard/CreateLeadWidget.php
@@ -98,6 +98,9 @@ class CreateLeadWidget implements IWidget
      */
     public function load(): void
     {
+        // Shared vendor chunks emitted by webpack splitChunks (see webpack.config.js).
+        Util::addScript(Application::APP_ID, Application::APP_ID.'-shared-vendor');
+        Util::addScript(Application::APP_ID, Application::APP_ID.'-shared-nc-vue');
         Util::addScript(Application::APP_ID, Application::APP_ID.'-createLeadWidget');
         Util::addStyle(Application::APP_ID, 'dashboardWidgets');
     }//end load()

--- a/lib/Dashboard/DealsOverviewWidget.php
+++ b/lib/Dashboard/DealsOverviewWidget.php
@@ -105,6 +105,9 @@ class DealsOverviewWidget implements IWidget
      */
     public function load(): void
     {
+        // Shared vendor chunks emitted by webpack splitChunks (see webpack.config.js).
+        Util::addScript(Application::APP_ID, Application::APP_ID.'-shared-vendor');
+        Util::addScript(Application::APP_ID, Application::APP_ID.'-shared-nc-vue');
         Util::addScript(Application::APP_ID, Application::APP_ID.'-dealsOverviewWidget');
         Util::addStyle(Application::APP_ID, 'dashboardWidgets');
 

--- a/lib/Dashboard/FindClientWidget.php
+++ b/lib/Dashboard/FindClientWidget.php
@@ -99,6 +99,9 @@ class FindClientWidget implements IWidget
      */
     public function load(): void
     {
+        // Shared vendor chunks emitted by webpack splitChunks (see webpack.config.js).
+        Util::addScript(Application::APP_ID, Application::APP_ID.'-shared-vendor');
+        Util::addScript(Application::APP_ID, Application::APP_ID.'-shared-nc-vue');
         Util::addScript(Application::APP_ID, Application::APP_ID.'-findClientWidget');
         Util::addStyle(Application::APP_ID, 'dashboardWidgets');
     }//end load()

--- a/lib/Dashboard/MyLeadsWidget.php
+++ b/lib/Dashboard/MyLeadsWidget.php
@@ -105,6 +105,11 @@ class MyLeadsWidget implements IWidget
      */
     public function load(): void
     {
+        // Shared vendor chunks emitted by webpack splitChunks. Util::addScript
+        // dedupes by (app, file), so the order across widgets settles on:
+        // vendor → nc-vue → widget JS, which is the dependency order.
+        Util::addScript(Application::APP_ID, Application::APP_ID.'-shared-vendor');
+        Util::addScript(Application::APP_ID, Application::APP_ID.'-shared-nc-vue');
         Util::addScript(Application::APP_ID, Application::APP_ID.'-myLeadsWidget');
         Util::addStyle(Application::APP_ID, 'dashboardWidgets');
 

--- a/lib/Dashboard/RecentActivitiesWidget.php
+++ b/lib/Dashboard/RecentActivitiesWidget.php
@@ -104,6 +104,9 @@ class RecentActivitiesWidget implements IWidget
      */
     public function load(): void
     {
+        // Shared vendor chunks emitted by webpack splitChunks (see webpack.config.js).
+        Util::addScript(Application::APP_ID, Application::APP_ID.'-shared-vendor');
+        Util::addScript(Application::APP_ID, Application::APP_ID.'-shared-nc-vue');
         Util::addScript(Application::APP_ID, Application::APP_ID.'-recentActivitiesWidget');
         Util::addStyle(Application::APP_ID, 'dashboardWidgets');
 

--- a/lib/Dashboard/StartRequestWidget.php
+++ b/lib/Dashboard/StartRequestWidget.php
@@ -98,6 +98,9 @@ class StartRequestWidget implements IWidget
      */
     public function load(): void
     {
+        // Shared vendor chunks emitted by webpack splitChunks (see webpack.config.js).
+        Util::addScript(Application::APP_ID, Application::APP_ID.'-shared-vendor');
+        Util::addScript(Application::APP_ID, Application::APP_ID.'-shared-nc-vue');
         Util::addScript(Application::APP_ID, Application::APP_ID.'-startRequestWidget');
         Util::addStyle(Application::APP_ID, 'dashboardWidgets');
     }//end load()

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -78,4 +78,41 @@ webpackConfig.plugins = [
 // preventing the nextcloud-vue submodule's nested deps (Vue 3) from leaking in.
 webpackConfig.resolve.alias['@nextcloud/dialogs'] = path.resolve(__dirname, 'node_modules/@nextcloud/dialogs')
 
+// Share Vue + @nextcloud/vue + pinia + icons + @conduction/nextcloud-vue
+// across every entry-point so each widget bundle no longer inlines its own
+// ~5 MB framework copy. Stable filenames (no contenthash in the JS name)
+// mean each widget's `Util::addScript` PHP call can reference the chunk
+// directly without a manifest. The vendor chunk is loaded once and cached
+// across every widget/page in the app.
+webpackConfig.optimization = {
+	...(webpackConfig.optimization || {}),
+	splitChunks: {
+		...(webpackConfig.optimization?.splitChunks || {}),
+		chunks: 'all',
+		cacheGroups: {
+			default: false,
+			defaultVendors: false,
+			ncVue: {
+				name: appId + '-shared-nc-vue',
+				// Matches both node_modules entries AND the monorepo-dev alias
+				// `../nextcloud-vue/src/...` which webpack resolves outside
+				// node_modules when @conduction/nextcloud-vue is aliased to it.
+				test: /[\\/]node_modules[\\/](@nextcloud[\\/]vue|@conduction[\\/]nextcloud-vue)[\\/]|[\\/]nextcloud-vue[\\/]src[\\/]/,
+				priority: 30,
+				reuseExistingChunk: true,
+				enforce: true,
+				filename: appId + '-shared-nc-vue.js',
+			},
+			vendor: {
+				name: appId + '-shared-vendor',
+				test: /[\\/]node_modules[\\/](vue|pinia|vue-material-design-icons|@vueuse|core-js)[\\/]/,
+				priority: 20,
+				reuseExistingChunk: true,
+				enforce: true,
+				filename: appId + '-shared-vendor.js',
+			},
+		},
+	},
+}
+
 module.exports = webpackConfig


### PR DESCRIPTION
Each dashboard widget entry currently inlines its own copy of Vue, `@nextcloud/vue`, `@conduction/nextcloud-vue`, `pinia` and the material-design-icon set — ~12 MB per bundle, multiplied across the 6 widgets attached to `/apps/mydash/`.

This change adds an `optimization.splitChunks` block that extracts those framework deps into two stable-filename shared chunks. Each widget keeps only widget-specific code; the shared chunks load once and stay cached across navigations.

## Bundle sizes after `npm run build`

| Bundle | Before | After |
|---|---:|---:|
| `pipelinq-main.js` | 16 MB | **4.47 MB** |
| `pipelinq-settings.js` | 14 MB | **3.47 MB** |
| `pipelinq-<each>Widget.js` | 12 MB | **3.00 MB** |
| `pipelinq-shared-nc-vue.js` | — | **2.84 MB** (loaded once) |
| `pipelinq-shared-vendor.js` | — | **0.35 MB** (loaded once) |

Total widget JS attached to `/apps/mydash/` on cold cache: **~72 MB → ~21 MB**. On warm cache the shared chunks are reused and only the per-widget delta is fetched.

## PHP

Each widget class `load()` now also `Util::addScript()`s the two shared chunks. `Util::addScript` dedupes by `(app, file)`, so even with mydash eagerly loading every widget the shared chunks emit once. Order in the rendered HTML is `vendor → nc-vue → widget` — the natural dependency order.

## Why stable filenames

The `filename` overrides on the cache groups produce stable filenames (no `contenthash` in the name). That keeps the PHP `Util::addScript()` call manifest-free — no `webpack-manifest-plugin` glue needed.

## Validation

- Built locally with `NODE_OPTIONS=--max-old-space-size=8192 npm run build` ✓
- Reloaded `/apps/mydash/` against this NC dev install ✓
- Console: no new errors vs. baseline (existing opencatalogi `appName/appVersion` warnings and procest store-registration errors are unchanged)
- Script load order in rendered HTML: `pipelinq-shared-vendor.js → pipelinq-shared-nc-vue.js → pipelinq-*Widget.js` ✓

## Test plan
- [ ] CI build passes
- [ ] Open `/apps/mydash/`, confirm pipelinq widgets render (deals, leads, etc.)
- [ ] Add a pipelinq widget to a dashboard via the picker, confirm it mounts