### PR TITLE
test(docs-capture): instrument 3 components with stable data-testid

### DIFF
--- a/src/components/ProspectCard.vue
+++ b/src/components/ProspectCard.vue
@@ -1,5 +1,9 @@
 <template>
-	<div class="prospect-card" tabindex="0" @keyup.enter="$emit('create-lead', prospect)">
+	<div
+		class="prospect-card"
+		:data-testid="`prospect-card-${prospect.kvkNumber}`"
+		tabindex="0"
+		@keyup.enter="$emit('create-lead', prospect)">
 		<div class="prospect-card__header">
 			<span class="prospect-card__name">{{ prospect.tradeName }}</span>
 			<span class="prospect-card__score" :class="scoreClass">
@@ -28,7 +32,7 @@
 
 		<div class="prospect-card__footer">
 			<span class="prospect-card__source">{{ prospect.source }}</span>
-			<NcButton type="primary" @click="$emit('create-lead', prospect)">
+			<NcButton type="primary" data-testid="prospect-create-lead" @click="$emit('create-lead', prospect)">
 				{{ t('pipelinq', 'Create Lead') }}
 			</NcButton>
 		</div>

--- a/src/views/clients/ClientCreateDialog.vue
+++ b/src/views/clients/ClientCreateDialog.vue
@@ -1,9 +1,9 @@
 <template>
-	<div class="create-overlay" @click.self="$emit('close')">
+	<div class="create-overlay" data-testid="client-create-dialog" @click.self="$emit('close')">
 		<div class="create-dialog">
 			<div class="create-dialog__header">
 				<h3>{{ t('pipelinq', 'New Client') }}</h3>
-				<NcButton type="tertiary" @click="$emit('close')">
+				<NcButton type="tertiary" data-testid="client-create-close" @click="$emit('close')">
 					✕
 				</NcButton>
 			</div>

--- a/src/views/clients/ClientForm.vue
+++ b/src/views/clients/ClientForm.vue
@@ -1,5 +1,5 @@
 <template>
-	<div class="client-form">
+	<div class="client-form" data-testid="client-form">
 		<div class="form-group">
 			<label for="client-name">{{ t('pipelinq', 'Name') }} *</label>
 			<NcTextField
@@ -8,6 +8,7 @@
 				:error="!!errors.name"
 				:helper-text="errors.name"
 				:maxlength="255"
+				data-testid="client-name-input"
 				@update:value="v => { form.name = v; validateField('name') }" />
 		</div>
 
@@ -19,6 +20,7 @@
 					input-id="client-type"
 					:options="typeOptions"
 					:placeholder="t('pipelinq', 'Select type')"
+					data-testid="client-type-select"
 					@input="validateField('type')" />
 				<p v-if="errors.type" class="field-error">
 					{{ errors.type }}
@@ -32,6 +34,7 @@
 					:error="!!errors.email"
 					:helper-text="errors.email"
 					type="email"
+					data-testid="client-email-input"
 					@update:value="v => { form.email = v; validateField('email') }" />
 			</div>
 		</div>
@@ -44,6 +47,7 @@
 					:value="form.phone"
 					:error="!!errors.phone"
 					:helper-text="errors.phone"
+					data-testid="client-phone-input"
 					@update:value="v => { form.phone = v; validateField('phone') }" />
 			</div>
 			<div class="form-group">
@@ -53,6 +57,7 @@
 					:value="form.website"
 					:error="!!errors.website"
 					:helper-text="errors.website"
+					data-testid="client-website-input"
 					@update:value="v => { form.website = v; validateField('website') }" />
 			</div>
 		</div>
@@ -62,19 +67,20 @@
 			<NcTextField
 				id="client-address"
 				:value="form.address"
+				data-testid="client-address-input"
 				@update:value="v => form.address = v" />
 		</div>
 
 		<div class="form-group">
 			<label for="client-notes">{{ t('pipelinq', 'Notes') }}</label>
-			<textarea id="client-notes" v-model="form.notes" rows="3" />
+			<textarea id="client-notes" v-model="form.notes" rows="3" data-testid="client-notes-input" />
 		</div>
 
 		<div class="client-form__actions">
-			<NcButton type="primary" :disabled="!isValid" @click="onSave">
+			<NcButton type="primary" :disabled="!isValid" data-testid="client-form-save" @click="onSave">
 				{{ t('pipelinq', 'Save') }}
 			</NcButton>
-			<NcButton @click="$emit('cancel')">
+			<NcButton data-testid="client-form-cancel" @click="$emit('cancel')">
 				{{ t('pipelinq', 'Cancel') }}
 			</NcButton>
 		</div>


### PR DESCRIPTION
## Summary

Smoke test of `/journeydoc-instrument` from [hydra PR #228](https://github.com/ConductionNL/hydra/pull/228). Adds 13 purely-additive `data-testid` attributes across the three components the pipelinq capture spec hits hardest.

## What changed

| File | testids |
|---|---|
| `src/views/clients/ClientCreateDialog.vue` | `client-create-dialog`, `client-create-close` |
| `src/views/clients/ClientForm.vue` | `client-form`, `client-{name,type,email,phone,website,address,notes}-{input,select}`, `client-form-save`, `client-form-cancel` |
| `src/components/ProspectCard.vue` | `prospect-card-${kvkNumber}` (unique per card), `prospect-create-lead` |

Pure attribute additions — no styling, no behaviour change, no existing test broken.

## Wiring

These hook the **U2 add-client** flow, **U3 link contact-person** flow, and **U4 move-lead-through-pipeline** flow in `tests/e2e/docs-screenshots.spec.ts`. The capture spec can now drive the full create-client form end-to-end and target a specific kanban card by KvK number.

## Follow-up instrumentation

Remaining capture stories need their own component-instrument pass. Suggested next files for `/journeydoc-instrument`:

- `src/views/contactmomenten/ContactmomentForm.vue` (U5 log contact moment)
- `src/views/widgets/MyLeadsWidget.vue` (U6 capture request)
- `src/views/settings/PipelineManager.vue` (A1 configure pipeline stages)
- `src/components/admin/QueueSettings.vue` (A2 / A3 admin sections)

## Note on inherited dev-branch CI red

Pipelinq's `development` branch is currently red on PHPCS / ESLint / Stylelint / npm-audit / npm-license — pre-existing, unrelated to this PR (see PR #324 conversation). This PR will inherit those failures. Recommend admin merge through them, with a separate fix-CI-quality-gates ticket on the team's docket.