### PR TITLE
feat: adopt the Features & Roadmap menu

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
 			"version": "0.1.0",
 			"license": "EUPL-1.2",
 			"dependencies": {
-				"@conduction/nextcloud-vue": "^1.0.0-beta.30",
+				"@conduction/nextcloud-vue": "^1.0.0-beta.35",
 				"@nextcloud/axios": "~2.5.2",
 				"@nextcloud/dialogs": "^3.2.0",
 				"@nextcloud/initial-state": "^2.2.0",
@@ -1795,9 +1795,9 @@
 			}
 		},
 		"node_modules/@conduction/nextcloud-vue": {
-			"version": "1.0.0-beta.30",
-			"resolved": "https://registry.npmjs.org/@conduction/nextcloud-vue/-/nextcloud-vue-1.0.0-beta.30.tgz",
-			"integrity": "sha512-VrynA0mukFikJt4Ey9a3r42GqvdtUF5PeOaqs8SKrPmkPwfySQnIHgdzETer3w1Nm1rcVlnWCHWFmAXFXZROzw==",
+			"version": "1.0.0-beta.35",
+			"resolved": "https://registry.npmjs.org/@conduction/nextcloud-vue/-/nextcloud-vue-1.0.0-beta.35.tgz",
+			"integrity": "sha512-T80Y6z+m/ni2z1yCNVrXAjzacv2WdXFNQcfZYfXHHmtCbJOjdFWLwALZ/WCrGO1FQIQMnjq01G0gBdMXXKQimg==",
 			"license": "EUPL-1.2",
 			"dependencies": {
 				"@codemirror/autocomplete": "^6.0.0",
@@ -1810,12 +1810,14 @@
 				"@codemirror/search": "^6.0.0",
 				"@codemirror/state": "^6.0.0",
 				"@codemirror/view": "^6.0.0",
+				"@microsoft/fetch-event-source": "^2.0.1",
 				"@nextcloud/dialogs": "^7.3.0",
 				"@nextcloud/notify_push": "^1.0.0",
 				"@uiw/codemirror-theme-github": "^4.25.8",
 				"@vueuse/core": "^10.0.0",
 				"apexcharts": "^4.7.0",
 				"codemirror": "^6.0.0",
+				"dompurify": "^3.0.0",
 				"gridstack": "^10.3.1",
 				"leaflet": "^1.9.0",
 				"lodash": "^4.17.21",
@@ -1827,6 +1829,7 @@
 				"vue-template-compiler": "^2.7.16"
 			},
 			"peerDependencies": {
+				"@nextcloud/auth": "^2.0.0 || ^3.0.0",
 				"@nextcloud/axios": "^2.0.0",
 				"@nextcloud/capabilities": "^1.2.1",
 				"@nextcloud/l10n": "^2.0.0 || ^3.0.0",
@@ -3249,6 +3252,12 @@
 			"resolved": "https://registry.npmjs.org/@mdi/js/-/js-7.4.47.tgz",
 			"integrity": "sha512-KPnNOtm5i2pMabqZxpUz7iQf+mfrYZyKCZ8QNz85czgEt7cuHcGorWfdzUMWYA0SD+a6Hn4FmJ+YhzzzjkTZrQ==",
 			"license": "Apache-2.0"
+		},
+		"node_modules/@microsoft/fetch-event-source": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/@microsoft/fetch-event-source/-/fetch-event-source-2.0.1.tgz",
+			"integrity": "sha512-W6CLUJ2eBMw3Rec70qrsEW0jOm/3twwJv21mrmj2yORiaVmVYGS4sSS5yUwvQc1ZlDLYGPnClVWmUUMagKNsfA==",
+			"license": "MIT"
 		},
 		"node_modules/@napi-rs/wasm-runtime": {
 			"version": "0.2.12",
@@ -4843,9 +4852,6 @@
 				"arm64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -4860,9 +4866,6 @@
 				"arm64"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -4877,9 +4880,6 @@
 				"ppc64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -4894,9 +4894,6 @@
 				"riscv64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -4911,9 +4908,6 @@
 				"riscv64"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -4928,9 +4922,6 @@
 				"s390x"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -4945,9 +4936,6 @@
 				"x64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -4962,9 +4950,6 @@
 				"x64"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -18419,9 +18404,9 @@
 			}
 		},
 		"@conduction/nextcloud-vue": {
-			"version": "1.0.0-beta.30",
-			"resolved": "https://registry.npmjs.org/@conduction/nextcloud-vue/-/nextcloud-vue-1.0.0-beta.30.tgz",
-			"integrity": "sha512-VrynA0mukFikJt4Ey9a3r42GqvdtUF5PeOaqs8SKrPmkPwfySQnIHgdzETer3w1Nm1rcVlnWCHWFmAXFXZROzw==",
+			"version": "1.0.0-beta.35",
+			"resolved": "https://registry.npmjs.org/@conduction/nextcloud-vue/-/nextcloud-vue-1.0.0-beta.35.tgz",
+			"integrity": "sha512-T80Y6z+m/ni2z1yCNVrXAjzacv2WdXFNQcfZYfXHHmtCbJOjdFWLwALZ/WCrGO1FQIQMnjq01G0gBdMXXKQimg==",
 			"requires": {
 				"@codemirror/autocomplete": "^6.0.0",
 				"@codemirror/commands": "^6.0.0",
@@ -18433,12 +18418,14 @@
 				"@codemirror/search": "^6.0.0",
 				"@codemirror/state": "^6.0.0",
 				"@codemirror/view": "^6.0.0",
+				"@microsoft/fetch-event-source": "^2.0.1",
 				"@nextcloud/dialogs": "^7.3.0",
 				"@nextcloud/notify_push": "^1.0.0",
 				"@uiw/codemirror-theme-github": "^4.25.8",
 				"@vueuse/core": "^10.0.0",
 				"apexcharts": "^4.7.0",
 				"codemirror": "^6.0.0",
+				"dompurify": "^3.0.0",
 				"gridstack": "^10.3.1",
 				"leaflet": "^1.9.0",
 				"lodash": "^4.17.21",
@@ -19384,6 +19371,11 @@
 			"version": "7.4.47",
 			"resolved": "https://registry.npmjs.org/@mdi/js/-/js-7.4.47.tgz",
 			"integrity": "sha512-KPnNOtm5i2pMabqZxpUz7iQf+mfrYZyKCZ8QNz85czgEt7cuHcGorWfdzUMWYA0SD+a6Hn4FmJ+YhzzzjkTZrQ=="
+		},
+		"@microsoft/fetch-event-source": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/@microsoft/fetch-event-source/-/fetch-event-source-2.0.1.tgz",
+			"integrity": "sha512-W6CLUJ2eBMw3Rec70qrsEW0jOm/3twwJv21mrmj2yORiaVmVYGS4sSS5yUwvQc1ZlDLYGPnClVWmUUMagKNsfA=="
 		},
 		"@napi-rs/wasm-runtime": {
 			"version": "0.2.12",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
 		"extends @nextcloud/browserslist-config"
 	],
 	"dependencies": {
-		"@conduction/nextcloud-vue": "^1.0.0-beta.30",
+		"@conduction/nextcloud-vue": "^1.0.0-beta.35",
 		"@nextcloud/axios": "~2.5.2",
 		"@nextcloud/dialogs": "^3.2.0",
 		"@nextcloud/initial-state": "^2.2.0",

--- a/src/customComponents.js
+++ b/src/customComponents.js
@@ -61,6 +61,11 @@ import AgentPerformanceView from './views/rapportage/AgentPerformance.vue'
 import PipelineManagerView from './views/settings/PipelineManager.vue'
 import SyncSettingsView from './views/sync/SyncSettings.vue'
 
+// --- Features & Roadmap page — thin wrapper around the lib's
+//     CnFeaturesAndRoadmapView (in-product roadmap surface powered by
+//     OpenRegister's github-issue-proxy). See ConductionNL/hydra#251. ---
+import FeaturesRoadmapView from './views/FeaturesRoadmap.vue'
+
 export default {
 	// Genuine exceptions
 	DashboardView,
@@ -104,4 +109,7 @@ export default {
 	// Admin managers
 	PipelineManagerView,
 	SyncSettingsView,
+
+	// Features & Roadmap page (lib's CnFeaturesAndRoadmapView)
+	FeaturesRoadmap: FeaturesRoadmapView,
 }

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -21,7 +21,8 @@
 		{ "id": "Documentation", "label": "Documentation", "icon": "icon-info", "href": "https://conduction.gitbook.io/pipelinq-nextcloud", "order": 160 },
 		{ "id": "Pipelines", "label": "Pipelines", "icon": "icon-category-organization", "route": "Pipelines", "section": "settings", "order": 200 },
 		{ "id": "Forms", "label": "Forms", "icon": "icon-file", "route": "Forms", "section": "settings", "order": 210 },
-		{ "id": "Automations", "label": "Automations", "icon": "icon-play", "route": "Automations", "section": "settings", "order": 220 }
+		{ "id": "Automations", "label": "Automations", "icon": "icon-play", "route": "Automations", "section": "settings", "order": 220 },
+		{ "id": "FeaturesRoadmapMenu", "label": "Features & roadmap", "icon": "icon-toggle", "route": "FeaturesRoadmap", "section": "settings", "order": 230 }
 	],
 	"pages": [
 		{
@@ -460,6 +461,13 @@
 			"type": "custom",
 			"title": "Automation history",
 			"component": "AutomationHistoryView"
+		},
+		{
+			"id": "FeaturesRoadmap",
+			"route": "/features-roadmap",
+			"type": "custom",
+			"title": "Features & roadmap",
+			"component": "FeaturesRoadmap"
 		}
 	]
 }

--- a/src/views/FeaturesRoadmap.vue
+++ b/src/views/FeaturesRoadmap.vue
@@ -1,0 +1,38 @@
+<template>
+	<CnFeaturesAndRoadmapView
+		:repo="repo"
+		:features="features"
+		:disabled="disabled" />
+</template>
+
+<script>
+// SPDX-License-Identifier: EUPL-1.2
+// Copyright (C) 2026 Conduction B.V.
+//
+// Features & Roadmap page — thin wrapper around `CnFeaturesAndRoadmapView`
+// from `@conduction/nextcloud-vue`. Mounted as the manifest `custom` page
+// `FeaturesRoadmap` (route `/features-roadmap`, surfaced from the Settings
+// section of the nav). `repo` / `features` / `disabled` come from
+// server-provided initial state when available, with sensible fallbacks so
+// the page is usable without backend wiring (the roadmap proxy and the
+// `openregister::features_roadmap_enabled` flag live on OpenRegister).
+
+import { CnFeaturesAndRoadmapView } from '@conduction/nextcloud-vue'
+import { loadState } from '@nextcloud/initial-state'
+
+export default {
+	name: 'FeaturesRoadmap',
+
+	components: {
+		CnFeaturesAndRoadmapView,
+	},
+
+	data() {
+		return {
+			repo: loadState('pipelinq', 'features_roadmap_repo', 'ConductionNL/pipelinq'),
+			features: loadState('pipelinq', 'features_roadmap_features', []),
+			disabled: loadState('pipelinq', 'features_roadmap_disabled', false),
+		}
+	},
+}
+</script>


### PR DESCRIPTION
## Summary

Adopts the Features & Roadmap menu in pipelinq — the in-product two-tab page (Features manifest + GitHub roadmap, with the in-context Suggest action) powered by OpenRegister's `github-issue-proxy` and `@conduction/nextcloud-vue`'s `Cn*` roadmap component family. Part of the org-wide rollout (ConductionNL/hydra#251); mirrors the procest adoption (ConductionNL/procest#422).

pipelinq is manifest-driven (`CnAppRoot` + `manifest.json`), so the adoption is wired through the manifest:

- `src/views/FeaturesRoadmap.vue` — thin wrapper around `CnFeaturesAndRoadmapView`; `repo` (`'ConductionNL/pipelinq'`) / `features` (`[]`) / `disabled` (`false`) come from `loadState('pipelinq', 'features_roadmap_*', …)` with those fallbacks.
- `src/customComponents.js` — registers it as the `FeaturesRoadmap` custom component.
- `src/manifest.json` — adds the `FeaturesRoadmap` `type:"custom"` page (`/features-roadmap`) + a `FeaturesRoadmapMenu` entry in the `settings` section.
- `package.json` — bumps `@conduction/nextcloud-vue` to `^1.0.0-beta.35`.

pipelinq already pins `@nextcloud/axios ~2.5.2`, so the openregister#1489 (`@nextcloud/axios@2.6.0` broke its exports) issue doesn't bite. The roadmap tab calls `GET /index.php/apps/openregister/api/github/issues?…` (proxy on the OpenRegister side, PR ConductionNL/openregister#1463); until that lands the tab degrades gracefully.

## Test plan

- [ ] `npm install && npm run build` green
- [ ] "Features & roadmap" appears in the Settings section of the nav → `/features-roadmap` renders the Features + Roadmap tabs + Suggest-feature button
- [ ] Roadmap tab shows the graceful empty state until the OpenRegister proxy is configured

Refs: ConductionNL/hydra#251 · ConductionNL/procest#422 · ConductionNL/openregister#1463