### PR TITLE
fix(docs): descriptive homepage title (#80)

### DIFF
--- a/docs/src/pages/index.js
+++ b/docs/src/pages/index.js
@@ -274,7 +274,7 @@ const WIDGETS = [
 export default function Home() {
   return (
     <Layout
-      title="Pipelinq"
+      title="Pipelinq, CRM and sales registers for Nextcloud"
       description="CRM on your Nextcloud. Customers, prospects, deals, quotes as typed registers. No separate sales database, no second login."
     >
       <main className="marketing-page">


### PR DESCRIPTION
Part of ConductionNL/.github#75 SEO epic and closes ConductionNL/.github#80.

Replaces the bare-brand Layout title with a descriptive form so SERPs surface the keyword payload before the site-title suffix Docusaurus appends.