### PR TITLE
fix(brand): use canonical cobalt #21468B in app-store.svg

### DIFF
--- a/img/app-store.svg
+++ b/img/app-store.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
-  <polygon points="256,26 455.19,141 455.19,371 256,486 56.81,371 56.81,141" fill="#4376FC"/>
+  <polygon points="256,26 455.19,141 455.19,371 256,486 56.81,371 56.81,141" fill="#21468B"/>
   <g transform="translate(136, 136) scale(10)" fill="#ffffff">
     <circle cx="9" cy="7.5" r="3.5"/>
     <path d="M2,20V17.5C2,15.01,6.03,13,9,13S16,15.01,16,17.5V20Z"/>


### PR DESCRIPTION
## Summary

Replaces the **legacy** brand hex `#4376FC` with the canonical Conduction Cobalt `#21468B` (`--c-blue-cobalt` in design-tokens, the Dutch flag blue) in `img/app-store.svg`.

Per `reference_conduction-brand-hex.md`, `#4376FC` was retired by the 2026-05-13 design-system sweep but this app was missed in the fleet rollout. This PR completes the cleanup.

## Scope

This PR intentionally only touches `img/app-store.svg` to stay atomic.

`#4376FC` also still appears in: `docusaurus/static/img/logo.svg` — these will be addressed in a follow-up sweep.

## Test plan

- Visual: open `img/app-store.svg` in any SVG viewer — background polygon should be deep cobalt (`#21468B`), not the lighter `#4376FC`.