### PR TITLE
fix(docs): hand-written meta descriptions (#81)

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,7 +1,7 @@
 ---
 sidebar_position: 2
 title: Installation
-description: Install and configure Pipelinq on your Nextcloud instance.
+description: Install Pipelinq on Nextcloud 29+ from the app store. OpenRegister prerequisite and admin-side configuration walkthrough included.
 ---
 
 # Installation

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 1
+description: Get started with Pipelinq, the CRM that lives in Nextcloud. Customers, deals, and quotes as typed OpenRegister records with native integration.
 ---
 
 # Pipelinq


### PR DESCRIPTION
Part of ConductionNL/.github#75 SEO epic and ConductionNL/.github#81.

Hand-written meta descriptions on the highest-traffic pages of this site. 140-160 chars, keyword-loaded, no em-dashes.