### PR TITLE
ci(docs): deploy from documentation branch (not development)

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -2,9 +2,9 @@ name: Documentation
 
 on:
   push:
-    branches: [development]
+    branches: [documentation]
   pull_request:
-    branches: [development]
+    branches: [documentation]
 
 jobs:
   deploy:


### PR DESCRIPTION
Docs should deploy from the documentation branch so it can be updated independently of the code CI/CD on development.