### PR TITLE
chore(license): allow (MIT AND ...) compound licenses for pako + sha.js

### DIFF
--- a/.license-overrides.json
+++ b/.license-overrides.json
@@ -1,0 +1,4 @@
+{
+	"pako": "License is (MIT AND Zlib) — both are approved open-source licenses on the default allowlist; transitive dep via webpack/babel toolchain; compound AND expression not parsed by checker",
+	"sha.js": "License is (MIT AND BSD-3-Clause) — both are approved open-source licenses on the default allowlist; transitive dep via webpack/babel toolchain; compound AND expression not parsed by checker"
+}


### PR DESCRIPTION
## Summary

Fixes the `quality / License (npm)` CI failure by approving `pako` and `sha.js` via `.license-overrides.json`.

## The failure

```
##[error]Disallowed license: pako (1.0.11) uses '(MIT AND Zlib)'
##[error]Disallowed license: sha.js (2.4.12) uses '(MIT AND BSD-3-Clause)'
```

Failing CI run: https://github.com/ConductionNL/pipelinq/actions/runs/25623924204/job/75215459016 (PR #331)

## Root cause

The shared workflow (`ConductionNL/.github/.github/workflows/quality.yml`) splits SPDX expressions on `" OR "` to allow dual-licensed packages, but does **not** split on `" AND "`. So `(MIT AND Zlib)` is checked as a single literal token and never matches the allowlist — even though both `MIT` and `Zlib` are individually approved.

Both `pako` and `sha.js` are transitive dependencies of the webpack/babel toolchain, so pinning them in `package.json` is wrong (creates maintenance rot, drift from upstream).

## Fix

Per the workflow's documented config interface, `.license-overrides.json` is the supported escape hatch for "dual-licensed packages where the checker picks the wrong one". Adding the two packages there is the minimal, app-local fix and matches the existing pattern other apps already use for the same `(X AND Y)` issue (e.g. `@fortawesome/free-solid-svg-icons` in zaakafhandelapp).

## Local verification

Replicated the workflow's `check_license()` + overrides logic against `license-checker --json --production`:

```
Before: DENIED: pako   -> (MIT AND Zlib)
        DENIED: sha.js -> (MIT AND BSD-3-Clause)
After:  Violations: 0  |  Overridden: 2
```

## Test plan

- [ ] `quality / License (npm)` passes on this PR
- [ ] No other quality jobs regress