### PR TITLE
ci(quality): pin openregister to development for Playwright seed

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -24,5 +24,8 @@ jobs:
       enable-playwright: true
       enable-playwright-coverage: true
       playwright-coverage-threshold: 75
-      additional-apps: '[{"repo":"ConductionNL/openregister","app":"openregister"}]'
+      # Pin openregister to development: main lacks the react/async composer dep
+      # that lib/Service/ObjectService.php (Async\await call) requires, so app:enable
+      # fails with "Call to undefined function React\Async\await()" during seed.
+      additional-apps: '[{"repo":"ConductionNL/openregister","app":"openregister","ref":"development"}]'
       playwright-seed-command: 'php occ app:disable pipelinq && php occ app:enable pipelinq'


### PR DESCRIPTION
## Why

Playwright job fails during `Seed test data` with:

```
Error: Call to undefined function React\Async\await() in lib/Service/ObjectService.php:909
```

The shared quality workflow clones additional-apps from `ref:main` by default. openregister/main's `ObjectService.php` calls `React\Async\await()`, but its `composer.json` only lists `react/promise`, not `react/async`. The dep is declared on `development` (commit f0345b3, "deps: declare react/async explicitly"), so we need to pull from there until the next OR release rolls main forward.

## What

Add `"ref":"development"` to the openregister entry in `additional-apps`.

## Test plan

- [x] Re-run Playwright after merge - seed step should now succeed