### PR TITLE
chore(deps): bump @conduction/nextcloud-vue to ^1.0.0-beta.40

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
 			"version": "0.1.0",
 			"license": "EUPL-1.2",
 			"dependencies": {
-				"@conduction/nextcloud-vue": "^1.0.0-beta.35",
+				"@conduction/nextcloud-vue": "^1.0.0-beta.40",
 				"@nextcloud/axios": "~2.5.2",
 				"@nextcloud/dialogs": "^3.2.0",
 				"@nextcloud/initial-state": "^2.2.0",
@@ -1795,9 +1795,9 @@
 			}
 		},
 		"node_modules/@conduction/nextcloud-vue": {
-			"version": "1.0.0-beta.35",
-			"resolved": "https://registry.npmjs.org/@conduction/nextcloud-vue/-/nextcloud-vue-1.0.0-beta.35.tgz",
-			"integrity": "sha512-T80Y6z+m/ni2z1yCNVrXAjzacv2WdXFNQcfZYfXHHmtCbJOjdFWLwALZ/WCrGO1FQIQMnjq01G0gBdMXXKQimg==",
+			"version": "1.0.0-beta.40",
+			"resolved": "https://registry.npmjs.org/@conduction/nextcloud-vue/-/nextcloud-vue-1.0.0-beta.40.tgz",
+			"integrity": "sha512-tiC0MZT3mPupFRgB9F5p0FY6o50PDwc2seGcAKENO8aFpgCQOgudJs+s1FiprtEJ19RX6tMDByXeeD2Cxd9eyw==",
 			"license": "EUPL-1.2",
 			"dependencies": {
 				"@codemirror/autocomplete": "^6.0.0",
@@ -18404,9 +18404,9 @@
 			}
 		},
 		"@conduction/nextcloud-vue": {
-			"version": "1.0.0-beta.35",
-			"resolved": "https://registry.npmjs.org/@conduction/nextcloud-vue/-/nextcloud-vue-1.0.0-beta.35.tgz",
-			"integrity": "sha512-T80Y6z+m/ni2z1yCNVrXAjzacv2WdXFNQcfZYfXHHmtCbJOjdFWLwALZ/WCrGO1FQIQMnjq01G0gBdMXXKQimg==",
+			"version": "1.0.0-beta.40",
+			"resolved": "https://registry.npmjs.org/@conduction/nextcloud-vue/-/nextcloud-vue-1.0.0-beta.40.tgz",
+			"integrity": "sha512-tiC0MZT3mPupFRgB9F5p0FY6o50PDwc2seGcAKENO8aFpgCQOgudJs+s1FiprtEJ19RX6tMDByXeeD2Cxd9eyw==",
 			"requires": {
 				"@codemirror/autocomplete": "^6.0.0",
 				"@codemirror/commands": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
 		"extends @nextcloud/browserslist-config"
 	],
 	"dependencies": {
-		"@conduction/nextcloud-vue": "^1.0.0-beta.35",
+		"@conduction/nextcloud-vue": "^1.0.0-beta.40",
 		"@nextcloud/axios": "~2.5.2",
 		"@nextcloud/dialogs": "^3.2.0",
 		"@nextcloud/initial-state": "^2.2.0",


### PR DESCRIPTION
Bumps `@conduction/nextcloud-vue` `^1.0.0-beta.35` → `^1.0.0-beta.40` — picks up the `CnIndexPage` store-backed self-fetch (nc-vue #223; manifest `type:"index"` pages now render rows instead of an empty table) plus `columns[].formatter`/`.widget`/`.aggregate` and `pages[].config.filter` (#219/#221/#222). Pure dep bump; CI runs the build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)