### PR TITLE
chore: bump @conduction/nextcloud-vue beta.40 → beta.55 (unblocks E2E)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
 			"version": "0.1.0",
 			"license": "EUPL-1.2",
 			"dependencies": {
-				"@conduction/nextcloud-vue": "^1.0.0-beta.40",
+				"@conduction/nextcloud-vue": "^1.0.0-beta.55",
 				"@nextcloud/axios": "~2.5.2",
 				"@nextcloud/dialogs": "^3.2.0",
 				"@nextcloud/initial-state": "^2.2.0",
@@ -1796,9 +1796,9 @@
 			}
 		},
 		"node_modules/@conduction/nextcloud-vue": {
-			"version": "1.0.0-beta.40",
-			"resolved": "https://registry.npmjs.org/@conduction/nextcloud-vue/-/nextcloud-vue-1.0.0-beta.40.tgz",
-			"integrity": "sha512-tiC0MZT3mPupFRgB9F5p0FY6o50PDwc2seGcAKENO8aFpgCQOgudJs+s1FiprtEJ19RX6tMDByXeeD2Cxd9eyw==",
+			"version": "1.0.0-beta.55",
+			"resolved": "https://registry.npmjs.org/@conduction/nextcloud-vue/-/nextcloud-vue-1.0.0-beta.55.tgz",
+			"integrity": "sha512-SiBMD/K5kxZUUQdsid8UItfuZTBwkH+n//RIfs8mmavMmaxBzlRzNtPVG6H5PF8xCslFK704CJhfuRwEeMchVw==",
 			"license": "EUPL-1.2",
 			"dependencies": {
 				"@codemirror/autocomplete": "^6.0.0",
@@ -1821,6 +1821,7 @@
 				"dompurify": "^3.0.0",
 				"gridstack": "^10.3.1",
 				"leaflet": "^1.9.0",
+				"leaflet.markercluster": "^1.5.3",
 				"lodash": "^4.17.21",
 				"marked": "^15.0.0",
 				"style-mod": "^4.0.0",
@@ -10677,6 +10678,15 @@
 			"integrity": "sha512-nxS1ynzJOmOlHp+iL3FyWqK89GtNL8U8rvlMOsQdTTssxZwCXh8N2NB3GDQOL+YR3XnWyZAxwQixURb+FA74PA==",
 			"license": "BSD-2-Clause"
 		},
+		"node_modules/leaflet.markercluster": {
+			"version": "1.5.3",
+			"resolved": "https://registry.npmjs.org/leaflet.markercluster/-/leaflet.markercluster-1.5.3.tgz",
+			"integrity": "sha512-vPTw/Bndq7eQHjLBVlWpnGeLa3t+3zGiuM7fJwCkiMFq+nmRuG3RI3f7f4N4TDX7T4NpbAXpR2+NTRSEGfCSeA==",
+			"license": "MIT",
+			"peerDependencies": {
+				"leaflet": "^1.3.1"
+			}
+		},
 		"node_modules/levn": {
 			"version": "0.4.1",
 			"resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
@@ -18468,9 +18478,9 @@
 			}
 		},
 		"@conduction/nextcloud-vue": {
-			"version": "1.0.0-beta.40",
-			"resolved": "https://registry.npmjs.org/@conduction/nextcloud-vue/-/nextcloud-vue-1.0.0-beta.40.tgz",
-			"integrity": "sha512-tiC0MZT3mPupFRgB9F5p0FY6o50PDwc2seGcAKENO8aFpgCQOgudJs+s1FiprtEJ19RX6tMDByXeeD2Cxd9eyw==",
+			"version": "1.0.0-beta.55",
+			"resolved": "https://registry.npmjs.org/@conduction/nextcloud-vue/-/nextcloud-vue-1.0.0-beta.55.tgz",
+			"integrity": "sha512-SiBMD/K5kxZUUQdsid8UItfuZTBwkH+n//RIfs8mmavMmaxBzlRzNtPVG6H5PF8xCslFK704CJhfuRwEeMchVw==",
 			"requires": {
 				"@codemirror/autocomplete": "^6.0.0",
 				"@codemirror/commands": "^6.0.0",
@@ -18492,6 +18502,7 @@
 				"dompurify": "^3.0.0",
 				"gridstack": "^10.3.1",
 				"leaflet": "^1.9.0",
+				"leaflet.markercluster": "^1.5.3",
 				"lodash": "^4.17.21",
 				"marked": "^15.0.0",
 				"style-mod": "^4.0.0",
@@ -24426,6 +24437,11 @@
 			"version": "1.9.4",
 			"resolved": "https://registry.npmjs.org/leaflet/-/leaflet-1.9.4.tgz",
 			"integrity": "sha512-nxS1ynzJOmOlHp+iL3FyWqK89GtNL8U8rvlMOsQdTTssxZwCXh8N2NB3GDQOL+YR3XnWyZAxwQixURb+FA74PA=="
+		},
+		"leaflet.markercluster": {
+			"version": "1.5.3",
+			"resolved": "https://registry.npmjs.org/leaflet.markercluster/-/leaflet.markercluster-1.5.3.tgz",
+			"integrity": "sha512-vPTw/Bndq7eQHjLBVlWpnGeLa3t+3zGiuM7fJwCkiMFq+nmRuG3RI3f7f4N4TDX7T4NpbAXpR2+NTRSEGfCSeA=="
 		},
 		"levn": {
 			"version": "0.4.1",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
 		"extends @nextcloud/browserslist-config"
 	],
 	"dependencies": {
-		"@conduction/nextcloud-vue": "^1.0.0-beta.40",
+		"@conduction/nextcloud-vue": "^1.0.0-beta.55",
 		"@nextcloud/axios": "~2.5.2",
 		"@nextcloud/dialogs": "^3.2.0",
 		"@nextcloud/initial-state": "^2.2.0",


### PR DESCRIPTION
Brings in two webpack-bundling fixes that were breaking pipelinq's Playwright E2E (and every other consumer app):

- **nc-vue#252** (CnObjectDataWidget): replace dynamic `require('../../store/index.js')` with static import — was causing `Module not found: ../../store/index.js` in consumer apps' webpack
- **nc-vue#253** (CnMapWidget): add `webpackIgnore` to `leaflet.markercluster` dynamic import — was causing `Module not found: leaflet.markercluster`

Both fixes are in v1.0.0-beta.55 (published 2026-05-19 09:04 UTC).

Once this lands on development, the 11 existing PRs on pipelinq that fail E2E should be able to clear their Playwright job after rebase. Remaining E2E failures (Dashboard quick-create, postgres LIKE) are separate from these two webpack issues.