### PR TITLE
chore: bump @conduction/nextcloud-vue to 1.0.0-beta.30

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
 			"version": "0.1.0",
 			"license": "EUPL-1.2",
 			"dependencies": {
-				"@conduction/nextcloud-vue": "^1.0.0-beta.12",
+				"@conduction/nextcloud-vue": "^1.0.0-beta.30",
 				"@nextcloud/axios": "~2.5.2",
 				"@nextcloud/dialogs": "^3.2.0",
 				"@nextcloud/initial-state": "^2.2.0",
@@ -1761,9 +1761,9 @@
 			}
 		},
 		"node_modules/@conduction/nextcloud-vue": {
-			"version": "1.0.0-beta.13",
-			"resolved": "https://registry.npmjs.org/@conduction/nextcloud-vue/-/nextcloud-vue-1.0.0-beta.13.tgz",
-			"integrity": "sha512-vhWXjNo8nP294otJkLyE5sh/tjAP6RFnbse1pureYY7aIt4lIgVDd8VCFjndnUoanF9S6TY5q410JmUz4Zm7lA==",
+			"version": "1.0.0-beta.30",
+			"resolved": "https://registry.npmjs.org/@conduction/nextcloud-vue/-/nextcloud-vue-1.0.0-beta.30.tgz",
+			"integrity": "sha512-VrynA0mukFikJt4Ey9a3r42GqvdtUF5PeOaqs8SKrPmkPwfySQnIHgdzETer3w1Nm1rcVlnWCHWFmAXFXZROzw==",
 			"license": "EUPL-1.2",
 			"dependencies": {
 				"@codemirror/autocomplete": "^6.0.0",
@@ -1776,7 +1776,6 @@
 				"@codemirror/search": "^6.0.0",
 				"@codemirror/state": "^6.0.0",
 				"@codemirror/view": "^6.0.0",
-				"@nextcloud/capabilities": "^1.2.1",
 				"@nextcloud/dialogs": "^7.3.0",
 				"@nextcloud/notify_push": "^1.0.0",
 				"@uiw/codemirror-theme-github": "^4.25.8",
@@ -1784,7 +1783,9 @@
 				"apexcharts": "^4.7.0",
 				"codemirror": "^6.0.0",
 				"gridstack": "^10.3.1",
+				"leaflet": "^1.9.0",
 				"lodash": "^4.17.21",
+				"marked": "^15.0.0",
 				"style-mod": "^4.0.0",
 				"vue-apexcharts": "^1.7.0",
 				"vue-codemirror6": "^1.4.3",
@@ -1793,6 +1794,7 @@
 			},
 			"peerDependencies": {
 				"@nextcloud/axios": "^2.0.0",
+				"@nextcloud/capabilities": "^1.2.1",
 				"@nextcloud/l10n": "^2.0.0 || ^3.0.0",
 				"@nextcloud/router": "^2.0.0 || ^3.0.0",
 				"@nextcloud/vue": "^8.0.0",
@@ -2757,17 +2759,6 @@
 				"url": "https://github.com/sponsors/epoberezkin"
 			}
 		},
-		"node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
-			"version": "1.1.12",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-			"integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"balanced-match": "^1.0.0",
-				"concat-map": "0.0.1"
-			}
-		},
 		"node_modules/@eslint/eslintrc/node_modules/eslint-visitor-keys": {
 			"version": "4.2.1",
 			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
@@ -2818,19 +2809,6 @@
 			"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
 			"dev": true,
 			"license": "MIT"
-		},
-		"node_modules/@eslint/eslintrc/node_modules/minimatch": {
-			"version": "3.1.5",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
-			"integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"brace-expansion": "^1.1.7"
-			},
-			"engines": {
-				"node": "*"
-			}
 		},
 		"node_modules/@eslint/js": {
 			"version": "9.39.3",
@@ -2892,28 +2870,6 @@
 			},
 			"engines": {
 				"node": ">=10.10.0"
-			}
-		},
-		"node_modules/@humanwhocodes/config-array/node_modules/brace-expansion": {
-			"version": "1.1.12",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-			"integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
-			"dev": true,
-			"dependencies": {
-				"balanced-match": "^1.0.0",
-				"concat-map": "0.0.1"
-			}
-		},
-		"node_modules/@humanwhocodes/config-array/node_modules/minimatch": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-			"integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-			"dev": true,
-			"dependencies": {
-				"brace-expansion": "^1.1.7"
-			},
-			"engines": {
-				"node": "*"
 			}
 		},
 		"node_modules/@humanwhocodes/module-importer": {
@@ -6003,7 +5959,8 @@
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
 			"integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-			"dev": true
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/confbox": {
 			"version": "0.2.4",
@@ -6971,16 +6928,6 @@
 				"url": "https://github.com/sponsors/epoberezkin"
 			}
 		},
-		"node_modules/eslint/node_modules/brace-expansion": {
-			"version": "1.1.12",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-			"integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
-			"dev": true,
-			"dependencies": {
-				"balanced-match": "^1.0.0",
-				"concat-map": "0.0.1"
-			}
-		},
 		"node_modules/eslint/node_modules/eslint-scope": {
 			"version": "7.2.2",
 			"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.2.tgz",
@@ -7024,18 +6971,6 @@
 			"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
 			"dev": true,
 			"license": "MIT"
-		},
-		"node_modules/eslint/node_modules/minimatch": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-			"integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-			"dev": true,
-			"dependencies": {
-				"brace-expansion": "^1.1.7"
-			},
-			"engines": {
-				"node": "*"
-			}
 		},
 		"node_modules/espree": {
 			"version": "9.6.1",
@@ -7621,28 +7556,6 @@
 			"resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
 			"integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
 			"dev": true
-		},
-		"node_modules/glob/node_modules/brace-expansion": {
-			"version": "1.1.12",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-			"integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
-			"dev": true,
-			"dependencies": {
-				"balanced-match": "^1.0.0",
-				"concat-map": "0.0.1"
-			}
-		},
-		"node_modules/glob/node_modules/minimatch": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-			"integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-			"dev": true,
-			"dependencies": {
-				"brace-expansion": "^1.1.7"
-			},
-			"engines": {
-				"node": "*"
-			}
 		},
 		"node_modules/global-modules": {
 			"version": "2.0.0",
@@ -8693,6 +8606,12 @@
 			"resolved": "https://registry.npmjs.org/layerr/-/layerr-3.0.0.tgz",
 			"integrity": "sha512-tv754Ki2dXpPVApOrjTyRo4/QegVb9eVFq4mjqp4+NM5NaX7syQvN5BBNfV/ZpAHCEHV24XdUVrBAoka4jt3pA=="
 		},
+		"node_modules/leaflet": {
+			"version": "1.9.4",
+			"resolved": "https://registry.npmjs.org/leaflet/-/leaflet-1.9.4.tgz",
+			"integrity": "sha512-nxS1ynzJOmOlHp+iL3FyWqK89GtNL8U8rvlMOsQdTTssxZwCXh8N2NB3GDQOL+YR3XnWyZAxwQixURb+FA74PA==",
+			"license": "BSD-2-Clause"
+		},
 		"node_modules/levn": {
 			"version": "0.4.1",
 			"resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
@@ -8992,6 +8911,18 @@
 			},
 			"funding": {
 				"url": "https://github.com/fb55/entities?sponsor=1"
+			}
+		},
+		"node_modules/marked": {
+			"version": "15.0.12",
+			"resolved": "https://registry.npmjs.org/marked/-/marked-15.0.12.tgz",
+			"integrity": "sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA==",
+			"license": "MIT",
+			"bin": {
+				"marked": "bin/marked.js"
+			},
+			"engines": {
+				"node": ">= 18"
 			}
 		},
 		"node_modules/material-colors": {
@@ -9824,6 +9755,30 @@
 			"resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
 			"integrity": "sha512-JIYlbt6g8i5jKfJ3xz7rF0LXmv2TkDxBLUkiBeZ7bAx4GnnNMr8xFpGnOxn6GhTEHx3SjRrZEoU+j04prX1ktg==",
 			"license": "MIT"
+		},
+		"node_modules/minimatch": {
+			"version": "3.1.5",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+			"integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"brace-expansion": "^1.1.7"
+			},
+			"engines": {
+				"node": "*"
+			}
+		},
+		"node_modules/minimatch/node_modules/brace-expansion": {
+			"version": "1.1.14",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+			"integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"balanced-match": "^1.0.0",
+				"concat-map": "0.0.1"
+			}
 		},
 		"node_modules/minimist": {
 			"version": "1.2.8",
@@ -15532,9 +15487,9 @@
 			}
 		},
 		"@conduction/nextcloud-vue": {
-			"version": "1.0.0-beta.13",
-			"resolved": "https://registry.npmjs.org/@conduction/nextcloud-vue/-/nextcloud-vue-1.0.0-beta.13.tgz",
-			"integrity": "sha512-vhWXjNo8nP294otJkLyE5sh/tjAP6RFnbse1pureYY7aIt4lIgVDd8VCFjndnUoanF9S6TY5q410JmUz4Zm7lA==",
+			"version": "1.0.0-beta.30",
+			"resolved": "https://registry.npmjs.org/@conduction/nextcloud-vue/-/nextcloud-vue-1.0.0-beta.30.tgz",
+			"integrity": "sha512-VrynA0mukFikJt4Ey9a3r42GqvdtUF5PeOaqs8SKrPmkPwfySQnIHgdzETer3w1Nm1rcVlnWCHWFmAXFXZROzw==",
 			"requires": {
 				"@codemirror/autocomplete": "^6.0.0",
 				"@codemirror/commands": "^6.0.0",
@@ -15546,7 +15501,6 @@
 				"@codemirror/search": "^6.0.0",
 				"@codemirror/state": "^6.0.0",
 				"@codemirror/view": "^6.0.0",
-				"@nextcloud/capabilities": "^1.2.1",
 				"@nextcloud/dialogs": "^7.3.0",
 				"@nextcloud/notify_push": "^1.0.0",
 				"@uiw/codemirror-theme-github": "^4.25.8",
@@ -15554,7 +15508,9 @@
 				"apexcharts": "^4.7.0",
 				"codemirror": "^6.0.0",
 				"gridstack": "^10.3.1",
+				"leaflet": "^1.9.0",
 				"lodash": "^4.17.21",
+				"marked": "^15.0.0",
 				"style-mod": "^4.0.0",
 				"vue-apexcharts": "^1.7.0",
 				"vue-codemirror6": "^1.4.3",
@@ -16134,16 +16090,6 @@
 						"uri-js": "^4.2.2"
 					}
 				},
-				"brace-expansion": {
-					"version": "1.1.12",
-					"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-					"integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
-					"dev": true,
-					"requires": {
-						"balanced-match": "^1.0.0",
-						"concat-map": "0.0.1"
-					}
-				},
 				"eslint-visitor-keys": {
 					"version": "4.2.1",
 					"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
@@ -16172,15 +16118,6 @@
 					"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
 					"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
 					"dev": true
-				},
-				"minimatch": {
-					"version": "3.1.5",
-					"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
-					"integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
-					"dev": true,
-					"requires": {
-						"brace-expansion": "^1.1.7"
-					}
 				}
 			}
 		},
@@ -16230,27 +16167,6 @@
 				"@humanwhocodes/object-schema": "^2.0.3",
 				"debug": "^4.3.1",
 				"minimatch": "^3.0.5"
-			},
-			"dependencies": {
-				"brace-expansion": {
-					"version": "1.1.12",
-					"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-					"integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
-					"dev": true,
-					"requires": {
-						"balanced-match": "^1.0.0",
-						"concat-map": "0.0.1"
-					}
-				},
-				"minimatch": {
-					"version": "3.1.2",
-					"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-					"integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-					"dev": true,
-					"requires": {
-						"brace-expansion": "^1.1.7"
-					}
-				}
 			}
 		},
 		"@humanwhocodes/module-importer": {
@@ -19115,16 +19031,6 @@
 						"uri-js": "^4.2.2"
 					}
 				},
-				"brace-expansion": {
-					"version": "1.1.12",
-					"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-					"integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
-					"dev": true,
-					"requires": {
-						"balanced-match": "^1.0.0",
-						"concat-map": "0.0.1"
-					}
-				},
 				"eslint-scope": {
 					"version": "7.2.2",
 					"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.2.tgz",
@@ -19152,15 +19058,6 @@
 					"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
 					"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
 					"dev": true
-				},
-				"minimatch": {
-					"version": "3.1.2",
-					"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-					"integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-					"dev": true,
-					"requires": {
-						"brace-expansion": "^1.1.7"
-					}
 				}
 			}
 		},
@@ -19587,27 +19484,6 @@
 				"minimatch": "^3.1.1",
 				"once": "^1.3.0",
 				"path-is-absolute": "^1.0.0"
-			},
-			"dependencies": {
-				"brace-expansion": {
-					"version": "1.1.12",
-					"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-					"integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
-					"dev": true,
-					"requires": {
-						"balanced-match": "^1.0.0",
-						"concat-map": "0.0.1"
-					}
-				},
-				"minimatch": {
-					"version": "3.1.2",
-					"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-					"integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-					"dev": true,
-					"requires": {
-						"brace-expansion": "^1.1.7"
-					}
-				}
 			}
 		},
 		"glob-parent": {
@@ -20335,6 +20211,11 @@
 			"resolved": "https://registry.npmjs.org/layerr/-/layerr-3.0.0.tgz",
 			"integrity": "sha512-tv754Ki2dXpPVApOrjTyRo4/QegVb9eVFq4mjqp4+NM5NaX7syQvN5BBNfV/ZpAHCEHV24XdUVrBAoka4jt3pA=="
 		},
+		"leaflet": {
+			"version": "1.9.4",
+			"resolved": "https://registry.npmjs.org/leaflet/-/leaflet-1.9.4.tgz",
+			"integrity": "sha512-nxS1ynzJOmOlHp+iL3FyWqK89GtNL8U8rvlMOsQdTTssxZwCXh8N2NB3GDQOL+YR3XnWyZAxwQixURb+FA74PA=="
+		},
 		"levn": {
 			"version": "0.4.1",
 			"resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
@@ -20555,6 +20436,11 @@
 					"integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="
 				}
 			}
+		},
+		"marked": {
+			"version": "15.0.12",
+			"resolved": "https://registry.npmjs.org/marked/-/marked-15.0.12.tgz",
+			"integrity": "sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA=="
 		},
 		"material-colors": {
 			"version": "1.2.6",
@@ -21075,6 +20961,27 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
 			"integrity": "sha512-JIYlbt6g8i5jKfJ3xz7rF0LXmv2TkDxBLUkiBeZ7bAx4GnnNMr8xFpGnOxn6GhTEHx3SjRrZEoU+j04prX1ktg=="
+		},
+		"minimatch": {
+			"version": "3.1.5",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+			"integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+			"dev": true,
+			"requires": {
+				"brace-expansion": "^1.1.7"
+			},
+			"dependencies": {
+				"brace-expansion": {
+					"version": "1.1.14",
+					"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+					"integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+					"dev": true,
+					"requires": {
+						"balanced-match": "^1.0.0",
+						"concat-map": "0.0.1"
+					}
+				}
+			}
 		},
 		"minimist": {
 			"version": "1.2.8",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
 		"extends @nextcloud/browserslist-config"
 	],
 	"dependencies": {
-		"@conduction/nextcloud-vue": "^1.0.0-beta.12",
+		"@conduction/nextcloud-vue": "^1.0.0-beta.30",
 		"@nextcloud/axios": "~2.5.2",
 		"@nextcloud/dialogs": "^3.2.0",
 		"@nextcloud/initial-state": "^2.2.0",


### PR DESCRIPTION
## Summary

Bumps `@conduction/nextcloud-vue` from `^1.0.0-beta.12` (lockfile resolved to `beta.13`) to `^1.0.0-beta.30`, pulling pipelinq onto the lib v2 wave:

- Form / wiki / map page types
- OR-guard default in `CnAppRoot` (auto-activates; manifest already declares OR, no opt-out needed)
- Dynamic menu
- `@resolve` refs in manifest
- Named-view sidebar slot
- Chart helpers
- Settings tabs
- `cardComponent` registry
- Actions handler

### npm semver gotcha

Caret on a `1.0.0-beta.X` pin does **not** slide forward across prereleases — `^1.0.0-beta.12` will not pick up `beta.30`. The `package.json` range was bumped explicitly, then `npm install --legacy-peer-deps` refreshed the lockfile.

### Versions

| | Before | After |
|---|---|---|
| `package.json` range | `^1.0.0-beta.12` | `^1.0.0-beta.30` |
| `package-lock.json` resolved | `1.0.0-beta.13` | `1.0.0-beta.30` |
| `app-manifest` schema | `1.2.0` | `1.3.0` |

### No code changes

`src/main.js` CnAppRoot mount remains intact (no `:requires-apps="[]"` opt-out — we want the new default). `src/App.vue` is a thin wrapper around `CnAppRoot` with the `#sidebar` slot — left untouched. The bundled 47-page manifest keeps working (Ajv validation passes against schema v1.3.0).

## Gates (vs `origin/development` baseline)

- `npm run build`: **PASS** — webpack compiled with 4 entrypoint-size warnings (baseline: 3). The extra warning reflects modest bundle growth from the new lib surface; no errors.
- `node tests/validate-manifest.js`: **PASS** — 0 Ajv errors against the new schema (`app-manifest` 1.3.0).
- `npm run lint`: pre-existing **FAIL** on baseline and post-bump (`@nextcloud/eslint-config` references `eslint-plugin-import` which is not installed). **Not introduced by this change.**
- `npm run stylelint`: pre-existing **FAIL** on baseline and post-bump (config-loading error). **Not introduced by this change.**

`npm test` is not defined.

## Test plan

- [ ] CI build green
- [ ] Manifest validation green
- [ ] Smoke-test pipelinq UI in dev container: dashboard, kanban, detail pages, settings
- [ ] Confirm OR-guard renders the dependency-missing screen when OpenRegister is disabled