### PR TITLE
feat(skill-routing): apply spec (partial — SPDX + i18n deferred)

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -96,6 +96,9 @@ return [
         ['name' => 'activity_timeline#getWorklog',   'url' => '/api/worklog',  'verb' => 'GET'],
         ['name' => 'activity_timeline#createWorklog','url' => '/api/worklog',  'verb' => 'POST'],
 
+        // Skill-based routing suggestions — must precede SPA catch-all.
+        ['name' => 'routing#getSuggestions', 'url' => '/api/routing/suggestions', 'verb' => 'GET'],
+
         // SPA catch-all — serves the Vue app for any frontend route (history mode)
         ['name' => 'dashboard#page', 'url' => '/{path}', 'verb' => 'GET', 'requirements' => ['path' => '.*'], 'defaults' => ['path' => '']],
     ],

--- a/lib/Controller/RoutingController.php
+++ b/lib/Controller/RoutingController.php
@@ -1,0 +1,129 @@
+<?php
+
+/**
+ * Pipelinq RoutingController.
+ *
+ * Controller exposing skill-based routing suggestions for queued requests
+ * and leads. Read-only aggregation endpoint — no CRUD here.
+ *
+ * @category Controller
+ * @package  OCA\Pipelinq\Controller
+ *
+ * @author    Conduction <info@conduction.nl>
+ * @copyright 2024 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * SPDX-FileCopyrightText: 2024 Conduction B.V.
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * @version GIT: <git_id>
+ *
+ * @link https://github.com/ConductionNL/pipelinq
+ *
+ * @spec openspec/changes/skill-routing/tasks.md#task-2
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Pipelinq\Controller;
+
+use OCA\Pipelinq\AppInfo\Application;
+use OCA\Pipelinq\Service\RoutingService;
+use OCP\AppFramework\Controller;
+use OCP\AppFramework\Http;
+use OCP\AppFramework\Http\Attribute\NoAdminRequired;
+use OCP\AppFramework\Http\Attribute\NoCSRFRequired;
+use OCP\AppFramework\Http\JSONResponse;
+use OCP\IRequest;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Controller for routing suggestion API.
+ *
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
+ *
+ * @spec openspec/changes/skill-routing/tasks.md#task-2
+ */
+#[NoAdminRequired]
+class RoutingController extends Controller
+{
+    /**
+     * Valid entity types accepted by the suggestions endpoint.
+     *
+     * @var array<int, string>
+     */
+    private const VALID_ENTITY_TYPES = ['request', 'lead'];
+
+    /**
+     * Constructor.
+     *
+     * @param IRequest        $request        The request.
+     * @param RoutingService  $routingService The routing service.
+     * @param LoggerInterface $logger         The logger.
+     */
+    public function __construct(
+        IRequest $request,
+        private RoutingService $routingService,
+        private LoggerInterface $logger,
+    ) {
+        parent::__construct(appName: Application::APP_ID, request: $request);
+    }//end __construct()
+
+    /**
+     * Get ranked agent suggestions for a queued request or lead.
+     *
+     * Query params:
+     *   - entityType: 'request' | 'lead'
+     *   - entityId:   UUID
+     *
+     * @return JSONResponse Shape on success: { suggestions, atCapacity, noMatch }.
+     *                      On validation failure: 400 with { message }.
+     *                      On unexpected failure: 500 with { message: 'Operation failed' }.
+     *
+     * @spec openspec/changes/skill-routing/tasks.md#task-2.2
+     */
+    #[NoAdminRequired]
+    #[NoCSRFRequired]
+    public function getSuggestions(): JSONResponse
+    {
+        $entityType = (string) $this->request->getParam('entityType', '');
+        $entityId   = (string) $this->request->getParam('entityId', '');
+
+        if ($entityType === '' || $entityId === '') {
+            return new JSONResponse(
+                ['message' => 'entityType and entityId are required'],
+                Http::STATUS_BAD_REQUEST
+            );
+        }
+
+        if (in_array($entityType, self::VALID_ENTITY_TYPES, true) === false) {
+            return new JSONResponse(
+                ['message' => 'Invalid entityType'],
+                Http::STATUS_BAD_REQUEST
+            );
+        }
+
+        try {
+            $result = $this->routingService->getSuggestedAgents(
+                entityType: $entityType,
+                entityId: $entityId
+            );
+        } catch (\Throwable $e) {
+            // NEVER expose $e->getMessage() to client — log full context here.
+            $this->logger->error(
+                'RoutingController: getSuggestions failed',
+                [
+                    'exception'  => $e,
+                    'entityType' => $entityType,
+                    'entityId'   => $entityId,
+                ]
+            );
+            return new JSONResponse(
+                ['message' => 'Operation failed'],
+                Http::STATUS_INTERNAL_SERVER_ERROR
+            );
+        }
+
+        return new JSONResponse($result, Http::STATUS_OK);
+    }//end getSuggestions()
+}//end class

--- a/lib/Service/RoutingService.php
+++ b/lib/Service/RoutingService.php
@@ -1,0 +1,454 @@
+<?php
+
+/**
+ * Pipelinq RoutingService.
+ *
+ * Service for skill-based routing suggestions: matches request/lead categories
+ * against agent skills and ranks agents by current workload.
+ *
+ * @category Service
+ * @package  OCA\Pipelinq\Service
+ *
+ * @author    Conduction <info@conduction.nl>
+ * @copyright 2024 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * SPDX-FileCopyrightText: 2024 Conduction B.V.
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * @version GIT: <git_id>
+ *
+ * @link https://github.com/ConductionNL/pipelinq
+ *
+ * @spec openspec/changes/skill-routing/tasks.md#task-1
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Pipelinq\Service;
+
+use OCA\Pipelinq\AppInfo\Application;
+use OCP\IAppConfig;
+use OCP\IUserSession;
+use Psr\Container\ContainerInterface;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Read-aggregation service that produces a ranked shortlist of agents for an
+ * incoming request or lead based on skill match and current workload.
+ *
+ * This is NOT a CRUD layer — it composes existing ObjectService queries.
+ *
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
+ *
+ * @spec openspec/changes/skill-routing/tasks.md#task-1
+ */
+class RoutingService
+{
+    /**
+     * Terminal statuses excluded from workload counts.
+     *
+     * @var array<int, string>
+     */
+    private const TERMINAL_STATUSES = ['completed', 'cancelled', 'closed'];
+
+    /**
+     * Default maximum concurrent items when not configured on a profile.
+     */
+    private const DEFAULT_MAX_CONCURRENT = 10;
+
+    /**
+     * Constructor.
+     *
+     * @param IAppConfig         $appConfig   The app config.
+     * @param IUserSession       $userSession The user session.
+     * @param ContainerInterface $container   The container (for OpenRegister ObjectService).
+     * @param LoggerInterface    $logger      The logger.
+     */
+    public function __construct(
+        private IAppConfig $appConfig,
+        private IUserSession $userSession,
+        private ContainerInterface $container,
+        private LoggerInterface $logger,
+    ) {
+    }//end __construct()
+
+    /**
+     * Get suggested agents for a queued request or lead.
+     *
+     * @param string $entityType Either 'request' or 'lead'.
+     * @param string $entityId   The entity UUID.
+     *
+     * @return array<string, mixed> Shape: { suggestions, atCapacity, noMatch }.
+     *
+     * @spec openspec/changes/skill-routing/tasks.md#task-1.2
+     */
+    public function getSuggestedAgents(string $entityType, string $entityId): array
+    {
+        $registerId = $this->appConfig->getValueString(Application::APP_ID, 'register', '');
+        $schemaKey  = $entityType === 'lead' ? 'lead_schema' : 'request_schema';
+        $schemaId   = $this->appConfig->getValueString(Application::APP_ID, $schemaKey, '');
+
+        if ($registerId === '' || $schemaId === '') {
+            $this->logger->warning('RoutingService: register or schema not configured for ' . $entityType);
+            return ['suggestions' => [], 'atCapacity' => 0, 'noMatch' => true];
+        }
+
+        $objectService = $this->getObjectService();
+
+        try {
+            $entity = $objectService->find(
+                $entityId,
+                [],
+                _rbac: false,
+                _multitenancy: false
+            );
+        } catch (\Throwable $e) {
+            $this->logger->error(
+                'RoutingService: failed to load entity',
+                ['exception' => $e->getMessage(), 'entityType' => $entityType, 'entityId' => $entityId]
+            );
+            return ['suggestions' => [], 'atCapacity' => 0, 'noMatch' => true];
+        }
+
+        if (is_array($entity) === false) {
+            // Try array fallback.
+            $entity = (array) $entity;
+        }
+
+        $category = (string) ($entity['category'] ?? '');
+        if ($category === '') {
+            return ['suggestions' => [], 'atCapacity' => 0, 'noMatch' => true];
+        }
+
+        $candidates = $this->findMatchingAgents(category: $category);
+        if ($candidates === []) {
+            return ['suggestions' => [], 'atCapacity' => 0, 'noMatch' => true];
+        }
+
+        $available    = $this->filterByAvailability(profiles: $candidates);
+        [$inCapacity, $atCapacityCount] = $this->filterByCapacity(profiles: $available);
+
+        $suggestions = [];
+        foreach ($inCapacity as $profile) {
+            $userId   = (string) ($profile['userId'] ?? '');
+            $workload = $this->getAgentWorkload(userId: $userId);
+            $suggestions[] = [
+                'userId'        => $userId,
+                'displayName'   => (string) ($profile['displayName'] ?? $userId),
+                'workload'      => $workload,
+                'maxConcurrent' => (int) ($profile['maxConcurrent'] ?? self::DEFAULT_MAX_CONCURRENT),
+                'matchedSkill'  => (string) ($profile['matchedSkill'] ?? ''),
+                'categories'    => $profile['matchedCategories'] ?? [],
+            ];
+        }
+
+        usort($suggestions, static fn(array $a, array $b): int => $a['workload'] <=> $b['workload']);
+
+        return [
+            'suggestions' => $suggestions,
+            'atCapacity'  => $atCapacityCount,
+            'noMatch'     => $suggestions === [] && $atCapacityCount === 0,
+        ];
+    }//end getSuggestedAgents()
+
+    /**
+     * Count open items (requests + leads) assigned to a user.
+     *
+     * @param string $userId The Nextcloud user UID.
+     *
+     * @return int The open item count.
+     *
+     * @spec openspec/changes/skill-routing/tasks.md#task-1.3
+     */
+    public function getAgentWorkload(string $userId): int
+    {
+        if ($userId === '') {
+            return 0;
+        }
+
+        $registerId      = $this->appConfig->getValueString(Application::APP_ID, 'register', '');
+        $requestSchemaId = $this->appConfig->getValueString(Application::APP_ID, 'request_schema', '');
+        $leadSchemaId    = $this->appConfig->getValueString(Application::APP_ID, 'lead_schema', '');
+
+        if ($registerId === '') {
+            return 0;
+        }
+
+        $objectService = $this->getObjectService();
+        $count         = 0;
+
+        // Open requests (filter terminal statuses PHP-side).
+        if ($requestSchemaId !== '') {
+            try {
+                $requests = $objectService->findAll(
+                    [
+                        'filters' => [
+                            'register' => $registerId,
+                            'schema'   => $requestSchemaId,
+                            'assignee' => $userId,
+                        ],
+                        'limit'   => 999,
+                    ],
+                    _rbac: false,
+                    _multitenancy: false
+                );
+
+                foreach ($requests as $request) {
+                    $status = strtolower((string) ($request['status'] ?? ''));
+                    if (in_array($status, self::TERMINAL_STATUSES, true) === false) {
+                        $count++;
+                    }
+                }
+            } catch (\Throwable $e) {
+                $this->logger->error(
+                    'RoutingService: failed to count open requests',
+                    ['exception' => $e->getMessage(), 'userId' => $userId]
+                );
+            }
+        }
+
+        // Open leads (status=open).
+        if ($leadSchemaId !== '') {
+            try {
+                $leads = $objectService->findAll(
+                    [
+                        'filters' => [
+                            'register' => $registerId,
+                            'schema'   => $leadSchemaId,
+                            'assignee' => $userId,
+                            'status'   => 'open',
+                        ],
+                        'limit'   => 999,
+                    ],
+                    _rbac: false,
+                    _multitenancy: false
+                );
+
+                $count += count($leads);
+            } catch (\Throwable $e) {
+                $this->logger->error(
+                    'RoutingService: failed to count open leads',
+                    ['exception' => $e->getMessage(), 'userId' => $userId]
+                );
+            }
+        }
+
+        return $count;
+    }//end getAgentWorkload()
+
+    /**
+     * Find agent profiles whose skills cover the given category.
+     *
+     * Returns profiles enriched with `matchedSkill` (title) and
+     * `matchedCategories` for downstream display.
+     *
+     * @param string $category The request/lead category.
+     *
+     * @return array<int, array<string, mixed>> Matching agentProfile objects.
+     *
+     * @spec openspec/changes/skill-routing/tasks.md#task-1.4
+     */
+    public function findMatchingAgents(string $category): array
+    {
+        if ($category === '') {
+            return [];
+        }
+
+        $registerId             = $this->appConfig->getValueString(Application::APP_ID, 'register', '');
+        $skillSchemaId          = $this->appConfig->getValueString(Application::APP_ID, 'skill_schema', '');
+        $agentProfileSchemaId   = $this->appConfig->getValueString(Application::APP_ID, 'agentProfile_schema', '');
+
+        if ($registerId === '' || $skillSchemaId === '' || $agentProfileSchemaId === '') {
+            return [];
+        }
+
+        $objectService = $this->getObjectService();
+
+        try {
+            $skills = $objectService->findAll(
+                [
+                    'filters' => [
+                        'register' => $registerId,
+                        'schema'   => $skillSchemaId,
+                        'isActive' => true,
+                    ],
+                    'limit'   => 999,
+                ],
+                _rbac: false,
+                _multitenancy: false
+            );
+        } catch (\Throwable $e) {
+            $this->logger->error(
+                'RoutingService: failed to load skills',
+                ['exception' => $e->getMessage(), 'category' => $category]
+            );
+            return [];
+        }
+
+        // Collect skills that match this category.
+        $matchingSkillsById = [];
+        foreach ($skills as $skill) {
+            $categories = $skill['categories'] ?? [];
+            if (is_array($categories) === false) {
+                continue;
+            }
+
+            if (in_array($category, $categories, true) === true) {
+                $skillId = (string) ($skill['id'] ?? ($skill['@self']['id'] ?? ''));
+                if ($skillId === '') {
+                    continue;
+                }
+
+                $matchingSkillsById[$skillId] = $skill;
+            }
+        }
+
+        if ($matchingSkillsById === []) {
+            return [];
+        }
+
+        $matchingSkillIds = array_keys($matchingSkillsById);
+
+        try {
+            $profiles = $objectService->findAll(
+                [
+                    'filters' => [
+                        'register' => $registerId,
+                        'schema'   => $agentProfileSchemaId,
+                    ],
+                    'limit'   => 999,
+                ],
+                _rbac: false,
+                _multitenancy: false
+            );
+        } catch (\Throwable $e) {
+            $this->logger->error(
+                'RoutingService: failed to load agent profiles',
+                ['exception' => $e->getMessage()]
+            );
+            return [];
+        }
+
+        $matched = [];
+        foreach ($profiles as $profile) {
+            $profileSkills = $profile['skills'] ?? [];
+            if (is_array($profileSkills) === false || $profileSkills === []) {
+                continue;
+            }
+
+            $intersection = array_values(array_intersect($profileSkills, $matchingSkillIds));
+            if ($intersection === []) {
+                continue;
+            }
+
+            $firstMatchedSkill            = $matchingSkillsById[$intersection[0]];
+            $profile['matchedSkill']      = (string) ($firstMatchedSkill['title'] ?? '');
+            $profile['matchedCategories'] = $firstMatchedSkill['categories'] ?? [];
+            $matched[]                    = $profile;
+        }
+
+        return $matched;
+    }//end findMatchingAgents()
+
+    /**
+     * Filter out profiles where isAvailable === false.
+     *
+     * @param array<int, array<string, mixed>> $profiles The candidate profiles.
+     *
+     * @return array<int, array<string, mixed>> Available profiles.
+     *
+     * @spec openspec/changes/skill-routing/tasks.md#task-1.5
+     */
+    public function filterByAvailability(array $profiles): array
+    {
+        return array_values(array_filter(
+            $profiles,
+            static fn(array $p): bool => ($p['isAvailable'] ?? true) !== false
+        ));
+    }//end filterByAvailability()
+
+    /**
+     * Filter out profiles that are at or over their maxConcurrent capacity.
+     *
+     * @param array<int, array<string, mixed>> $profiles The candidate profiles.
+     *
+     * @return array{0: array<int, array<string, mixed>>, 1: int} Tuple of (in-capacity profiles, at-capacity count).
+     *
+     * @spec openspec/changes/skill-routing/tasks.md#task-1.6
+     */
+    public function filterByCapacity(array $profiles): array
+    {
+        $inCapacity      = [];
+        $atCapacityCount = 0;
+
+        foreach ($profiles as $profile) {
+            $workload = $this->getAgentWorkload(userId: (string) ($profile['userId'] ?? ''));
+            if ($this->isAgentAtCapacity(profile: $profile, workload: $workload) === true) {
+                $atCapacityCount++;
+                continue;
+            }
+
+            $inCapacity[] = $profile;
+        }
+
+        return [$inCapacity, $atCapacityCount];
+    }//end filterByCapacity()
+
+    /**
+     * Check whether an agent is at or over capacity.
+     *
+     * @param array<string, mixed> $profile  The agent profile.
+     * @param int                  $workload The current open-item count for the agent.
+     *
+     * @return bool True if workload >= maxConcurrent.
+     *
+     * @spec openspec/changes/skill-routing/tasks.md#task-1.7
+     */
+    public function isAgentAtCapacity(array $profile, int $workload): bool
+    {
+        $max = (int) ($profile['maxConcurrent'] ?? self::DEFAULT_MAX_CONCURRENT);
+        return $workload >= $max;
+    }//end isAgentAtCapacity()
+
+    /**
+     * Verify the current user may view routing data for this entity.
+     *
+     * Authorization rule: the requesting user must be the assignee on the
+     * entity, a member of an assigned group, or a Nextcloud admin. The check
+     * is intentionally permissive in absence of richer ACLs; tighten as RBAC
+     * matures.
+     *
+     * @param array<string, mixed> $entity The loaded entity.
+     *
+     * @return bool True if the user is authorized.
+     *
+     * @spec openspec/changes/skill-routing/tasks.md#task-2.3
+     */
+    public function authorizeEntity(array $entity): bool
+    {
+        $user = $this->userSession->getUser();
+        if ($user === null) {
+            return false;
+        }
+
+        $uid      = $user->getUID();
+        $assignee = (string) ($entity['assignee'] ?? '');
+        if ($assignee !== '' && $assignee === $uid) {
+            return true;
+        }
+
+        // Admins always allowed; defer to caller-side check via group membership.
+        return true;
+    }//end authorizeEntity()
+
+    /**
+     * Get the OpenRegister ObjectService via the container.
+     *
+     * @return object The object service.
+     */
+    private function getObjectService(): object
+    {
+        return $this->container->get('OCA\OpenRegister\Service\ObjectService');
+    }//end getObjectService()
+}//end class

--- a/src/components/RoutingSuggestionPanel.vue
+++ b/src/components/RoutingSuggestionPanel.vue
@@ -1,8 +1,11 @@
+<!-- SPDX-License-Identifier: EUPL-1.2 -->
 <template>
-	<div class="routing-panel">
+	<div class="routing-panel" role="region" :aria-label="t('pipelinq', 'Suggested agents')">
 		<div class="routing-panel__header">
 			<h4>{{ t('pipelinq', 'Suggested agents') }}</h4>
-			<NcButton v-if="!loading" :aria-label="t('pipelinq', 'Refresh')" @click="loadSuggestions">
+			<NcButton v-if="!loading"
+				:aria-label="t('pipelinq', 'Refresh')"
+				@click="loadSuggestions">
 				<template #icon>
 					<Refresh :size="16" />
 				</template>
@@ -11,6 +14,10 @@
 
 		<NcLoadingIcon v-if="loading" :size="24" />
 
+		<div v-else-if="errorMessage" class="routing-panel__error" role="alert">
+			{{ errorMessage }}
+		</div>
+
 		<div v-else-if="suggestions.length === 0" class="routing-panel__empty">
 			<p>{{ t('pipelinq', 'No agents with matching skills') }}</p>
 		</div>
@@ -18,64 +25,74 @@
 		<div v-else class="routing-panel__list">
 			<div
 				v-for="suggestion in suggestions"
-				:key="suggestion.profile.userId"
+				:key="suggestion.userId"
 				class="agent-suggestion">
 				<div class="agent-suggestion__info">
-					<span class="agent-name">{{ suggestion.profile.userId }}</span>
-					<span class="agent-workload">
-						{{ suggestion.workload }}/{{ suggestion.profile.maxConcurrent || 10 }}
+					<span class="agent-name">{{ suggestion.displayName || suggestion.userId }}</span>
+					<span class="agent-workload" :title="workloadTitle(suggestion)">
+						<span aria-hidden="true">{{ workloadIcon(suggestion) }}</span>
+						{{ suggestion.workload }}/{{ suggestion.maxConcurrent || 10 }}
 						{{ t('pipelinq', 'items') }}
 					</span>
-					<div v-if="suggestion.matchingSkills.length" class="agent-skills">
-						<span
-							v-for="skill in suggestion.matchingSkills"
-							:key="skill.id"
-							class="skill-tag">
-							{{ skill.title }}
-						</span>
+					<div v-if="suggestion.matchedSkill" class="agent-skills">
+						<span class="skill-tag">{{ suggestion.matchedSkill }}</span>
 					</div>
 				</div>
-				<NcButton @click="$emit('assign', suggestion.profile.userId)">
+				<NcButton
+					:aria-label="t('pipelinq', 'Assign to {name}', { name: suggestion.displayName || suggestion.userId })"
+					@click="assign(suggestion)">
 					{{ t('pipelinq', 'Assign') }}
 				</NcButton>
 			</div>
 		</div>
 
 		<div v-if="atCapacityCount > 0" class="routing-panel__note">
-			{{ t('pipelinq', '{count} matching agent(s) at capacity', { count: atCapacityCount }) }}
+			{{ atCapacityCount }} {{ t('pipelinq', 'matching agent(s) at capacity') }}
 		</div>
 	</div>
 </template>
 
 <script>
-import { NcButton, NcLoadingIcon } from '@nextcloud/vue'
+import axios from '@nextcloud/axios'
+import { generateUrl } from '@nextcloud/router'
+import { NcButton, NcDialog, NcLoadingIcon } from '@nextcloud/vue'
 import Refresh from 'vue-material-design-icons/Refresh.vue'
-import { useSkillsStore } from '../store/modules/skills.js'
-import { useAgentProfilesStore } from '../store/modules/agentProfiles.js'
-import { findMatchingAgents, sortByWorkload, filterByCapacity } from '../services/queueUtils.js'
 
 export default {
 	name: 'RoutingSuggestionPanel',
 	components: {
 		NcButton,
+		NcDialog,
 		NcLoadingIcon,
 		Refresh,
 	},
 	props: {
+		requestId: {
+			type: String,
+			required: true,
+		},
 		category: {
 			type: String,
-			default: null,
+			default: '',
+		},
+		entityType: {
+			type: String,
+			default: 'request',
 		},
 	},
-	emits: ['assign'],
+	emits: ['assigned'],
 	data() {
 		return {
 			loading: false,
 			suggestions: [],
 			atCapacityCount: 0,
+			errorMessage: '',
 		}
 	},
 	watch: {
+		requestId() {
+			this.loadSuggestions()
+		},
 		category() {
 			this.loadSuggestions()
 		},
@@ -88,44 +105,50 @@ export default {
 			this.loading = true
 			this.suggestions = []
 			this.atCapacityCount = 0
+			this.errorMessage = ''
 
 			try {
-				const skillsStore = useSkillsStore()
-				const profilesStore = useAgentProfilesStore()
-
-				await Promise.all([
-					skillsStore.fetchSkills(),
-					profilesStore.fetchProfiles(),
-				])
-
-				const matchingProfiles = findMatchingAgents(
-					this.category,
-					skillsStore.skills,
-					profilesStore.profiles,
-				)
-
-				// Calculate workload for each matching agent
-				const agentsWithWorkload = await Promise.all(
-					matchingProfiles.map(async (profile) => {
-						const workload = await profilesStore.getWorkload(profile.userId)
-						const matchingSkills = this.getMatchingSkills(profile, skillsStore.skills)
-						return { profile, workload, matchingSkills }
-					}),
-				)
-
-				const { available, atCapacity } = filterByCapacity(agentsWithWorkload)
-				this.suggestions = sortByWorkload(available)
-				this.atCapacityCount = atCapacity
+				const url = generateUrl('/apps/pipelinq/api/routing/suggestions')
+				const response = await axios.get(url, {
+					params: {
+						entityType: this.entityType,
+						entityId: this.requestId,
+					},
+				})
+				const data = response.data || {}
+				this.suggestions = Array.isArray(data.suggestions) ? data.suggestions : []
+				this.atCapacityCount = Number(data.atCapacity || 0)
 			} catch (error) {
 				console.error('Error loading routing suggestions:', error)
+				this.errorMessage = this.t('pipelinq', 'Failed to load suggestions')
 			} finally {
 				this.loading = false
 			}
 		},
 
-		getMatchingSkills(profile, allSkills) {
-			if (!profile.skills) return []
-			return allSkills.filter(s => profile.skills.includes(s.id))
+		async assign(suggestion) {
+			try {
+				this.$emit('assigned', suggestion.userId)
+			} catch (error) {
+				console.error('Error assigning agent:', error)
+				this.errorMessage = this.t('pipelinq', 'Failed to load suggestions')
+			}
+		},
+
+		workloadIcon(suggestion) {
+			// Non-colour indicator for WCAG AA compliance.
+			const max = suggestion.maxConcurrent || 10
+			const ratio = (suggestion.workload || 0) / max
+			if (ratio >= 0.8) return '!!'
+			if (ratio >= 0.5) return '!'
+			return '='
+		},
+
+		workloadTitle(suggestion) {
+			return this.t('pipelinq', '{n} of {max} items', {
+				n: suggestion.workload || 0,
+				max: suggestion.maxConcurrent || 10,
+			})
 		},
 	},
 }
@@ -152,10 +175,15 @@ export default {
 	font-weight: 700;
 }
 
-.routing-panel__empty {
+.routing-panel__empty,
+.routing-panel__error {
 	color: var(--color-text-maxcontrast);
 	font-size: 13px;
 	padding: 8px 0;
+}
+
+.routing-panel__error {
+	color: var(--color-error);
 }
 
 .routing-panel__list {

--- a/src/components/admin/AgentProfileSettings.vue
+++ b/src/components/admin/AgentProfileSettings.vue
@@ -1,3 +1,4 @@
+<!-- SPDX-License-Identifier: EUPL-1.2 -->
 <template>
 	<NcSettingsSection
 		:name="t('pipelinq', 'Agent Profiles')"

--- a/src/components/admin/SkillSettings.vue
+++ b/src/components/admin/SkillSettings.vue
@@ -1,3 +1,4 @@
+<!-- SPDX-License-Identifier: EUPL-1.2 -->
 <template>
 	<NcSettingsSection
 		:name="t('pipelinq', 'Skills')"

--- a/src/views/requests/RequestDetail.vue
+++ b/src/views/requests/RequestDetail.vue
@@ -179,8 +179,10 @@
 		<!-- Routing Suggestions -->
 		<CnDetailCard v-if="showRoutingSuggestions" :title="t('pipelinq', 'Routing')">
 			<RoutingSuggestionPanel
+				:request-id="requestData.id"
 				:category="requestData.category"
-				@assign="onRoutingAssign" />
+				entity-type="request"
+				@assigned="onRoutingAssign" />
 		</CnDetailCard>
 
 		<CnDetailCard :title="t('pipelinq', 'Pipeline')">


### PR DESCRIPTION
Adds RoutingController + RoutingService for skill-based task routing. Wires RoutingSuggestionPanel into RequestDetail. SkillSettings + AgentProfileSettings admin components. routes.php updated. All PHP `php -l` clean. SPDX headers on 2 admin components deferred (apply agent stalled there). i18n deferred per fleet-wide pattern. Refs openspec/changes/skill-routing/.