### PR TITLE
feat(mcp-tools): PipelinqToolProvider — AI companion MCP tools

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,11 @@
 			"OCA\\Pipelinq\\": "lib/"
 		}
 	},
+	"autoload-dev": {
+		"psr-4": {
+			"OCA\\OpenRegister\\": "tests/Stubs/"
+		}
+	},
 	"require": {
 		"php": "^8.1"
 	},

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -32,6 +32,7 @@ use OCA\Pipelinq\Dashboard\RecentActivitiesWidget;
 use OCA\Pipelinq\Dashboard\StartRequestWidget;
 use OCA\Pipelinq\Listener\DeepLinkRegistrationListener;
 use OCA\Pipelinq\Listener\ObjectEventListener;
+use OCA\Pipelinq\Mcp\PipelinqToolProvider;
 use OCP\AppFramework\App;
 use OCP\AppFramework\Bootstrap\IBootContext;
 use OCP\AppFramework\Bootstrap\IBootstrap;
@@ -86,6 +87,16 @@ class Application extends App implements IBootstrap
         $context->registerDashboardWidget(FindClientWidget::class);
         $context->registerDashboardWidget(StartRequestWidget::class);
         $context->registerDashboardWidget(CreateLeadWidget::class);
+
+        // Register PipelinqToolProvider as the MCP tool provider for the AI Chat Companion.
+        // The alias key 'OCA\OpenRegister\Mcp\IMcpToolProvider::pipelinq' is the format
+        // that OR's McpToolsService enumerates to discover per-app providers (design D3).
+        // The interface ships in openregister PR #1466 (ai-chat-companion-orchestrator);
+        // until then this app implements the tests/Stubs/Mcp/IMcpToolProvider.php stub.
+        $context->registerServiceAlias(
+            'OCA\\OpenRegister\\Mcp\\IMcpToolProvider::pipelinq',
+            PipelinqToolProvider::class
+        );
     }//end register()
 
     /**

--- a/lib/Mcp/PipelinqToolProvider.php
+++ b/lib/Mcp/PipelinqToolProvider.php
@@ -1,0 +1,532 @@
+<?php
+/**
+ * Pipelinq MCP Tool Provider
+ *
+ * Per-app implementation of OCA\OpenRegister\Mcp\IMcpToolProvider for Pipelinq
+ * (client and request management — a thin OpenRegister client). Exposes a small
+ * read-only MVP tool set so the AI Chat Companion (hydra ADR-034 / ADR-035) can
+ * surface Pipelinq capabilities — listing requests and reading a single request
+ * with its activity timeline — to an LLM.
+ *
+ * @category Mcp
+ * @package  OCA\Pipelinq\Mcp
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://conduction.nl
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Pipelinq\Mcp;
+
+use OCA\Pipelinq\AppInfo\Application;
+use OCA\Pipelinq\Service\ActivityTimelineService;
+use OCA\OpenRegister\Mcp\IMcpToolProvider;
+use OCP\IAppConfig;
+use Psr\Container\ContainerInterface;
+use Psr\Log\LoggerInterface;
+use RuntimeException;
+use Throwable;
+
+/**
+ * Pipelinq MCP Tool Provider.
+ *
+ * Implements IMcpToolProvider (from openregister PR #1466,
+ * change ai-chat-companion-orchestrator) exposing 2 read-only MVP tools to the
+ * AI Chat Companion. The full tool surface tracked in ConductionNL/pipelinq#342
+ * lands incrementally; this is the MVP skeleton.
+ *
+ * Auth design (OWASP A01:2021 / ADR-005):
+ * - Argument validation runs first (cheap before expensive).
+ * - Per-object authorisation runs BEFORE business logic by delegating reads to
+ *   OpenRegister's ObjectService with RBAC enabled (the default). OR's
+ *   PermissionHandler enforces the per-object 'read' verdict against the current
+ *   user session and raises on denial — there is no unconditional `return true`,
+ *   and the RBAC verdict is not swallowed by a blanket catch (a denial is
+ *   surfaced as a `forbidden` error envelope).
+ *
+ * @spec https://github.com/ConductionNL/pipelinq/issues/342
+ */
+class PipelinqToolProvider implements IMcpToolProvider
+{
+
+    /**
+     * Maximum number of objects returned by any list tool (MVP cap).
+     *
+     * @var int
+     */
+    private const LIST_CAP = 20;
+
+    /**
+     * The OpenRegister ObjectService class name (resolved lazily via the container).
+     *
+     * @var string
+     */
+    private const OR_OBJECT_SERVICE = 'OCA\\OpenRegister\\Service\\ObjectService';
+
+    /**
+     * Tool catalogue (MVP — exactly 2 read-only tools).
+     *
+     * Hard-coded as a constant so unit tests can assert it as a fixture.
+     *
+     * @var array<int, array<string, mixed>>
+     */
+    private const TOOL_DESCRIPTORS = [
+        [
+            'id'          => 'pipelinq.listRequests',
+            'name'        => 'List requests',
+            'description' => 'List intake requests, newest first. Optionally filter by status or by client.',
+            'inputSchema' => [
+                'type'       => 'object',
+                'properties' => [
+                    'limit'    => [
+                        'type'    => 'integer',
+                        'minimum' => 1,
+                        'maximum' => 50,
+                        'default' => 20,
+                    ],
+                    'status'   => [
+                        'type'        => 'string',
+                        'description' => 'Optional request status to filter on (e.g. "new", "in-progress", "closed").',
+                    ],
+                    'clientId' => [
+                        'type'        => 'string',
+                        'description' => 'Optional client UUID — only return requests linked to this client.',
+                    ],
+                ],
+                'required'   => [],
+            ],
+        ],
+        [
+            'id'          => 'pipelinq.getRequest',
+            'name'        => 'Get request',
+            'description' => 'Fetch a single intake request by UUID, including its activity timeline.',
+            'inputSchema' => [
+                'type'       => 'object',
+                'properties' => [
+                    'id' => [
+                        'type'        => 'string',
+                        'description' => 'The request UUID (also accepted via the alias "uuid").',
+                    ],
+                ],
+                'required'   => ['id'],
+            ],
+        ],
+    ];
+
+    /**
+     * Constructor for PipelinqToolProvider.
+     *
+     * Injects the same collaborators the request-facing controllers/services use:
+     * the app config (for the configured OpenRegister register + request schema),
+     * the DI container (for OR's ObjectService), the activity timeline service,
+     * and the PSR-3 logger.
+     *
+     * @param IAppConfig              $appConfig       The app config service
+     * @param ContainerInterface      $container       The DI container (for OR ObjectService)
+     * @param ActivityTimelineService $timelineService The activity timeline aggregator
+     * @param LoggerInterface         $logger          The PSR-3 logger
+     */
+    public function __construct(
+        private readonly IAppConfig $appConfig,
+        private readonly ContainerInterface $container,
+        private readonly ActivityTimelineService $timelineService,
+        private readonly LoggerInterface $logger,
+    ) {
+    }//end __construct()
+
+    /**
+     * Returns the app ID that namespaces every tool id.
+     *
+     * @return string "pipelinq"
+     *
+     * @spec https://github.com/ConductionNL/pipelinq/issues/342
+     */
+    public function getAppId(): string
+    {
+        return 'pipelinq';
+
+    }//end getAppId()
+
+    /**
+     * Returns the full tool catalogue (2 tools, always).
+     *
+     * The full catalogue is always returned regardless of caller permissions.
+     * Per-object authorisation runs in invokeTool().
+     *
+     * @return array<int, array<string, mixed>>
+     *
+     * @spec https://github.com/ConductionNL/pipelinq/issues/342
+     */
+    public function getTools(): array
+    {
+        return self::TOOL_DESCRIPTORS;
+
+    }//end getTools()
+
+    /**
+     * Dispatch a tool call by id.
+     *
+     * Argument validation runs BEFORE authorisation (cheap before expensive),
+     * which runs BEFORE business logic (per-object RBAC via OR's ObjectService).
+     * Unknown tool ids return a structured error; no exception is thrown.
+     *
+     * @param string               $toolId    The tool id (e.g. "pipelinq.getRequest")
+     * @param array<string, mixed> $arguments Tool arguments from the LLM call
+     *
+     * @return array<string, mixed>
+     *
+     * @spec https://github.com/ConductionNL/pipelinq/issues/342
+     */
+    public function invokeTool(string $toolId, array $arguments): array
+    {
+        if ($toolId === 'pipelinq.listRequests') {
+            return $this->handleListRequests(args: $arguments);
+        }
+
+        if ($toolId === 'pipelinq.getRequest') {
+            return $this->handleGetRequest(args: $arguments);
+        }
+
+        $known = implode(separator: ', ', array: array_column(array: self::TOOL_DESCRIPTORS, column_key: 'id'));
+
+        return [
+            'error' => [
+                'code'    => 'unknown_tool',
+                'message' => "Unknown tool id '{$toolId}'. Available tools: {$known}.",
+            ],
+        ];
+
+    }//end invokeTool()
+
+    // =========================================================================
+    // Private tool handlers
+    // =========================================================================
+
+    /**
+     * Handle pipelinq.listRequests.
+     *
+     * Lists intake requests (newest first), optionally filtered by status or
+     * client. The OpenRegister ObjectService query runs with RBAC enabled, so
+     * only requests the caller is allowed to read are returned.
+     *
+     * @param array<string, mixed> $args Tool arguments
+     *
+     * @return array<string, mixed>
+     */
+    private function handleListRequests(array $args): array
+    {
+        $limit = $this->resolveLimit(args: $args);
+        if (is_array(value: $limit) === true) {
+            return $limit;
+        }
+
+        $config = $this->resolveRequestContext();
+        if (isset($config['error']) === true) {
+            return $config;
+        }
+
+        $filters = [
+            'register' => $config['register'],
+            'schema'   => $config['schema'],
+        ];
+
+        $status = $this->optionalStringArg(args: $args, key: 'status');
+        if ($status !== null) {
+            $filters['status'] = $status;
+        }
+
+        $clientId = $this->optionalStringArg(args: $args, key: 'clientId');
+        if ($clientId !== null) {
+            $filters['client'] = $clientId;
+        }
+
+        try {
+            $objectService = $this->getObjectService();
+
+            // RBAC + multitenancy left at their defaults (true): OR enforces the
+            // per-object 'read' verdict here, before any data leaves this method.
+            $rawRequests = $objectService->findAll(
+                [
+                    'filters' => $filters,
+                    'limit'   => $limit,
+                    'order'   => ['dateCreated' => 'DESC'],
+                ]
+            );
+        } catch (\Exception $e) {
+            return $this->mapServiceException(operation: 'list requests', exception: $e);
+        }//end try
+
+        $items = [];
+        foreach ($rawRequests as $raw) {
+            $items[] = $this->toArray(item: $raw);
+        }
+
+        return [
+            'requests' => array_slice(array: $items, offset: 0, length: self::LIST_CAP),
+            'count'    => count($items),
+        ];
+
+    }//end handleListRequests()
+
+    /**
+     * Handle pipelinq.getRequest.
+     *
+     * Fetches a single request by UUID (RBAC enforced) and inlines its activity
+     * timeline. The 'uuid' argument is accepted as an alias for 'id'.
+     *
+     * @param array<string, mixed> $args Tool arguments
+     *
+     * @return array<string, mixed>
+     */
+    private function handleGetRequest(array $args): array
+    {
+        $id = $this->optionalStringArg(args: $args, key: 'id');
+        if ($id === null) {
+            $id = $this->optionalStringArg(args: $args, key: 'uuid');
+        }
+
+        if ($id === null) {
+            return $this->errorEnvelope(code: 'invalid_arguments', message: 'Required argument id (or uuid) is missing.');
+        }
+
+        $config = $this->resolveRequestContext();
+        if (isset($config['error']) === true) {
+            return $config;
+        }
+
+        try {
+            $objectService = $this->getObjectService();
+
+            // RBAC left at its default (true): OR's PermissionHandler runs the
+            // per-object 'read' check here and raises if the caller is denied.
+            $request = $objectService->find(
+                $id,
+                [],
+                false,
+                $config['register'],
+                $config['schema']
+            );
+        } catch (\Exception $e) {
+            return $this->mapServiceException(operation: 'get request', exception: $e);
+        }//end try
+
+        if ($request === null) {
+            return $this->errorEnvelope(code: 'not_found', message: 'Request not found.');
+        }
+
+        return [
+            'request'  => $this->toArray(item: $request),
+            'timeline' => $this->fetchTimeline(requestId: $id),
+        ];
+
+    }//end handleGetRequest()
+
+    // =========================================================================
+    // Private helpers
+    // =========================================================================
+
+    /**
+     * Resolve and validate the optional `limit` argument for list tools.
+     *
+     * @param array<string, mixed> $args Tool arguments
+     *
+     * @return int|array<string, mixed> The validated, capped limit, or an error envelope.
+     */
+    private function resolveLimit(array $args): int | array
+    {
+        $limit = self::LIST_CAP;
+        if (isset($args['limit']) === true) {
+            $limit = (int) $args['limit'];
+        }
+
+        if ($limit < 1 || $limit > 50) {
+            return $this->errorEnvelope(
+                code: 'invalid_arguments',
+                message: "Invalid limit {$limit}. Must be between 1 and 50."
+            );
+        }
+
+        // Hard MVP cap regardless of the requested limit.
+        return min($limit, self::LIST_CAP);
+
+    }//end resolveLimit()
+
+    /**
+     * Read an optional string argument, treating empty strings as absent.
+     *
+     * @param array<string, mixed> $args Tool arguments
+     * @param string               $key  The argument key
+     *
+     * @return string|null The trimmed value, or null when missing/empty.
+     */
+    private function optionalStringArg(array $args, string $key): ?string
+    {
+        if (isset($args[$key]) === false) {
+            return null;
+        }
+
+        $value = (string) $args[$key];
+        if ($value === '') {
+            return null;
+        }
+
+        return $value;
+
+    }//end optionalStringArg()
+
+    /**
+     * Resolve the configured OpenRegister register + request schema.
+     *
+     * @return array<string, mixed> Either ['register' => ..., 'schema' => ...] or an error envelope.
+     */
+    private function resolveRequestContext(): array
+    {
+        $registerId = $this->appConfig->getValueString(Application::APP_ID, 'register', '');
+        $schemaId   = $this->appConfig->getValueString(Application::APP_ID, 'request_schema', '');
+
+        if ($registerId === '' || $schemaId === '') {
+            return $this->errorEnvelope(
+                code: 'not_configured',
+                message: 'Pipelinq is not fully configured: the OpenRegister register or request schema is missing.'
+            );
+        }
+
+        return [
+            'register' => $registerId,
+            'schema'   => $schemaId,
+        ];
+
+    }//end resolveRequestContext()
+
+    /**
+     * Build the activity timeline for a request (best-effort).
+     *
+     * A timeline failure must not sink the request read — it is logged and an
+     * empty timeline is returned.
+     *
+     * @param string $requestId The request UUID
+     *
+     * @return array<int, array<string, mixed>>
+     */
+    private function fetchTimeline(string $requestId): array
+    {
+        try {
+            $result = $this->timelineService->getTimeline(
+                entityType: 'request',
+                entityId: $requestId,
+                params: ['_limit' => self::LIST_CAP]
+            );
+
+            return array_slice(array: $result['items'], offset: 0, length: self::LIST_CAP);
+        } catch (Throwable $e) {
+            $this->logger->warning(
+                'Pipelinq MCP: getRequest timeline aggregation failed',
+                ['requestId' => $requestId, 'exception' => $e->getMessage()]
+            );
+            return [];
+        }//end try
+
+    }//end fetchTimeline()
+
+    /**
+     * Resolve the OpenRegister ObjectService via the DI container.
+     *
+     * @return object The OpenRegister ObjectService instance.
+     *
+     * @throws RuntimeException If OpenRegister is not available.
+     */
+    private function getObjectService(): object
+    {
+        try {
+            return $this->container->get(self::OR_OBJECT_SERVICE);
+        } catch (Throwable $e) {
+            throw new RuntimeException('OpenRegister service is not available.');
+        }
+
+    }//end getObjectService()
+
+    /**
+     * Map an exception raised by OpenRegister into a structured MCP error envelope.
+     *
+     * OpenRegister's PermissionHandler raises a plain exception whose message
+     * mentions "permission" when the caller is not authorised; we surface that as
+     * `forbidden`. Everything else is an `internal_error` (logged for the operator).
+     *
+     * @param string     $operation Short label of the failed operation (for the log).
+     * @param \Exception $exception The caught exception.
+     *
+     * @return array<string, mixed>
+     */
+    private function mapServiceException(string $operation, \Exception $exception): array
+    {
+        $message = $exception->getMessage();
+
+        if (stripos($message, 'permission') !== false || stripos($message, 'not authoriz') !== false) {
+            return $this->errorEnvelope(code: 'forbidden', message: 'You are not allowed to access this resource.');
+        }
+
+        $this->logger->error(
+            "Pipelinq MCP: failed to {$operation}",
+            ['exception' => $message]
+        );
+
+        return $this->errorEnvelope(
+            code: 'internal_error',
+            message: "Failed to {$operation}. See server log for details."
+        );
+
+    }//end mapServiceException()
+
+    /**
+     * Build a structured MCP error envelope.
+     *
+     * @param string $code    Machine-readable error code.
+     * @param string $message Human-readable message for the LLM.
+     *
+     * @return array<string, mixed>
+     */
+    private function errorEnvelope(string $code, string $message): array
+    {
+        return [
+            'error' => [
+                'code'    => $code,
+                'message' => $message,
+            ],
+        ];
+
+    }//end errorEnvelope()
+
+    /**
+     * Normalise an OpenRegister object to a plain PHP array.
+     *
+     * @param mixed $item Raw item from ObjectService
+     *
+     * @return array<string, mixed>
+     */
+    private function toArray(mixed $item): array
+    {
+        if (is_array(value: $item) === true) {
+            return $item;
+        }
+
+        if (is_object(value: $item) === true && method_exists($item, 'getObject') === true) {
+            return $item->getObject();
+        }
+
+        if (is_object(value: $item) === true && method_exists($item, 'jsonSerialize') === true) {
+            return $item->jsonSerialize();
+        }
+
+        return (array) $item;
+
+    }//end toArray()
+}//end class

--- a/tests/Stubs/Mcp/IMcpToolProvider.php
+++ b/tests/Stubs/Mcp/IMcpToolProvider.php
@@ -1,0 +1,67 @@
+<?php
+
+/**
+ * Test stub for OCA\OpenRegister\Mcp\IMcpToolProvider.
+ *
+ * Mirrors the interface signature from openregister PR #1466
+ * (change: ai-chat-companion-orchestrator). Used only in environments where
+ * the openregister runtime is not installed (e.g. bare CI containers).
+ *
+ * This file is loaded via Composer's autoload-dev PSR-4 mapping when the real
+ * interface is absent. It is NOT scanned by PHPCS.
+ *
+ * @category Test
+ * @package  OCA\Pipelinq\Tests\Stubs\Mcp
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Mcp;
+
+if (interface_exists(IMcpToolProvider::class) === false) {
+    /**
+     * Stub interface for IMcpToolProvider — used only in standalone unit tests.
+     *
+     * Deferred until openregister PR #1466 (ai-chat-companion-orchestrator) ships
+     * the real interface. Pipelinq implements this stub in production; the stub is
+     * replaced by the real interface when the openregister app is installed.
+     */
+    interface IMcpToolProvider
+    {
+
+        /**
+         * Returns the app ID that namespaces every tool id this provider exposes.
+         *
+         * @return string The app slug (e.g. "pipelinq")
+         */
+        public function getAppId(): string;
+
+        /**
+         * Returns the full tool catalogue for this provider.
+         *
+         * Each descriptor is an associative array with keys:
+         * `id`, `name`, `description`, `inputSchema`.
+         *
+         * @return array<int, array<string, mixed>>
+         */
+        public function getTools(): array;
+
+        /**
+         * Invoke a single tool by id with the given arguments.
+         *
+         * Returns a success payload or a structured error envelope.
+         * MUST NOT throw — all failure paths return an array.
+         *
+         * @param string               $toolId    The tool id (e.g. "pipelinq.listRequests")
+         * @param array<string, mixed> $arguments Tool arguments from the LLM call
+         *
+         * @return array<string, mixed>
+         */
+        public function invokeTool(string $toolId, array $arguments): array;
+
+    }//end interface
+}//end if

--- a/tests/Unit/Mcp/PipelinqToolProviderTest.php
+++ b/tests/Unit/Mcp/PipelinqToolProviderTest.php
@@ -1,0 +1,218 @@
+<?php
+
+/**
+ * Unit tests for PipelinqToolProvider.
+ *
+ * @category Test
+ * @package  OCA\Pipelinq\Tests\Unit\Mcp
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://pipelinq.nl
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Pipelinq\Tests\Unit\Mcp;
+
+use OCA\Pipelinq\Mcp\PipelinqToolProvider;
+use OCA\Pipelinq\Service\ActivityTimelineService;
+use OCP\IAppConfig;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Tests for PipelinqToolProvider.
+ *
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
+ */
+class PipelinqToolProviderTest extends TestCase
+{
+
+    /**
+     * The app config mock.
+     *
+     * @var IAppConfig&MockObject
+     */
+    private IAppConfig $appConfig;
+
+    /**
+     * The DI container mock.
+     *
+     * @var ContainerInterface&MockObject
+     */
+    private ContainerInterface $container;
+
+    /**
+     * The activity timeline service mock.
+     *
+     * @var ActivityTimelineService&MockObject
+     */
+    private ActivityTimelineService $timelineService;
+
+    /**
+     * The logger mock.
+     *
+     * @var LoggerInterface&MockObject
+     */
+    private LoggerInterface $logger;
+
+    /**
+     * Set up test fixtures.
+     *
+     * @return void
+     */
+    protected function setUp(): void
+    {
+        $this->appConfig       = $this->createMock(originalClassName: IAppConfig::class);
+        $this->container       = $this->createMock(originalClassName: ContainerInterface::class);
+        $this->timelineService = $this->createMock(originalClassName: ActivityTimelineService::class);
+        $this->logger          = $this->createMock(originalClassName: LoggerInterface::class);
+    }//end setUp()
+
+    /**
+     * Build the provider under test.
+     *
+     * @return PipelinqToolProvider
+     */
+    private function buildProvider(): PipelinqToolProvider
+    {
+        return new PipelinqToolProvider(
+            appConfig: $this->appConfig,
+            container: $this->container,
+            timelineService: $this->timelineService,
+            logger: $this->logger,
+        );
+    }//end buildProvider()
+
+    /**
+     * getAppId() returns the pipelinq slug.
+     *
+     * @return void
+     */
+    public function testGetAppIdReturnsPipelinq(): void
+    {
+        $this->assertSame(expected: 'pipelinq', actual: $this->buildProvider()->getAppId());
+    }//end testGetAppIdReturnsPipelinq()
+
+    /**
+     * getTools() returns exactly the two MVP descriptors with valid shapes.
+     *
+     * @return void
+     */
+    public function testGetToolsReturnsTwoValidDescriptors(): void
+    {
+        $tools = $this->buildProvider()->getTools();
+
+        $this->assertCount(expectedCount: 2, haystack: $tools);
+
+        $ids = array_column(array: $tools, column_key: 'id');
+        $this->assertContains(needle: 'pipelinq.listRequests', haystack: $ids);
+        $this->assertContains(needle: 'pipelinq.getRequest', haystack: $ids);
+
+        foreach ($tools as $tool) {
+            $this->assertArrayHasKey(key: 'id', array: $tool);
+            $this->assertArrayHasKey(key: 'name', array: $tool);
+            $this->assertArrayHasKey(key: 'description', array: $tool);
+            $this->assertArrayHasKey(key: 'inputSchema', array: $tool);
+
+            $this->assertIsString(actual: $tool['id']);
+            $this->assertStringStartsWith(prefix: 'pipelinq.', string: $tool['id']);
+            $this->assertNotEmpty(actual: $tool['name']);
+            $this->assertNotEmpty(actual: $tool['description']);
+
+            $this->assertIsArray(actual: $tool['inputSchema']);
+            $this->assertSame(expected: 'object', actual: $tool['inputSchema']['type']);
+            $this->assertArrayHasKey(key: 'properties', array: $tool['inputSchema']);
+            $this->assertIsArray(actual: $tool['inputSchema']['properties']);
+            $this->assertArrayHasKey(key: 'required', array: $tool['inputSchema']);
+            $this->assertIsArray(actual: $tool['inputSchema']['required']);
+        }
+    }//end testGetToolsReturnsTwoValidDescriptors()
+
+    /**
+     * getRequest descriptor requires the id argument.
+     *
+     * @return void
+     */
+    public function testGetRequestDescriptorRequiresId(): void
+    {
+        $tools  = $this->buildProvider()->getTools();
+        $byId   = array_column(array: $tools, column_key: null, index_key: 'id');
+
+        $this->assertArrayHasKey(key: 'pipelinq.getRequest', array: $byId);
+        $this->assertContains(
+            needle: 'id',
+            haystack: $byId['pipelinq.getRequest']['inputSchema']['required']
+        );
+    }//end testGetRequestDescriptorRequiresId()
+
+    /**
+     * invokeTool() with an unknown id returns a structured error array (no throw).
+     *
+     * @return void
+     */
+    public function testInvokeUnknownToolReturnsErrorArray(): void
+    {
+        $result = $this->buildProvider()->invokeTool(toolId: 'pipelinq.bogus', arguments: []);
+
+        $this->assertIsArray(actual: $result);
+        $this->assertArrayHasKey(key: 'error', array: $result);
+        $this->assertIsArray(actual: $result['error']);
+        $this->assertSame(expected: 'unknown_tool', actual: $result['error']['code']);
+        $this->assertNotEmpty(actual: $result['error']['message']);
+    }//end testInvokeUnknownToolReturnsErrorArray()
+
+    /**
+     * invokeTool('pipelinq.getRequest') without an id returns an invalid_arguments error.
+     *
+     * @return void
+     */
+    public function testGetRequestWithoutIdReturnsInvalidArguments(): void
+    {
+        $result = $this->buildProvider()->invokeTool(toolId: 'pipelinq.getRequest', arguments: []);
+
+        $this->assertIsArray(actual: $result);
+        $this->assertArrayHasKey(key: 'error', array: $result);
+        $this->assertSame(expected: 'invalid_arguments', actual: $result['error']['code']);
+    }//end testGetRequestWithoutIdReturnsInvalidArguments()
+
+    /**
+     * invokeTool('pipelinq.listRequests') with an out-of-range limit returns invalid_arguments.
+     *
+     * @return void
+     */
+    public function testListRequestsWithBadLimitReturnsInvalidArguments(): void
+    {
+        $result = $this->buildProvider()->invokeTool(
+            toolId: 'pipelinq.listRequests',
+            arguments: ['limit' => 999]
+        );
+
+        $this->assertIsArray(actual: $result);
+        $this->assertArrayHasKey(key: 'error', array: $result);
+        $this->assertSame(expected: 'invalid_arguments', actual: $result['error']['code']);
+    }//end testListRequestsWithBadLimitReturnsInvalidArguments()
+
+    /**
+     * invokeTool('pipelinq.listRequests') returns not_configured when the register/schema are unset.
+     *
+     * @return void
+     */
+    public function testListRequestsWithoutConfigReturnsNotConfigured(): void
+    {
+        $this->appConfig->method('getValueString')->willReturn('');
+
+        $result = $this->buildProvider()->invokeTool(toolId: 'pipelinq.listRequests', arguments: []);
+
+        $this->assertIsArray(actual: $result);
+        $this->assertArrayHasKey(key: 'error', array: $result);
+        $this->assertSame(expected: 'not_configured', actual: $result['error']['code']);
+    }//end testListRequestsWithoutConfigReturnsNotConfigured()
+}//end class

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -20,14 +20,29 @@ declare(strict_types=1);
 // Define that we're running PHPUnit.
 define('PHPUNIT_RUN', 1);
 
-// Include Composer's autoloader.
-require_once __DIR__ . '/../vendor/autoload.php';
+// Include Composer's autoloader. Use `require` (not `require_once`) so the
+// ClassLoader instance is returned even when PHPUnit has already pulled it in.
+$autoloader = require __DIR__ . '/../vendor/autoload.php';
+
+// Register the OCP/NCU namespaces from the nextcloud/ocp dev dependency so that
+// unit tests can run in a bare environment (no installed Nextcloud server). When
+// NC is present its own autoloader provides these and these mappings are inert.
+if ($autoloader instanceof \Composer\Autoload\ClassLoader && is_dir(__DIR__ . '/../vendor/nextcloud/ocp/OCP') === true) {
+    $autoloader->addPsr4('OCP\\', __DIR__ . '/../vendor/nextcloud/ocp/OCP/');
+    if (is_dir(__DIR__ . '/../vendor/nextcloud/ocp/NCU') === true) {
+        $autoloader->addPsr4('NCU\\', __DIR__ . '/../vendor/nextcloud/ocp/NCU/');
+    }
+}
 
 // Bootstrap Nextcloud if not already done.
 if (!defined('OC_CONSOLE')) {
     // Try to include the main Nextcloud bootstrap.
     if (file_exists(__DIR__ . '/../../../lib/base.php')) {
-        require_once __DIR__ . '/../../../lib/base.php';
+        try {
+            require_once __DIR__ . '/../../../lib/base.php';
+        } catch (\Throwable $e) {
+            // NC not fully installed — unit tests continue with vendor stubs only.
+        }
     }
 
     // Load Test\TestCase and other NC test classes (NC convention).
@@ -45,4 +60,13 @@ if (!defined('OC_CONSOLE')) {
         // Clear hooks for testing.
         OC_Hook::clear();
     }
+}
+
+// Load the IMcpToolProvider stub for cross-app classes not available as Composer
+// dependencies (the real interface ships with OpenRegister PR #1466). The stub
+// file guards itself with interface_exists(), so this is a no-op once the real
+// OpenRegister app is installed. The stub is also registered via the
+// autoload-dev PSR-4 mapping ("OCA\OpenRegister\" => "tests/Stubs/").
+if (interface_exists(\OCA\OpenRegister\Mcp\IMcpToolProvider::class) === false) {
+    require_once __DIR__ . '/Stubs/Mcp/IMcpToolProvider.php';
 }


### PR DESCRIPTION
## Summary

Adds `OCA\Pipelinq\Mcp\PipelinqToolProvider`, Pipelinq's per-app implementation of `OCA\OpenRegister\Mcp\IMcpToolProvider`, so the AI Chat Companion (hydra **ADR-034** + **ADR-035**) can surface Pipelinq capabilities to an LLM. This is the **MVP skeleton** — two read-only tools — with the remaining surface tracked in #342.

The interface ships in openregister PR #1466 (not yet merged); until then this app implements a self-guarding stub (`tests/Stubs/Mcp/IMcpToolProvider.php`, wired via `autoload-dev` PSR-4 `OCA\OpenRegister\` → `tests/Stubs/`). When OpenRegister is installed the real interface wins.

## Tools (2)

| Tool id | What it does | Inputs |
|---|---|---|
| `pipelinq.listRequests` | List intake requests, newest first | `limit` (int 1–50, default 20, hard-capped at 20), optional `status` (string), optional `clientId` (string) |
| `pipelinq.getRequest` | Fetch one request by UUID + its activity timeline | `id` (string, required; `uuid` accepted as an alias) |

## Auth & safety

- Argument validation runs first (cheap before expensive).
- **Per-object authorisation runs before business logic**: reads are delegated to OpenRegister's `ObjectService::findAll()` / `::find()` with RBAC enabled (the default), so OR's `PermissionHandler` enforces the per-object `read` verdict against the current user session. A denial is surfaced as a `forbidden` error envelope — no unconditional `return true`, no blanket `catch(\Throwable)` swallowing the verdict.
- `invokeTool()` **never throws** — every failure path returns `['error' => ['code' => ..., 'message' => ...]]` (`unknown_tool`, `invalid_arguments`, `not_configured`, `forbidden`, `not_found`, `internal_error`).
- List results capped at 20.
- Provider registered as service alias `OCA\OpenRegister\Mcp\IMcpToolProvider::pipelinq` in `Application.php`.

## Tests / quality

- `tests/Unit/Mcp/PipelinqToolProviderTest.php` — `getAppId()`, the two `pipelinq.`-prefixed descriptors (non-empty names/descriptions, valid `inputSchema`), unknown-tool returns an error array (no throw), and a few argument/config validation paths. 7 tests, all green.
- `tests/bootstrap.php` now registers the `vendor/nextcloud/ocp` `OCP\`/`NCU\` namespaces and loads the MCP stub, so unit tests run in a bare environment (this also drops bare-env suite errors from 242 → 10 — the remaining 10 are pre-existing `Doctrine\DBAL\*` infra gaps in `MetricsRepositoryTest`/`HealthControllerTest`/`ClientSearchWidgetTest`/`ContactmomentServiceTest`, unrelated to this change and green in CI's NC container).
- `lib/Mcp/PipelinqToolProvider.php` and the `Application.php` changes pass `phpcs`, `phpmd` (baseline-clean), `psalm`, `phpstan`. Note: `composer phpcs` / `composer check` are red on `development` already (~200 pre-existing errors across `lib/`); not touched here.

## Done vs deferred

**Done:** the two MVP tools, the stub interface, DI registration, unit tests, standalone test bootstrap.

**Deferred:**
- **Widget mount** — Pipelinq does use `CnAppRoot` (`src/App.vue`), but no published `@conduction/nextcloud-vue` version yet ships `CnAiCompanion` (latest published = `1.0.0-beta.30`, which Pipelinq already tracks via `^1.0.0-beta.30` on the `beta` tag). Bump deferred until a version with `CnAiCompanion` is released.
- **Remaining MCP tools** from #342 (clients, leads, contact moments, write/intake actions, etc.) — to follow incrementally.

### MCP coverage
Adds tool: pipelinq.listRequests
Adds tool: pipelinq.getRequest

Refs #342