### PR TITLE
feat(docs): adopt @conduction/docusaurus-preset + move to pipelinq.conduction.nl

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -1,27 +1,40 @@
 // @ts-check
 
-/** @type {import('@docusaurus/types').Config} */
-const config = {
+/**
+ * Pipelinq documentation site.
+ *
+ * Built on @conduction/docusaurus-preset for brand defaults (tokens,
+ * theme swizzles for Navbar / Footer, four-locale i18n scaffolding,
+ * KvK / BTW copyright). Site-specific overrides — locale (en only),
+ * sidebar path, mermaid theme, custom prism themes, pipelinq-only
+ * navbar items — are passed through createConfig() opts.
+ */
+
+const { createConfig, baseFooterLinks } = require('@conduction/docusaurus-preset');
+
+/* createConfig replaces themes wholesale when `themes:` is passed, so
+   we re-include the brand theme plugin alongside @docusaurus/theme-mermaid.
+   Without the brand theme entry the Navbar/Footer swizzles and
+   brand.css auto-load would silently drop. */
+const BRAND_THEME = require.resolve('@conduction/docusaurus-preset/theme');
+
+const config = createConfig({
   title: 'Pipelinq',
   tagline: 'CRM and pipeline management for Nextcloud',
   url: 'https://pipelinq.conduction.nl',
   baseUrl: '/',
 
-  // GitHub pages deployment config
   organizationName: 'ConductionNL',
   projectName: 'pipelinq',
-  trailingSlash: false,
 
-  onBrokenLinks: 'warn',
-  onBrokenMarkdownLinks: 'warn',
-  onBrokenAnchors: 'warn',
-
+  /* English-only for now. Dutch was dropped on the previous config
+     because i18n/nl/ carries stale translation strings without
+     translated markdown and broke Dutch SSR (see ADR-030). Re-enable
+     by adding 'nl' back once the Dutch translation pass has been
+     completed or the metadata audited for stale references. The
+     brand preset's default i18n block (nl/en/de/fr) is replaced
+     wholesale here. */
   i18n: {
-    // Dutch locale dropped — `i18n/nl/` carries only stale translation
-    // strings (no actual translated markdown), and stale doc IDs trigger
-    // SSR `Cannot read properties of undefined (reading 'id')` errors
-    // (see ADR-030). Re-add `'nl'` to `locales` once the Dutch
-    // translation pass has been completed or the metadata audited.
     defaultLocale: 'en',
     locales: ['en'],
     localeConfigs: {
@@ -29,97 +42,107 @@ const config = {
     },
   },
 
-  markdown: {
-    mermaid: true,
-    // Tutorial pages reference screenshots populated by
-    // `tests/e2e/docs-screenshots.spec.ts`. The Playwright capture run
-    // is separate from the docs build, so the build must succeed even
-    // when a fresh checkout doesn't have every PNG yet (ADR-030).
-    hooks: {
-      onBrokenMarkdownImages: 'warn',
-    },
-  },
-
+  /* The pipelinq docs source lives at the repo root of `docs/` rather
+     than under a `docs/` subfolder, so we override the preset's default
+     `presets:` block to point `docs.path` at './' and disable the blog
+     plugin. customCss carries pipelinq-specific CSS only — brand tokens
+     and the theme swizzles are auto-loaded by the brand theme entry in
+     `themes:` below. */
   presets: [
     [
       'classic',
-      /** @type {import('@docusaurus/preset-classic').Options} */
-      ({
+      {
         docs: {
           path: './',
-          exclude: ['**/node_modules/**'],
+          /* docs.path: './' makes plugin-content-docs scan every file
+             in docs/, which collides with plugin-content-pages's own
+             scan of docs/src/pages/. The same index.mdx then gets
+             processed by both plugins; the docs side runs MDX-ESM
+             over the JSX expression body and trips on it as a
+             "FunctionDeclaration" because that parser only allows
+             top-level import/export. Exclude src/ (pages live there)
+             plus the standard node_modules bucket. */
+          exclude: ['**/node_modules/**', 'src/**'],
           sidebarPath: require.resolve('./sidebars.js'),
-          editUrl:
-            'https://github.com/ConductionNL/pipelinq/tree/main/docs/',
+          editUrl: 'https://github.com/ConductionNL/pipelinq/tree/main/docs/',
         },
         blog: false,
         theme: {
           customCss: require.resolve('./src/css/custom.css'),
         },
-      }),
+      },
     ],
   ],
 
-  themeConfig:
-    /** @type {import('@docusaurus/preset-classic').ThemeConfig} */
-    ({
-      navbar: {
-        title: 'Pipelinq',
-        logo: {
-          alt: 'Pipelinq Logo',
-          src: 'img/logo.svg',
-        },
-        items: [
-          {
-            type: 'docSidebar',
-            sidebarId: 'tutorialSidebar',
-            position: 'left',
-            label: 'Documentation',
-          },
-          {
-            href: 'https://github.com/ConductionNL/pipelinq',
-            label: 'GitHub',
-            position: 'right',
-          },
-          {
-            type: 'localeDropdown',
-            position: 'right',
-          },
-        ],
+  themes: [BRAND_THEME, '@docusaurus/theme-mermaid'],
+
+  /* Brand navbar provides locale dropdown + GitHub by default; we
+     replace items[] with pipelinq's own (Documentation sidebar link,
+     pipelinq GitHub link). Object.assign in createConfig is shallow,
+     so items: replaces wholesale — re-include the locale dropdown
+     and add the pipelinq GitHub repo link explicitly. */
+  navbar: {
+    items: [
+      {
+        type: 'docSidebar',
+        sidebarId: 'tutorialSidebar',
+        position: 'left',
+        label: 'Documentation',
       },
-      footer: {
-        style: 'dark',
-        links: [
-          {
-            title: 'Docs',
-            items: [
-              {
-                label: 'Documentation',
-                to: '/docs/FEATURES',
-              },
-            ],
-          },
-          {
-            title: 'Community',
-            items: [
-              {
-                label: 'GitHub',
-                href: 'https://github.com/ConductionNL/pipelinq',
-              },
-            ],
-          },
-        ],
-        copyright: `Copyright © ${new Date().getFullYear()} for <a href="https://openwebconcept.nl">Open Webconcept</a> by <a href="https://conduction.nl">Conduction B.V.</a>`,
+      {
+        href: 'https://github.com/ConductionNL/pipelinq',
+        label: 'GitHub',
+        position: 'right',
       },
-      prism: {
-        theme: require('prism-react-renderer/themes/github'),
-        darkTheme: require('prism-react-renderer/themes/dracula'),
-      },
-      mermaid: {
-        theme: { light: 'default', dark: 'dark' },
-      },
-    }),
-  themes: ['@docusaurus/theme-mermaid'],
+      { type: 'localeDropdown', position: 'right' },
+    ],
+  },
+
+  /* Per-property footer override (preset 1.2.0+): we pass `links` only,
+     so the brand `style: 'dark'` and the brand KvK/BTW/IBAN/address
+     copyright string both inherit unchanged. Conduction-only column
+     here; site-specific Product / Support columns may be added later. */
+  footer: {
+    links: [
+      ...baseFooterLinks().filter((column) => column.title === 'Conduction'),
+    ],
+  },
+
+  /* Drop the canal-footer's boat-sinking + kade-cyclist mini-games
+     on this product-page footer (preset 1.3.0+). The static skyline +
+     canal decoration are kept; the interactive layer goes away. */
+  minigames: false,
+
+  /* themeConfig is shallow-merged into the preset's defaults
+     (colorMode + navbar + footer). prism + mermaid land alongside. */
+  themeConfig: {
+    prism: {
+      theme: require('prism-react-renderer/themes/github'),
+      darkTheme: require('prism-react-renderer/themes/dracula'),
+    },
+    mermaid: {
+      theme: { light: 'default', dark: 'dark' },
+    },
+  },
+});
+
+/* createConfig doesn't pass-through arbitrary top-level fields; assign
+   markdown + onBrokenAnchors directly so they make it into the final
+   Docusaurus config. trailingSlash is left at the preset's default
+   (true) so /docs/intro/ resolves cleanly under GH Pages — the prior
+   `false` override 404'd /-suffix URLs that visitors typed by hand. */
+config.onBrokenAnchors = 'warn';
+config.markdown = {
+  mermaid: true,
+  /* Tutorial pages reference screenshots populated by
+     `tests/e2e/docs-screenshots.spec.ts`. The Playwright capture run
+     is separate from the docs build, so the build needs to succeed
+     even when a fresh checkout doesn't have every PNG yet. Warn
+     instead of failing — the absence is visible at preview time and
+     the capture spec brings everything back on demand. */
+  hooks: {
+    onBrokenMarkdownImages: 'warn',
+  },
 };
 
 module.exports = config;

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -1,0 +1,28 @@
+---
+sidebar_position: 1
+---
+
+# Pipelinq
+
+CRM and pipeline management for Nextcloud. Customers, prospects, deals, and
+quotes as typed registers. No separate sales database, no second login.
+
+## What you get
+
+- Kanban deal-flow with configurable stages, per-team filters via Nextcloud
+  groups, KPI cards on top.
+- Customers and contacts as a typed OpenRegister schema with citation-stable
+  IDs and an audit trail per record.
+- Quote generation through DocuDesk templates, signed with your instance
+  certificate.
+- Connector to your accounting system (Exact, Twinfield, AFAS) via
+  OpenConnector.
+
+## Getting started
+
+Install Pipelinq from the [Nextcloud app store](https://apps.nextcloud.com/apps/pipelinq)
+or enable it in your Nextcloud admin settings, then point it at an
+OpenRegister register on the settings page.
+
+For features, architecture, and government-specific capabilities, see the
+sidebar.

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -8,6 +8,7 @@
       "name": "pipelinq-docs",
       "version": "0.0.0",
       "dependencies": {
+        "@conduction/docusaurus-preset": "^1.4.3",
         "@docusaurus/core": "^3.7.0",
         "@docusaurus/preset-classic": "^3.7.0",
         "@docusaurus/theme-mermaid": "^3.7.0",
@@ -2036,6 +2037,18 @@
       "optional": true,
       "engines": {
         "node": ">=0.1.90"
+      }
+    },
+    "node_modules/@conduction/docusaurus-preset": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/@conduction/docusaurus-preset/-/docusaurus-preset-1.4.3.tgz",
+      "integrity": "sha512-64F8A0qal/EfNYJKqsXMGjsOV2X0WYi72plO6MTC/9h60Fz85cMwzEiRpi58e9lloHAc3UBVMuffrzmDimsfwA==",
+      "license": "EUPL-1.2",
+      "peerDependencies": {
+        "@docusaurus/core": "^3.0.0",
+        "@docusaurus/preset-classic": "^3.0.0",
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
       }
     },
     "node_modules/@csstools/cascade-layer-name-parser": {

--- a/docs/package.json
+++ b/docs/package.json
@@ -15,6 +15,7 @@
     "ci": "npm ci --legacy-peer-deps && npm run build"
   },
   "dependencies": {
+    "@conduction/docusaurus-preset": "^1.4.3",
     "@docusaurus/core": "^3.7.0",
     "@docusaurus/preset-classic": "^3.7.0",
     "@docusaurus/theme-mermaid": "^3.7.0",

--- a/docs/src/pages/index.js
+++ b/docs/src/pages/index.js
@@ -1,40 +1,311 @@
+/**
+ * Pipelinq landing page.
+ *
+ * Composes the brand <DetailHero> + <WidgetShelf> from
+ * @conduction/docusaurus-preset/components, mirroring the connext page
+ * at sites/www/src/pages/apps/pipelinq.mdx.
+ *
+ * Written as .js (not .mdx) because the docs site has the docs plugin
+ * pointed at `path: './'`, and an MDX file in src/pages/ trips the
+ * MDX-ESM parser even with the docs plugin's `src/**` exclude — likely
+ * a quirk of how mdx-loader's micromark stack reuses parser state
+ * across files in this Docusaurus 3.10 + this preset combination.
+ * Authoring the page in JSX keeps the same component composition.
+ */
+
 import React from 'react';
-import clsx from 'clsx';
-import Link from '@docusaurus/Link';
-import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 import Layout from '@theme/Layout';
-import HomepageFeatures from '@site/src/components/HomepageFeatures';
+import {
+  DetailHero,
+  WidgetShelf,
+  AppMock,
+} from '@conduction/docusaurus-preset/components';
 
-import styles from './index.module.css';
+/* Pipeline-spike glyph: same SVG as the connext detail page at
+   sites/www/src/pages/apps/pipelinq.mdx. Read as a stylised pipeline
+   trace running through a sales funnel — the spike is the won deal. */
+const PIPELINQ_ICON = (
+  <svg viewBox="0 0 24 24">
+    <path d="M3 12h4l3-9 4 18 3-9h4" />
+  </svg>
+);
 
-function HomepageHeader() {
-  const {siteConfig} = useDocusaurusContext();
+const TAGLINE = (
+  <>
+    CRM on your <span className="next-blue">Nextcloud</span>. Customers,
+    prospects, deals, quotes. Everything as a typed register, no separate
+    sales database, no second login. Your sales team works where your
+    delivery team already is.
+  </>
+);
+
+function PipelineValuePanel() {
+  const rows = [
+    { label: 'lead', val: '40%', tone: 'var(--c-cobalt-300)' },
+    { label: 'qualified', val: '60%', tone: 'var(--c-lavender-300)' },
+    { label: 'proposal', val: '75%', tone: 'var(--c-mint-500)' },
+    { label: 'won', val: '50%', tone: 'var(--c-forest-300)' },
+  ];
   return (
-    <header className={clsx('hero hero--primary', styles.heroBanner)}>
-      <div className="container">
-        <h1 className="hero__title">{siteConfig.title}</h1>
-        <p className="hero__subtitle">{siteConfig.tagline}</p>
-        <div className={styles.buttons}>
-          <Link
-            className="button button--secondary button--lg"
-            to="/docs/FEATURES">
-            Documentation
-          </Link>
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'baseline',
+          gap: 6,
+          marginBottom: 4,
+        }}
+      >
+        <div
+          style={{
+            fontFamily: 'var(--conduction-typography-font-family-code)',
+            fontSize: 24,
+            fontWeight: 700,
+            color: 'var(--c-cobalt-700)',
+          }}
+        >
+          € 487k
+        </div>
+        <div
+          style={{
+            fontFamily: 'var(--conduction-typography-font-family-code)',
+            fontSize: 10,
+            letterSpacing: '0.05em',
+            color: 'var(--c-mint-500)',
+          }}
+        >
+          +12%
         </div>
       </div>
-    </header>
+      {rows.map((row, i) => (
+        <div
+          key={i}
+          style={{ display: 'flex', alignItems: 'center', gap: 6 }}
+        >
+          <div
+            style={{
+              fontFamily: 'var(--conduction-typography-font-family-code)',
+              fontSize: 8,
+              letterSpacing: '0.05em',
+              textTransform: 'uppercase',
+              color: 'var(--c-cobalt-500)',
+              width: 50,
+            }}
+          >
+            {row.label}
+          </div>
+          <div
+            style={{
+              flex: 1,
+              height: 6,
+              background: 'var(--c-cobalt-100)',
+              borderRadius: 1,
+            }}
+          >
+            <div
+              style={{
+                height: '100%',
+                width: row.val,
+                background: row.tone,
+                borderRadius: 1,
+              }}
+            />
+          </div>
+        </div>
+      ))}
+    </div>
   );
 }
 
+function QuotesPanel() {
+  const rows = [
+    { tone: 'var(--c-mint-500)', stage: 'signed' },
+    { tone: 'var(--c-lavender-300)', stage: 'sent' },
+    { tone: 'var(--c-mint-500)', stage: 'signed' },
+    { tone: 'var(--c-orange-knvb)', stage: 'draft' },
+  ];
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+      {rows.map((row, i) => (
+        <div
+          key={i}
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: 8,
+            padding: '4px 0',
+            borderBottom:
+              i < rows.length - 1 ? '1px solid var(--c-cobalt-50)' : 'none',
+          }}
+        >
+          <span
+            style={{
+              width: 10,
+              height: 11,
+              clipPath: 'var(--hex-pointy-top)',
+              background: row.tone,
+              flexShrink: 0,
+            }}
+          />
+          <div
+            style={{
+              flex: 1,
+              display: 'flex',
+              flexDirection: 'column',
+              gap: 2,
+            }}
+          >
+            <div
+              style={{
+                height: 4,
+                width: '70%',
+                background: 'var(--c-cobalt-700)',
+                borderRadius: 1,
+              }}
+            />
+            <div
+              style={{
+                height: 3,
+                width: '50%',
+                background: 'var(--c-cobalt-200)',
+                borderRadius: 1,
+              }}
+            />
+          </div>
+          <div
+            style={{
+              fontFamily: 'var(--conduction-typography-font-family-code)',
+              fontSize: 8,
+              letterSpacing: '0.05em',
+              textTransform: 'uppercase',
+              color: 'var(--c-cobalt-500)',
+            }}
+          >
+            {row.stage}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function HotLeadsPanel() {
+  const rows = [
+    { val: '€ 84k', tone: 'var(--c-orange-knvb)' },
+    { val: '€ 62k', tone: 'var(--c-mint-500)' },
+    { val: '€ 48k', tone: 'var(--c-lavender-300)' },
+    { val: '€ 31k', tone: 'var(--c-cobalt-300)' },
+  ];
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+      {rows.map((row, i) => (
+        <div
+          key={i}
+          style={{ display: 'flex', alignItems: 'center', gap: 8 }}
+        >
+          <span
+            style={{
+              width: 12,
+              height: 14,
+              clipPath: 'var(--hex-pointy-top)',
+              background: row.tone,
+              flexShrink: 0,
+            }}
+          />
+          <div
+            style={{
+              flex: 1,
+              display: 'flex',
+              flexDirection: 'column',
+              gap: 2,
+            }}
+          >
+            <div
+              style={{
+                height: 4,
+                width: '65%',
+                background: 'var(--c-cobalt-700)',
+                borderRadius: 1,
+              }}
+            />
+            <div
+              style={{
+                height: 3,
+                width: '45%',
+                background: 'var(--c-cobalt-200)',
+                borderRadius: 1,
+              }}
+            />
+          </div>
+          <div
+            style={{
+              fontFamily: 'var(--conduction-typography-font-family-code)',
+              fontSize: 10,
+              fontWeight: 700,
+              color: 'var(--c-cobalt-700)',
+            }}
+          >
+            {row.val}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+const WIDGETS = [
+  {
+    title: 'Pipeline value',
+    desc: 'Total deal value per stage. KPI on top, mini bars per stage. Live, not nightly batch.',
+    panel: <PipelineValuePanel />,
+  },
+  {
+    title: "This week's quotes",
+    desc: 'Quotes generated, sent, and signed. DocuDesk fills the template, signs with your instance certificate.',
+    panel: <QuotesPanel />,
+  },
+  {
+    title: 'Hot leads',
+    desc: 'Top deals by value or recent activity. Click through to the customer record.',
+    panel: <HotLeadsPanel />,
+  },
+];
+
 export default function Home() {
-  const {siteConfig} = useDocusaurusContext();
   return (
     <Layout
-      title={`${siteConfig.title}`}
-      description="CRM and pipeline management for Nextcloud">
-      <HomepageHeader />
-      <main>
-        <HomepageFeatures />
+      title="Pipelinq"
+      description="CRM on your Nextcloud. Customers, prospects, deals, quotes as typed registers. No separate sales database, no second login."
+    >
+      <main className="marketing-page">
+        <DetailHero
+          appId="pipelinq"
+          status={{ label: 'Beta', color: 'var(--c-orange-knvb)' }}
+          version="v0.7"
+          locales="NL · EN"
+          title="Pipelinq"
+          tagline={TAGLINE}
+          primaryCta={{
+            label: 'Install from app store',
+            href: 'https://apps.nextcloud.com/apps/pipelinq',
+            tone: 'orange',
+          }}
+          secondaryCta={{ label: 'Read the docs', href: '/docs/intro' }}
+          tertiaryCta={{
+            label: 'View on GitHub',
+            href: 'https://github.com/ConductionNL/pipelinq',
+          }}
+          iconColor="var(--c-orange-knvb)"
+          icon={PIPELINQ_ICON}
+          illustration={<AppMock app="pipelinq" />}
+        />
+
+        <WidgetShelf
+          eyebrow="Widgets we ship"
+          title="Sales on the dashboard the team already opens."
+          lede="Install Pipelinq and these widgets show up on every sales rep's home screen. Pipeline value first, this week's quotes next, hot leads below."
+          widgets={WIDGETS}
+        />
       </main>
     </Layout>
   );

--- a/src/views/settings/Settings.vue
+++ b/src/views/settings/Settings.vue
@@ -4,7 +4,7 @@
 		<NcSettingsSection
 			:name="t('pipelinq', 'Pipelinq Settings')"
 			:description="t('pipelinq', 'Configure your Pipelinq installation')"
-			doc-url="https://pipelinq.app" />
+			doc-url="https://pipelinq.conduction.nl/docs/intro" />
 
 		<!-- Version Information -->
 		<CnVersionInfoCard


### PR DESCRIPTION
## Summary

- Migrate `docs/` to `@conduction/docusaurus-preset@^1.4.3` so Pipelinq's docs site adopts the shared brand tokens, Navbar/Footer swizzles, and KvK/BTW copyright in line with the other Conduction product docs.
- New brand landing page (`docs/src/pages/index.js`) using `<DetailHero>` + `<WidgetShelf>`, mirroring the connext detail page (pipeline-spike glyph, orange-knvb accent, Pipeline value / This week's quotes / Hot leads widgets).
- New `docs/intro.md` entry so `/docs/intro` resolves cleanly.
- Switch `url` to `https://pipelinq.conduction.nl`. CNAME (`docs/static/CNAME`) and `.github/workflows/documentation.yml` already point at `pipelinq.conduction.nl` from the ADR-030 bootstrap, so no further change there.
- In-app fix: `src/views/settings/Settings.vue:7` `doc-url` switches from `https://pipelinq.app` to `https://pipelinq.conduction.nl/docs/intro` so the Settings panel link follows the new domain.

## Test plan

- [ ] CI documentation workflow builds the site and deploys to `pipelinq.conduction.nl`
- [ ] Verify `/docs/intro` renders after deploy
- [ ] Verify the Pipelinq Settings page Help link in Nextcloud opens `https://pipelinq.conduction.nl/docs/intro`
- [ ] Visual check: brand landing page hero + widget shelf vs connext mock