### PR TITLE
feat(manifest-v2): migrate to universal widget manifest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
 			"version": "0.1.0",
 			"license": "EUPL-1.2",
 			"dependencies": {
-				"@conduction/nextcloud-vue": "^1.0.0-beta.55",
+				"@conduction/nextcloud-vue": "^1.0.0-beta.58",
 				"@nextcloud/axios": "~2.5.2",
 				"@nextcloud/dialogs": "^3.2.0",
 				"@nextcloud/initial-state": "^2.2.0",
@@ -45,6 +45,7 @@
 				"ajv": "^8.20.0",
 				"ajv-formats": "^3.0.1",
 				"babel-loader": "^10.1.1",
+				"commander": "^12.1.0",
 				"css-loader": "~7.1.1",
 				"eslint": "^8.56.0",
 				"eslint-config-standard": "^17.1.0",
@@ -1796,9 +1797,9 @@
 			}
 		},
 		"node_modules/@conduction/nextcloud-vue": {
-			"version": "1.0.0-beta.55",
-			"resolved": "https://registry.npmjs.org/@conduction/nextcloud-vue/-/nextcloud-vue-1.0.0-beta.55.tgz",
-			"integrity": "sha512-SiBMD/K5kxZUUQdsid8UItfuZTBwkH+n//RIfs8mmavMmaxBzlRzNtPVG6H5PF8xCslFK704CJhfuRwEeMchVw==",
+			"version": "1.0.0-beta.58",
+			"resolved": "https://registry.npmjs.org/@conduction/nextcloud-vue/-/nextcloud-vue-1.0.0-beta.58.tgz",
+			"integrity": "sha512-tFoV9jCNv+62c/MKbMgxwbOKH0pUTxnYGYW6pfjdhTLiSJts+BzGffZnK6khs6KDVbEssmAA3ntcpPp0hZqS/Q==",
 			"license": "EUPL-1.2",
 			"dependencies": {
 				"@codemirror/autocomplete": "^6.0.0",
@@ -1816,6 +1817,8 @@
 				"@nextcloud/notify_push": "^1.0.0",
 				"@uiw/codemirror-theme-github": "^4.25.8",
 				"@vueuse/core": "^10.0.0",
+				"ajv": "^8.20.0",
+				"ajv-formats": "^3.0.1",
 				"apexcharts": "^4.7.0",
 				"codemirror": "^6.0.0",
 				"dompurify": "^3.0.0",
@@ -1829,6 +1832,9 @@
 				"vue-codemirror6": "^1.4.3",
 				"vue-color": "^2.8.2",
 				"vue-template-compiler": "^2.7.16"
+			},
+			"bin": {
+				"manifest-migrate": "src/cli/manifest-migrate.js"
 			},
 			"peerDependencies": {
 				"@nextcloud/auth": "^2.0.0 || ^3.0.0",
@@ -5633,7 +5639,6 @@
 			"version": "8.20.0",
 			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
 			"integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"fast-deep-equal": "^3.1.3",
@@ -5650,7 +5655,6 @@
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
 			"integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"ajv": "^8.0.0"
@@ -6864,10 +6868,14 @@
 			}
 		},
 		"node_modules/commander": {
-			"version": "2.20.3",
-			"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-			"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-			"dev": true
+			"version": "12.1.0",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+			"integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			}
 		},
 		"node_modules/comment-parser": {
 			"version": "1.4.1",
@@ -8685,8 +8693,7 @@
 		"node_modules/fast-deep-equal": {
 			"version": "3.1.3",
 			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-			"integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-			"dev": true
+			"integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
 		},
 		"node_modules/fast-glob": {
 			"version": "3.3.3",
@@ -8733,7 +8740,6 @@
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
 			"integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
-			"dev": true,
 			"funding": [
 				{
 					"type": "github",
@@ -10622,7 +10628,6 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
 			"integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/json-stable-stringify-without-jsonify": {
@@ -12189,6 +12194,14 @@
 				"type": "individual",
 				"url": "https://nearley.js.org/#give-to-nearley"
 			}
+		},
+		"node_modules/nearley/node_modules/commander": {
+			"version": "2.20.3",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+			"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true
 		},
 		"node_modules/neo-async": {
 			"version": "2.6.2",
@@ -14089,7 +14102,6 @@
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
 			"integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
-			"dev": true,
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -15728,6 +15740,13 @@
 				}
 			}
 		},
+		"node_modules/terser/node_modules/commander": {
+			"version": "2.20.3",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+			"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/text-table": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
@@ -16968,15 +16987,6 @@
 				"webpack-dev-server": {
 					"optional": true
 				}
-			}
-		},
-		"node_modules/webpack-cli/node_modules/commander": {
-			"version": "12.1.0",
-			"resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
-			"integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
-			"dev": true,
-			"engines": {
-				"node": ">=18"
 			}
 		},
 		"node_modules/webpack-merge": {
@@ -18478,9 +18488,9 @@
 			}
 		},
 		"@conduction/nextcloud-vue": {
-			"version": "1.0.0-beta.55",
-			"resolved": "https://registry.npmjs.org/@conduction/nextcloud-vue/-/nextcloud-vue-1.0.0-beta.55.tgz",
-			"integrity": "sha512-SiBMD/K5kxZUUQdsid8UItfuZTBwkH+n//RIfs8mmavMmaxBzlRzNtPVG6H5PF8xCslFK704CJhfuRwEeMchVw==",
+			"version": "1.0.0-beta.58",
+			"resolved": "https://registry.npmjs.org/@conduction/nextcloud-vue/-/nextcloud-vue-1.0.0-beta.58.tgz",
+			"integrity": "sha512-tFoV9jCNv+62c/MKbMgxwbOKH0pUTxnYGYW6pfjdhTLiSJts+BzGffZnK6khs6KDVbEssmAA3ntcpPp0hZqS/Q==",
 			"requires": {
 				"@codemirror/autocomplete": "^6.0.0",
 				"@codemirror/commands": "^6.0.0",
@@ -18497,6 +18507,8 @@
 				"@nextcloud/notify_push": "^1.0.0",
 				"@uiw/codemirror-theme-github": "^4.25.8",
 				"@vueuse/core": "^10.0.0",
+				"ajv": "^8.20.0",
+				"ajv-formats": "^3.0.1",
 				"apexcharts": "^4.7.0",
 				"codemirror": "^6.0.0",
 				"dompurify": "^3.0.0",
@@ -21006,7 +21018,6 @@
 			"version": "8.20.0",
 			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
 			"integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
-			"dev": true,
 			"requires": {
 				"fast-deep-equal": "^3.1.3",
 				"fast-uri": "^3.0.1",
@@ -21018,7 +21029,6 @@
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
 			"integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
-			"dev": true,
 			"requires": {
 				"ajv": "^8.0.0"
 			}
@@ -21856,9 +21866,9 @@
 			"integrity": "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg=="
 		},
 		"commander": {
-			"version": "2.20.3",
-			"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-			"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+			"version": "12.1.0",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+			"integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
 			"dev": true
 		},
 		"comment-parser": {
@@ -23120,8 +23130,7 @@
 		"fast-deep-equal": {
 			"version": "3.1.3",
 			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-			"integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-			"dev": true
+			"integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
 		},
 		"fast-glob": {
 			"version": "3.3.3",
@@ -23162,8 +23171,7 @@
 		"fast-uri": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-			"integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
-			"dev": true
+			"integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA=="
 		},
 		"fast-xml-parser": {
 			"version": "4.5.6",
@@ -24393,8 +24401,7 @@
 		"json-schema-traverse": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-			"integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-			"dev": true
+			"integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
 		},
 		"json-stable-stringify-without-jsonify": {
 			"version": "1.0.1",
@@ -25456,6 +25463,15 @@
 				"moo": "^0.5.0",
 				"railroad-diagrams": "^1.0.0",
 				"randexp": "0.4.6"
+			},
+			"dependencies": {
+				"commander": {
+					"version": "2.20.3",
+					"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+					"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+					"dev": true,
+					"optional": true
+				}
 			}
 		},
 		"neo-async": {
@@ -26743,8 +26759,7 @@
 		"require-from-string": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
-			"integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
-			"dev": true
+			"integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="
 		},
 		"requireindex": {
 			"version": "1.2.0",
@@ -27817,6 +27832,14 @@
 				"acorn": "^8.15.0",
 				"commander": "^2.20.0",
 				"source-map-support": "~0.5.20"
+			},
+			"dependencies": {
+				"commander": {
+					"version": "2.20.3",
+					"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+					"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+					"dev": true
+				}
 			}
 		},
 		"terser-webpack-plugin": {
@@ -28660,14 +28683,6 @@
 				"interpret": "^3.1.1",
 				"rechoir": "^0.8.0",
 				"webpack-merge": "^6.0.1"
-			},
-			"dependencies": {
-				"commander": {
-					"version": "12.1.0",
-					"resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
-					"integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
-					"dev": true
-				}
 			}
 		},
 		"webpack-merge": {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
 		"extends @nextcloud/browserslist-config"
 	],
 	"dependencies": {
-		"@conduction/nextcloud-vue": "^1.0.0-beta.55",
+		"@conduction/nextcloud-vue": "^1.0.0-beta.58",
 		"@nextcloud/axios": "~2.5.2",
 		"@nextcloud/dialogs": "^3.2.0",
 		"@nextcloud/initial-state": "^2.2.0",
@@ -59,6 +59,7 @@
 		"@playwright/test": "^1.49.0",
 		"@vue/eslint-config-typescript": "^13.0.0",
 		"ajv": "^8.20.0",
+		"commander": "^12.1.0",
 		"ajv-formats": "^3.0.1",
 		"babel-loader": "^10.1.1",
 		"css-loader": "~7.1.1",

--- a/src/App.vue
+++ b/src/App.vue
@@ -18,6 +18,7 @@
 	<CnAppRoot
 		:manifest="manifest"
 		:custom-components="customComponents"
+		:registry="registry"
 		:page-types="pageTypes"
 		app-id="pipelinq"
 		:translate="translateForApp"
@@ -105,6 +106,17 @@ export default {
 		 *   - `pages[].config.sections[].component` (settings rich sections)
 		 */
 		customComponents: {
+			type: Object,
+			default: () => ({}),
+		},
+		/**
+		 * V2 component registry — maps string keys from `manifest.pages[].component`
+		 * to `{ kind, component }` entries. Passed through to CnAppRoot for v2
+		 * renderer resolution. The v2 renderer emits a one-shot deprecation
+		 * warning when both `registry` and `customComponents` are present and the
+		 * manifest declares `$schema` as the v2 URL.
+		 */
+		registry: {
 			type: Object,
 			default: () => ({}),
 		},

--- a/src/main.js
+++ b/src/main.js
@@ -16,6 +16,7 @@ import pinia from './pinia.js'
 import App from './App.vue'
 import bundledManifest from './manifest.json'
 import customComponents from './customComponents.js'
+import registry from './registry.js'
 import { initializeStores } from './store/store.js'
 
 // Library CSS — must be explicit import (webpack tree-shakes side-effect imports from aliased packages)
@@ -103,6 +104,7 @@ tryLoadTranslations()
 // of @conduction/nextcloud-vue@1.0.0-beta.12; defence-in-depth here.
 const pageTypesProp = { ...defaultPageTypes }
 const customComponentsProp = { ...customComponents }
+const registryProp = { ...registry }
 
 // Create and mount Vue instance immediately so the App renders.
 new Vue({
@@ -112,6 +114,7 @@ new Vue({
 		props: {
 			manifest: bundledManifest,
 			customComponents: customComponentsProp,
+			registry: registryProp,
 			pageTypes: pageTypesProp,
 		},
 	}),

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,28 +1,154 @@
 {
-	"$schema": "https://raw.githubusercontent.com/ConductionNL/nextcloud-vue/main/src/schemas/app-manifest.schema.json",
+	"$schema": "https://raw.githubusercontent.com/ConductionNL/nextcloud-vue/main/src/schemas/app-manifest-v2.schema.json",
 	"version": "1.0.0",
-	"dependencies": ["openregister"],
+	"dependencies": [
+		"openregister"
+	],
 	"menu": [
-		{ "id": "Dashboard", "label": "Dashboard", "icon": "icon-category-dashboard", "route": "Dashboard", "order": 10 },
-		{ "id": "Clients", "label": "Clients", "icon": "icon-group", "route": "Clients", "order": 20 },
-		{ "id": "Contacts", "label": "Contacts", "icon": "icon-user", "route": "Contacts", "order": 30 },
-		{ "id": "Leads", "label": "Leads", "icon": "icon-checkmark", "route": "Leads", "order": 40 },
-		{ "id": "Requests", "label": "Requests", "icon": "icon-file", "route": "Requests", "order": 50 },
-		{ "id": "Tasks", "label": "Tasks", "icon": "icon-checkmark", "route": "Tasks", "order": 60 },
-		{ "id": "Contactmomenten", "label": "Contactmomenten", "icon": "icon-comment", "route": "Contactmomenten", "order": 70 },
-		{ "id": "Complaints", "label": "Complaints", "icon": "icon-error", "route": "Complaints", "order": 80 },
-		{ "id": "Products", "label": "Products", "icon": "icon-files", "route": "Products", "order": 90 },
-		{ "id": "Pipeline", "label": "Pipeline", "icon": "icon-category-organization", "route": "Pipeline", "order": 100 },
-		{ "id": "Surveys", "label": "Surveys", "icon": "icon-comment", "route": "Surveys", "order": 110 },
-		{ "id": "Queues", "label": "Queues", "icon": "icon-files", "route": "Queues", "order": 120 },
-		{ "id": "Kennisbank", "label": "Kennisbank", "icon": "icon-info", "route": "Kennisbank", "order": 130 },
-		{ "id": "MyWork", "label": "My Work", "icon": "icon-user", "route": "MyWork", "order": 140 },
-		{ "id": "Rapportage", "label": "Reporting", "icon": "icon-category-monitoring", "route": "Rapportage", "order": 150 },
-		{ "id": "Documentation", "label": "Documentation", "icon": "icon-info", "href": "https://conduction.gitbook.io/pipelinq-nextcloud", "order": 160 },
-		{ "id": "Pipelines", "label": "Pipelines", "icon": "icon-category-organization", "route": "Pipelines", "section": "settings", "order": 200 },
-		{ "id": "Forms", "label": "Forms", "icon": "icon-file", "route": "Forms", "section": "settings", "order": 210 },
-		{ "id": "Automations", "label": "Automations", "icon": "icon-play", "route": "Automations", "section": "settings", "order": 220 },
-		{ "id": "FeaturesRoadmapMenu", "label": "Features & roadmap", "icon": "icon-toggle", "route": "FeaturesRoadmap", "section": "settings", "order": 230 }
+		{
+			"id": "Dashboard",
+			"label": "Dashboard",
+			"icon": "icon-category-dashboard",
+			"route": "Dashboard",
+			"order": 10
+		},
+		{
+			"id": "Clients",
+			"label": "Clients",
+			"icon": "icon-group",
+			"route": "Clients",
+			"order": 20
+		},
+		{
+			"id": "Contacts",
+			"label": "Contacts",
+			"icon": "icon-user",
+			"route": "Contacts",
+			"order": 30
+		},
+		{
+			"id": "Leads",
+			"label": "Leads",
+			"icon": "icon-checkmark",
+			"route": "Leads",
+			"order": 40
+		},
+		{
+			"id": "Requests",
+			"label": "Requests",
+			"icon": "icon-file",
+			"route": "Requests",
+			"order": 50
+		},
+		{
+			"id": "Tasks",
+			"label": "Tasks",
+			"icon": "icon-checkmark",
+			"route": "Tasks",
+			"order": 60
+		},
+		{
+			"id": "Contactmomenten",
+			"label": "Contactmomenten",
+			"icon": "icon-comment",
+			"route": "Contactmomenten",
+			"order": 70
+		},
+		{
+			"id": "Complaints",
+			"label": "Complaints",
+			"icon": "icon-error",
+			"route": "Complaints",
+			"order": 80
+		},
+		{
+			"id": "Products",
+			"label": "Products",
+			"icon": "icon-files",
+			"route": "Products",
+			"order": 90
+		},
+		{
+			"id": "Pipeline",
+			"label": "Pipeline",
+			"icon": "icon-category-organization",
+			"route": "Pipeline",
+			"order": 100
+		},
+		{
+			"id": "Surveys",
+			"label": "Surveys",
+			"icon": "icon-comment",
+			"route": "Surveys",
+			"order": 110
+		},
+		{
+			"id": "Queues",
+			"label": "Queues",
+			"icon": "icon-files",
+			"route": "Queues",
+			"order": 120
+		},
+		{
+			"id": "Kennisbank",
+			"label": "Kennisbank",
+			"icon": "icon-info",
+			"route": "Kennisbank",
+			"order": 130
+		},
+		{
+			"id": "MyWork",
+			"label": "My Work",
+			"icon": "icon-user",
+			"route": "MyWork",
+			"order": 140
+		},
+		{
+			"id": "Rapportage",
+			"label": "Reporting",
+			"icon": "icon-category-monitoring",
+			"route": "Rapportage",
+			"order": 150
+		},
+		{
+			"id": "Documentation",
+			"label": "Documentation",
+			"icon": "icon-info",
+			"href": "https://conduction.gitbook.io/pipelinq-nextcloud",
+			"order": 160
+		},
+		{
+			"id": "Pipelines",
+			"label": "Pipelines",
+			"icon": "icon-category-organization",
+			"route": "Pipelines",
+			"section": "settings",
+			"order": 200
+		},
+		{
+			"id": "Forms",
+			"label": "Forms",
+			"icon": "icon-file",
+			"route": "Forms",
+			"section": "settings",
+			"order": 210
+		},
+		{
+			"id": "Automations",
+			"label": "Automations",
+			"icon": "icon-play",
+			"route": "Automations",
+			"section": "settings",
+			"order": 220
+		},
+		{
+			"id": "FeaturesRoadmapMenu",
+			"label": "Features & roadmap",
+			"icon": "icon-toggle",
+			"route": "FeaturesRoadmap",
+			"section": "settings",
+			"order": 230
+		}
 	],
 	"pages": [
 		{
@@ -30,7 +156,8 @@
 			"route": "/",
 			"type": "custom",
 			"title": "Dashboard",
-			"component": "DashboardView"
+			"component": "DashboardView",
+			"_note": "Bespoke multi-widget dashboard with gridstack layout; lib gap: no declarative dashboard page type with grid-aware widget placement."
 		},
 		{
 			"id": "Clients",
@@ -40,8 +167,17 @@
 			"config": {
 				"register": "pipelinq",
 				"schema": "client",
-				"columns": ["name", "type", "industry", "email", "phone"],
-				"sidebar": { "enabled": true, "showMetadata": true }
+				"columns": [
+					"name",
+					"type",
+					"industry",
+					"email",
+					"phone"
+				],
+				"sidebar": {
+					"enabled": true,
+					"showMetadata": true
+				}
 			}
 		},
 		{
@@ -51,12 +187,37 @@
 			"title": "Client",
 			"config": {
 				"register": "pipelinq",
-				"schema": "client",
-				"sidebarTabs": [
-					{ "id": "overview", "label": "Overview", "icon": "icon-info", "widgets": [{ "type": "data" }, { "type": "metadata" }], "order": 10 },
-					{ "id": "audit", "label": "Audit trail", "icon": "icon-history", "widgets": [{ "type": "audit-trail" }], "order": 90 }
-				]
-			}
+				"schema": "client"
+			},
+			"widgets": [
+				{
+					"widgetKey": "data",
+					"slot": "sidebar",
+					"tabGroup": "overview",
+					"gridX": 0,
+					"gridY": 0,
+					"gridWidth": 1,
+					"gridHeight": 1
+				},
+				{
+					"widgetKey": "metadata",
+					"slot": "sidebar",
+					"tabGroup": "overview",
+					"gridX": 0,
+					"gridY": 1,
+					"gridWidth": 1,
+					"gridHeight": 1
+				},
+				{
+					"widgetKey": "audit-trail",
+					"slot": "sidebar",
+					"tabGroup": "audit",
+					"gridX": 0,
+					"gridY": 2,
+					"gridWidth": 1,
+					"gridHeight": 1
+				}
+			]
 		},
 		{
 			"id": "Requests",
@@ -66,8 +227,17 @@
 			"config": {
 				"register": "pipelinq",
 				"schema": "request",
-				"columns": ["title", "status", "priority", "channel", "requestedAt"],
-				"sidebar": { "enabled": true, "showMetadata": true }
+				"columns": [
+					"title",
+					"status",
+					"priority",
+					"channel",
+					"requestedAt"
+				],
+				"sidebar": {
+					"enabled": true,
+					"showMetadata": true
+				}
 			}
 		},
 		{
@@ -77,12 +247,37 @@
 			"title": "Request",
 			"config": {
 				"register": "pipelinq",
-				"schema": "request",
-				"sidebarTabs": [
-					{ "id": "overview", "label": "Overview", "icon": "icon-info", "widgets": [{ "type": "data" }, { "type": "metadata" }], "order": 10 },
-					{ "id": "audit", "label": "Audit trail", "icon": "icon-history", "widgets": [{ "type": "audit-trail" }], "order": 90 }
-				]
-			}
+				"schema": "request"
+			},
+			"widgets": [
+				{
+					"widgetKey": "data",
+					"slot": "sidebar",
+					"tabGroup": "overview",
+					"gridX": 0,
+					"gridY": 0,
+					"gridWidth": 1,
+					"gridHeight": 1
+				},
+				{
+					"widgetKey": "metadata",
+					"slot": "sidebar",
+					"tabGroup": "overview",
+					"gridX": 0,
+					"gridY": 1,
+					"gridWidth": 1,
+					"gridHeight": 1
+				},
+				{
+					"widgetKey": "audit-trail",
+					"slot": "sidebar",
+					"tabGroup": "audit",
+					"gridX": 0,
+					"gridY": 2,
+					"gridWidth": 1,
+					"gridHeight": 1
+				}
+			]
 		},
 		{
 			"id": "Complaints",
@@ -92,8 +287,18 @@
 			"config": {
 				"register": "pipelinq",
 				"schema": "complaint",
-				"columns": ["title", "status", "priority", "category", "channel", "_dateCreated"],
-				"sidebar": { "enabled": true, "showMetadata": true }
+				"columns": [
+					"title",
+					"status",
+					"priority",
+					"category",
+					"channel",
+					"_dateCreated"
+				],
+				"sidebar": {
+					"enabled": true,
+					"showMetadata": true
+				}
 			}
 		},
 		{
@@ -103,12 +308,37 @@
 			"title": "Complaint",
 			"config": {
 				"register": "pipelinq",
-				"schema": "complaint",
-				"sidebarTabs": [
-					{ "id": "overview", "label": "Overview", "icon": "icon-info", "widgets": [{ "type": "data" }, { "type": "metadata" }], "order": 10 },
-					{ "id": "audit", "label": "Audit trail", "icon": "icon-history", "widgets": [{ "type": "audit-trail" }], "order": 90 }
-				]
-			}
+				"schema": "complaint"
+			},
+			"widgets": [
+				{
+					"widgetKey": "data",
+					"slot": "sidebar",
+					"tabGroup": "overview",
+					"gridX": 0,
+					"gridY": 0,
+					"gridWidth": 1,
+					"gridHeight": 1
+				},
+				{
+					"widgetKey": "metadata",
+					"slot": "sidebar",
+					"tabGroup": "overview",
+					"gridX": 0,
+					"gridY": 1,
+					"gridWidth": 1,
+					"gridHeight": 1
+				},
+				{
+					"widgetKey": "audit-trail",
+					"slot": "sidebar",
+					"tabGroup": "audit",
+					"gridX": 0,
+					"gridY": 2,
+					"gridWidth": 1,
+					"gridHeight": 1
+				}
+			]
 		},
 		{
 			"id": "Contacts",
@@ -118,8 +348,16 @@
 			"config": {
 				"register": "pipelinq",
 				"schema": "contact",
-				"columns": ["name", "email", "phone", "role"],
-				"sidebar": { "enabled": true, "showMetadata": true }
+				"columns": [
+					"name",
+					"email",
+					"phone",
+					"role"
+				],
+				"sidebar": {
+					"enabled": true,
+					"showMetadata": true
+				}
 			}
 		},
 		{
@@ -129,12 +367,37 @@
 			"title": "Contact",
 			"config": {
 				"register": "pipelinq",
-				"schema": "contact",
-				"sidebarTabs": [
-					{ "id": "overview", "label": "Overview", "icon": "icon-info", "widgets": [{ "type": "data" }, { "type": "metadata" }], "order": 10 },
-					{ "id": "audit", "label": "Audit trail", "icon": "icon-history", "widgets": [{ "type": "audit-trail" }], "order": 90 }
-				]
-			}
+				"schema": "contact"
+			},
+			"widgets": [
+				{
+					"widgetKey": "data",
+					"slot": "sidebar",
+					"tabGroup": "overview",
+					"gridX": 0,
+					"gridY": 0,
+					"gridWidth": 1,
+					"gridHeight": 1
+				},
+				{
+					"widgetKey": "metadata",
+					"slot": "sidebar",
+					"tabGroup": "overview",
+					"gridX": 0,
+					"gridY": 1,
+					"gridWidth": 1,
+					"gridHeight": 1
+				},
+				{
+					"widgetKey": "audit-trail",
+					"slot": "sidebar",
+					"tabGroup": "audit",
+					"gridX": 0,
+					"gridY": 2,
+					"gridWidth": 1,
+					"gridHeight": 1
+				}
+			]
 		},
 		{
 			"id": "Leads",
@@ -144,8 +407,18 @@
 			"config": {
 				"register": "pipelinq",
 				"schema": "lead",
-				"columns": ["title", "stage", "status", "priority", "value", "expectedCloseDate"],
-				"sidebar": { "enabled": true, "showMetadata": true }
+				"columns": [
+					"title",
+					"stage",
+					"status",
+					"priority",
+					"value",
+					"expectedCloseDate"
+				],
+				"sidebar": {
+					"enabled": true,
+					"showMetadata": true
+				}
 			}
 		},
 		{
@@ -155,12 +428,37 @@
 			"title": "Lead",
 			"config": {
 				"register": "pipelinq",
-				"schema": "lead",
-				"sidebarTabs": [
-					{ "id": "overview", "label": "Overview", "icon": "icon-info", "widgets": [{ "type": "data" }, { "type": "metadata" }], "order": 10 },
-					{ "id": "audit", "label": "Audit trail", "icon": "icon-history", "widgets": [{ "type": "audit-trail" }], "order": 90 }
-				]
-			}
+				"schema": "lead"
+			},
+			"widgets": [
+				{
+					"widgetKey": "data",
+					"slot": "sidebar",
+					"tabGroup": "overview",
+					"gridX": 0,
+					"gridY": 0,
+					"gridWidth": 1,
+					"gridHeight": 1
+				},
+				{
+					"widgetKey": "metadata",
+					"slot": "sidebar",
+					"tabGroup": "overview",
+					"gridX": 0,
+					"gridY": 1,
+					"gridWidth": 1,
+					"gridHeight": 1
+				},
+				{
+					"widgetKey": "audit-trail",
+					"slot": "sidebar",
+					"tabGroup": "audit",
+					"gridX": 0,
+					"gridY": 2,
+					"gridWidth": 1,
+					"gridHeight": 1
+				}
+			]
 		},
 		{
 			"id": "Contactmomenten",
@@ -170,8 +468,17 @@
 			"config": {
 				"register": "pipelinq",
 				"schema": "contactmoment",
-				"columns": ["channel", "subject", "client", "agent", "occurredAt"],
-				"sidebar": { "enabled": true, "showMetadata": true }
+				"columns": [
+					"channel",
+					"subject",
+					"client",
+					"agent",
+					"occurredAt"
+				],
+				"sidebar": {
+					"enabled": true,
+					"showMetadata": true
+				}
 			}
 		},
 		{
@@ -179,7 +486,8 @@
 			"route": "/contactmomenten/new",
 			"type": "custom",
 			"title": "New contactmoment",
-			"component": "ContactmomentForm"
+			"component": "ContactmomentForm",
+			"_note": "Bespoke create wizard with client/contact resolution; lib gap: no multi-step create flow in declarative index type."
 		},
 		{
 			"id": "ContactmomentDetail",
@@ -188,12 +496,37 @@
 			"title": "Contactmoment",
 			"config": {
 				"register": "pipelinq",
-				"schema": "contactmoment",
-				"sidebarTabs": [
-					{ "id": "overview", "label": "Overview", "icon": "icon-info", "widgets": [{ "type": "data" }, { "type": "metadata" }], "order": 10 },
-					{ "id": "audit", "label": "Audit trail", "icon": "icon-history", "widgets": [{ "type": "audit-trail" }], "order": 90 }
-				]
-			}
+				"schema": "contactmoment"
+			},
+			"widgets": [
+				{
+					"widgetKey": "data",
+					"slot": "sidebar",
+					"tabGroup": "overview",
+					"gridX": 0,
+					"gridY": 0,
+					"gridWidth": 1,
+					"gridHeight": 1
+				},
+				{
+					"widgetKey": "metadata",
+					"slot": "sidebar",
+					"tabGroup": "overview",
+					"gridX": 0,
+					"gridY": 1,
+					"gridWidth": 1,
+					"gridHeight": 1
+				},
+				{
+					"widgetKey": "audit-trail",
+					"slot": "sidebar",
+					"tabGroup": "audit",
+					"gridX": 0,
+					"gridY": 2,
+					"gridWidth": 1,
+					"gridHeight": 1
+				}
+			]
 		},
 		{
 			"id": "Tasks",
@@ -203,8 +536,18 @@
 			"config": {
 				"register": "pipelinq",
 				"schema": "task",
-				"columns": ["title", "type", "status", "priority", "assignee", "dueDate"],
-				"sidebar": { "enabled": true, "showMetadata": true }
+				"columns": [
+					"title",
+					"type",
+					"status",
+					"priority",
+					"assignee",
+					"dueDate"
+				],
+				"sidebar": {
+					"enabled": true,
+					"showMetadata": true
+				}
 			}
 		},
 		{
@@ -212,7 +555,8 @@
 			"route": "/tasks/new",
 			"type": "custom",
 			"title": "New task",
-			"component": "TaskForm"
+			"component": "TaskForm",
+			"_note": "Bespoke create wizard with assignee lookup and recurrence controls; lib gap: no multi-step create flow."
 		},
 		{
 			"id": "TaskDetail",
@@ -221,12 +565,37 @@
 			"title": "Task",
 			"config": {
 				"register": "pipelinq",
-				"schema": "task",
-				"sidebarTabs": [
-					{ "id": "overview", "label": "Overview", "icon": "icon-info", "widgets": [{ "type": "data" }, { "type": "metadata" }], "order": 10 },
-					{ "id": "audit", "label": "Audit trail", "icon": "icon-history", "widgets": [{ "type": "audit-trail" }], "order": 90 }
-				]
-			}
+				"schema": "task"
+			},
+			"widgets": [
+				{
+					"widgetKey": "data",
+					"slot": "sidebar",
+					"tabGroup": "overview",
+					"gridX": 0,
+					"gridY": 0,
+					"gridWidth": 1,
+					"gridHeight": 1
+				},
+				{
+					"widgetKey": "metadata",
+					"slot": "sidebar",
+					"tabGroup": "overview",
+					"gridX": 0,
+					"gridY": 1,
+					"gridWidth": 1,
+					"gridHeight": 1
+				},
+				{
+					"widgetKey": "audit-trail",
+					"slot": "sidebar",
+					"tabGroup": "audit",
+					"gridX": 0,
+					"gridY": 2,
+					"gridWidth": 1,
+					"gridHeight": 1
+				}
+			]
 		},
 		{
 			"id": "Products",
@@ -236,8 +605,17 @@
 			"config": {
 				"register": "pipelinq",
 				"schema": "product",
-				"columns": ["name", "category", "type", "status", "price"],
-				"sidebar": { "enabled": true, "showMetadata": true }
+				"columns": [
+					"name",
+					"category",
+					"type",
+					"status",
+					"price"
+				],
+				"sidebar": {
+					"enabled": true,
+					"showMetadata": true
+				}
 			}
 		},
 		{
@@ -247,68 +625,101 @@
 			"title": "Product",
 			"config": {
 				"register": "pipelinq",
-				"schema": "product",
-				"sidebarTabs": [
-					{ "id": "overview", "label": "Overview", "icon": "icon-info", "widgets": [{ "type": "data" }, { "type": "metadata" }], "order": 10 },
-					{ "id": "audit", "label": "Audit trail", "icon": "icon-history", "widgets": [{ "type": "audit-trail" }], "order": 90 }
-				]
-			}
+				"schema": "product"
+			},
+			"widgets": [
+				{
+					"widgetKey": "data",
+					"slot": "sidebar",
+					"tabGroup": "overview",
+					"gridX": 0,
+					"gridY": 0,
+					"gridWidth": 1,
+					"gridHeight": 1
+				},
+				{
+					"widgetKey": "metadata",
+					"slot": "sidebar",
+					"tabGroup": "overview",
+					"gridX": 0,
+					"gridY": 1,
+					"gridWidth": 1,
+					"gridHeight": 1
+				},
+				{
+					"widgetKey": "audit-trail",
+					"slot": "sidebar",
+					"tabGroup": "audit",
+					"gridX": 0,
+					"gridY": 2,
+					"gridWidth": 1,
+					"gridHeight": 1
+				}
+			]
 		},
 		{
 			"id": "Pipeline",
 			"route": "/pipeline",
 			"type": "custom",
 			"title": "Pipeline",
-			"component": "PipelineBoardView"
+			"component": "PipelineBoardView",
+			"_note": "Kanban board with drag-and-drop lane management; lib gap: no kanban/board page type."
 		},
 		{
 			"id": "Queues",
 			"route": "/queues",
 			"type": "custom",
 			"title": "Queues",
-			"component": "QueueListView"
+			"component": "QueueListView",
+			"_note": "Bespoke routing-rule editor list with priority ordering; lib gap: no routing-rules list widget."
 		},
 		{
 			"id": "QueueDetail",
 			"route": "/queues/:id",
 			"type": "custom",
 			"title": "Queue",
-			"component": "QueueDetailView"
+			"component": "QueueDetailView",
+			"_note": "Bespoke routing-rule condition + action builder; lib gap: no routing-rules detail widget."
 		},
 		{
 			"id": "Kennisbank",
 			"route": "/kennisbank",
 			"type": "custom",
 			"title": "Kennisbank",
-			"component": "KennisbankHomeView"
+			"component": "KennisbankHomeView",
+			"_note": "Wiki home with article listing + category filter; lib gap: no wiki/knowledge-base page type."
 		},
 		{
 			"id": "KennisbankNew",
 			"route": "/kennisbank/articles/new",
 			"type": "custom",
 			"title": "New article",
-			"component": "ArticleEditorView"
+			"component": "ArticleEditorView",
+			"_note": "Markdown article editor with category picker; lib gap: no rich-text editor page type."
 		},
 		{
 			"id": "KennisbankDetail",
 			"route": "/kennisbank/articles/:id",
 			"type": "custom",
 			"title": "Article",
-			"component": "ArticleDetailView"
+			"component": "ArticleDetailView",
+			"_note": "Rendered markdown article view with related-articles panel; lib gap: no wiki article detail type."
 		},
 		{
 			"id": "KennisbankEdit",
 			"route": "/kennisbank/articles/:id/edit",
 			"type": "custom",
 			"title": "Edit article",
-			"component": "ArticleEditorView"
+			"component": "ArticleEditorView",
+			"_note": "Markdown article editor (edit path); lib gap: no rich-text editor page type."
 		},
 		{
 			"id": "KennisbankCategories",
 			"route": "/kennisbank/categories",
 			"type": "custom",
 			"title": "Categories",
-			"component": "CategoryManagerView"
+			"component": "CategoryManagerView",
+			"_note": "Drag-and-drop category tree manager; lib gap: no taxonomy/tree-manager page type."
 		},
 		{
 			"id": "Surveys",
@@ -318,8 +729,16 @@
 			"config": {
 				"register": "pipelinq",
 				"schema": "survey",
-				"columns": ["title", "status", "responseCount", "_dateCreated"],
-				"sidebar": { "enabled": true, "showMetadata": true }
+				"columns": [
+					"title",
+					"status",
+					"responseCount",
+					"_dateCreated"
+				],
+				"sidebar": {
+					"enabled": true,
+					"showMetadata": true
+				}
 			}
 		},
 		{
@@ -327,7 +746,8 @@
 			"route": "/surveys/new",
 			"type": "custom",
 			"title": "New survey",
-			"component": "SurveyFormView"
+			"component": "SurveyFormView",
+			"_note": "Survey builder with dynamic question types; lib gap: no form-builder page type."
 		},
 		{
 			"id": "SurveyDetail",
@@ -336,75 +756,109 @@
 			"title": "Survey",
 			"config": {
 				"register": "pipelinq",
-				"schema": "survey",
-				"sidebarTabs": [
-					{ "id": "overview", "label": "Overview", "icon": "icon-info", "widgets": [{ "type": "data" }, { "type": "metadata" }], "order": 10 },
-					{ "id": "audit", "label": "Audit trail", "icon": "icon-history", "widgets": [{ "type": "audit-trail" }], "order": 90 }
-				]
-			}
+				"schema": "survey"
+			},
+			"widgets": [
+				{
+					"widgetKey": "data",
+					"slot": "sidebar",
+					"tabGroup": "overview",
+					"gridX": 0,
+					"gridY": 0,
+					"gridWidth": 1,
+					"gridHeight": 1
+				},
+				{
+					"widgetKey": "metadata",
+					"slot": "sidebar",
+					"tabGroup": "overview",
+					"gridX": 0,
+					"gridY": 1,
+					"gridWidth": 1,
+					"gridHeight": 1
+				},
+				{
+					"widgetKey": "audit-trail",
+					"slot": "sidebar",
+					"tabGroup": "audit",
+					"gridX": 0,
+					"gridY": 2,
+					"gridWidth": 1,
+					"gridHeight": 1
+				}
+			]
 		},
 		{
 			"id": "SurveyEdit",
 			"route": "/surveys/:id/edit",
 			"type": "custom",
 			"title": "Edit survey",
-			"component": "SurveyFormView"
+			"component": "SurveyFormView",
+			"_note": "Survey builder (edit path); lib gap: no form-builder page type."
 		},
 		{
 			"id": "SurveyAnalytics",
 			"route": "/surveys/:id/analytics",
 			"type": "custom",
 			"title": "Survey analytics",
-			"component": "SurveyAnalyticsView"
+			"component": "SurveyAnalyticsView",
+			"_note": "Chart-driven survey response analytics with apexcharts; lib gap: no chart-widget page type."
 		},
 		{
 			"id": "PublicSurvey",
 			"route": "/public/survey/:token",
 			"type": "custom",
 			"title": "Survey",
-			"component": "PublicSurveyFormView"
+			"component": "PublicSurveyFormView",
+			"_note": "Anonymous-public survey response form (no auth required); genuine exception — no typed-page analogue for tokenised public routes."
 		},
 		{
 			"id": "MyWork",
 			"route": "/my-work",
 			"type": "custom",
 			"title": "My Work",
-			"component": "MyWorkView"
+			"component": "MyWorkView",
+			"_note": "Personalised work surface mixing tasks + leads + requests for the current user; genuine exception — no single-entity typed page captures multi-entity user dashboard."
 		},
 		{
 			"id": "SyncSettings",
 			"route": "/sync-settings",
 			"type": "custom",
 			"title": "Sync settings",
-			"component": "SyncSettingsView"
+			"component": "SyncSettingsView",
+			"_note": "External integration sync configuration panel; lib gap: no settings rich-section type for complex integration config."
 		},
 		{
 			"id": "Rapportage",
 			"route": "/rapportage",
 			"type": "custom",
 			"title": "Reporting",
-			"component": "RapportageDashboardView"
+			"component": "RapportageDashboardView",
+			"_note": "KPI reporting dashboard with apexcharts; lib gap: no chart-widget page type."
 		},
 		{
 			"id": "ChannelAnalytics",
 			"route": "/rapportage/channels",
 			"type": "custom",
 			"title": "Channel analytics",
-			"component": "ChannelAnalyticsView"
+			"component": "ChannelAnalyticsView",
+			"_note": "Channel breakdown analytics with apexcharts; lib gap: no chart-widget page type."
 		},
 		{
 			"id": "AgentPerformance",
 			"route": "/rapportage/agents",
 			"type": "custom",
 			"title": "Agent performance",
-			"component": "AgentPerformanceView"
+			"component": "AgentPerformanceView",
+			"_note": "Per-agent performance charts with apexcharts; lib gap: no chart-widget page type."
 		},
 		{
 			"id": "Pipelines",
 			"route": "/pipelines",
 			"type": "custom",
 			"title": "Pipelines",
-			"component": "PipelineManagerView"
+			"component": "PipelineManagerView",
+			"_note": "Pipeline stage + transition manager with drag-and-drop reordering; lib gap: no pipeline-designer page type."
 		},
 		{
 			"id": "Forms",
@@ -414,11 +868,26 @@
 			"config": {
 				"register": "pipelinq",
 				"schema": "intakeForm",
-				"columns": ["name", "isActive", "submitCount", "targetPipeline"],
-				"actions": [
-					{ "id": "submissions", "label": "View submissions", "icon": "format-list-bulleted", "handler": "navigate", "route": "FormSubmissions" }
+				"columns": [
+					"name",
+					"isActive",
+					"submitCount",
+					"targetPipeline"
 				],
-				"sidebar": { "enabled": true, "showMetadata": true }
+				"actions": [
+					{
+						"id": "submissions",
+						"label": "View submissions",
+						"icon": "format-list-bulleted",
+						"handler": "navigate",
+						"route": "FormSubmissions",
+						"type": "handler"
+					}
+				],
+				"sidebar": {
+					"enabled": true,
+					"showMetadata": true
+				}
 			}
 		},
 		{
@@ -426,14 +895,16 @@
 			"route": "/forms/new",
 			"type": "custom",
 			"title": "New form",
-			"component": "FormBuilderView"
+			"component": "FormBuilderView",
+			"_note": "Visual form builder with drag-and-drop field palette; lib gap: no form-builder page type."
 		},
 		{
 			"id": "FormDetail",
 			"route": "/forms/:id",
 			"type": "custom",
 			"title": "Form",
-			"component": "FormBuilderView"
+			"component": "FormBuilderView",
+			"_note": "Visual form builder (edit path); lib gap: no form-builder page type."
 		},
 		{
 			"id": "FormSubmissions",
@@ -443,14 +914,24 @@
 			"config": {
 				"register": "pipelinq",
 				"schema": "intakeSubmission",
-				"filter": { "form": "@route.id" },
+				"filter": {
+					"form": "@route.id"
+				},
 				"sortKey": "submittedAt",
 				"sortOrder": "desc",
-				"columns": ["submittedAt", "status", "contactId", "leadId"],
+				"columns": [
+					"submittedAt",
+					"status",
+					"contactId",
+					"leadId"
+				],
 				"emptyText": "No submissions yet",
 				"showAdd": false,
 				"showFormDialog": false,
-				"sidebar": { "enabled": true, "showMetadata": true }
+				"sidebar": {
+					"enabled": true,
+					"showMetadata": true
+				}
 			}
 		},
 		{
@@ -461,11 +942,27 @@
 			"config": {
 				"register": "pipelinq",
 				"schema": "automation",
-				"columns": ["name", "trigger", "isActive", "lastRun", "runCount"],
-				"actions": [
-					{ "id": "history", "label": "View history", "icon": "history", "handler": "navigate", "route": "AutomationHistory" }
+				"columns": [
+					"name",
+					"trigger",
+					"isActive",
+					"lastRun",
+					"runCount"
 				],
-				"sidebar": { "enabled": true, "showMetadata": true }
+				"actions": [
+					{
+						"id": "history",
+						"label": "View history",
+						"icon": "history",
+						"handler": "navigate",
+						"route": "AutomationHistory",
+						"type": "handler"
+					}
+				],
+				"sidebar": {
+					"enabled": true,
+					"showMetadata": true
+				}
 			}
 		},
 		{
@@ -473,14 +970,16 @@
 			"route": "/automations/new",
 			"type": "custom",
 			"title": "New automation",
-			"component": "AutomationBuilderView"
+			"component": "AutomationBuilderView",
+			"_note": "Visual automation graph editor (trigger + actions); lib gap: no automation-graph page type."
 		},
 		{
 			"id": "AutomationDetail",
 			"route": "/automations/:id",
 			"type": "custom",
 			"title": "Automation",
-			"component": "AutomationBuilderView"
+			"component": "AutomationBuilderView",
+			"_note": "Visual automation graph editor (edit path); lib gap: no automation-graph page type."
 		},
 		{
 			"id": "AutomationHistory",
@@ -490,10 +989,18 @@
 			"config": {
 				"register": "pipelinq",
 				"schema": "automationLog",
-				"filter": { "automation": "@route.id" },
+				"filter": {
+					"automation": "@route.id"
+				},
 				"sortKey": "triggeredAt",
 				"sortOrder": "desc",
-				"columns": ["triggeredAt", "status", "triggerEntity", "actionsExecuted", "error"],
+				"columns": [
+					"triggeredAt",
+					"status",
+					"triggerEntity",
+					"actionsExecuted",
+					"error"
+				],
 				"emptyText": "This automation has not been triggered yet.",
 				"selectable": false,
 				"showAdd": false,
@@ -511,7 +1018,8 @@
 			"route": "/features-roadmap",
 			"type": "custom",
 			"title": "Features & roadmap",
-			"component": "FeaturesRoadmap"
+			"component": "FeaturesRoadmap",
+			"_note": "Thin wrapper around the lib's CnFeaturesAndRoadmapView; in-product roadmap surface powered by OpenRegister's GitHub-issue proxy (ConductionNL/hydra#251)."
 		}
 	]
 }

--- a/src/registry.js
+++ b/src/registry.js
@@ -1,0 +1,211 @@
+// SPDX-License-Identifier: EUPL-1.2
+// Copyright (C) 2026 Conduction B.V.
+//
+// V2 component registry for pipelinq.
+//
+// Every entry here corresponds to a manifest `type: "custom"` page. The
+// registry maps the string key used in the manifest to a `{ kind, component }`
+// entry so CnAppRoot can resolve the component at render time.
+//
+// Recognised kinds: page, modal, widget, form-field, cell-renderer
+//
+// Resolution order (v2 renderer):
+//   1. Built-in page types   (CnIndexPage, CnDetailPage, …)
+//   2. Built-in widget types (version-info, register-mapping, …)
+//   3. registry (this file)  ← consumer-injected components
+//   4. customComponents      ← v1 fallback, kept during transition
+//
+// See:
+//   - openspec/changes/pipelinq-manifest-v1/design.md
+//   - hydra/openspec/architecture/adr-036-manifest-v2.md
+
+// --- Genuine exceptions: no abstract manifest analogue. ---
+import DashboardView from './views/Dashboard.vue'
+import MyWorkView from './views/MyWork.vue'
+import PublicSurveyFormView from './views/surveys/PublicSurveyForm.vue'
+
+// --- Bespoke create wizards (lib gap: no multi-step create flow). ---
+import ContactmomentForm from './views/contactmomenten/ContactmomentForm.vue'
+import TaskForm from './views/tasks/TaskForm.vue'
+
+// --- Kanban board (lib gap: no kanban/board page type). ---
+import PipelineBoardView from './views/pipeline/PipelineBoard.vue'
+
+// --- Queues / routing rules (lib gap: no routing-rules widget). ---
+import QueueListView from './views/queues/QueueList.vue'
+import QueueDetailView from './views/queues/QueueDetail.vue'
+
+// --- Kennisbank wiki (lib gap: no wiki page type). ---
+import KennisbankHomeView from './views/kennisbank/KennisbankHome.vue'
+import ArticleDetailView from './views/kennisbank/ArticleDetail.vue'
+import ArticleEditorView from './views/kennisbank/ArticleEditor.vue'
+import CategoryManagerView from './views/kennisbank/CategoryManager.vue'
+
+// --- Surveys builder/analytics (lib gap: no form-builder / chart page type). ---
+import SurveyFormView from './views/surveys/SurveyForm.vue'
+import SurveyAnalyticsView from './views/surveys/SurveyAnalytics.vue'
+
+// --- Forms visual builder (lib gap: no form-builder page type;
+//     Forms list + FormSubmissions are declarative type:"index"). ---
+import FormBuilderView from './views/forms/FormBuilder.vue'
+
+// --- Automations visual builder (lib gap: no automation-graph page type;
+//     Automations list + AutomationHistory are declarative type:"index"). ---
+import AutomationBuilderView from './views/automations/AutomationBuilder.vue'
+
+// --- Reporting dashboards (lib gap: no chart-widget page type). ---
+import RapportageDashboardView from './views/rapportage/RapportageDashboard.vue'
+import ChannelAnalyticsView from './views/rapportage/ChannelAnalytics.vue'
+import AgentPerformanceView from './views/rapportage/AgentPerformance.vue'
+
+// --- Admin managers (lib gap: no pipeline-designer / settings rich-section type). ---
+import PipelineManagerView from './views/settings/PipelineManager.vue'
+import SyncSettingsView from './views/sync/SyncSettings.vue'
+
+// --- Features & Roadmap page (lib's CnFeaturesAndRoadmapView wrapper). ---
+import FeaturesRoadmapView from './views/FeaturesRoadmap.vue'
+
+/**
+ * V2 component registry.
+ *
+ * Keys must match the `component` strings used in the manifest.
+ * All full-page custom routes are kind: "page" — the v2 renderer resolves
+ * any `component` key from this registry at render time.
+ *
+ * @type {Record<string, { kind: string, component: object, _note?: string }>}
+ */
+const registry = {
+	// --- Genuine exceptions: no abstract manifest analogue. ---
+	DashboardView: {
+		kind: 'page',
+		component: DashboardView,
+		_note: 'Bespoke multi-widget dashboard with gridstack layout; lib gap: no declarative dashboard page type with grid-aware widget placement.',
+	},
+	MyWorkView: {
+		kind: 'page',
+		component: MyWorkView,
+		_note: 'Personalised work surface mixing tasks + leads + requests for the current user; no single-entity typed page captures multi-entity user dashboard.',
+	},
+	PublicSurveyFormView: {
+		kind: 'page',
+		component: PublicSurveyFormView,
+		_note: 'Anonymous-public survey response form (no auth required); genuine exception — no typed-page analogue for tokenised public routes.',
+	},
+
+	// --- Bespoke create wizards. ---
+	ContactmomentForm: {
+		kind: 'page',
+		component: ContactmomentForm,
+		_note: 'Bespoke create wizard with client/contact resolution; lib gap: no multi-step create flow in declarative index type.',
+	},
+	TaskForm: {
+		kind: 'page',
+		component: TaskForm,
+		_note: 'Bespoke create wizard with assignee lookup and recurrence controls; lib gap: no multi-step create flow.',
+	},
+
+	// --- Kanban board. ---
+	PipelineBoardView: {
+		kind: 'page',
+		component: PipelineBoardView,
+		_note: 'Kanban board with drag-and-drop lane management; lib gap: no kanban/board page type.',
+	},
+
+	// --- Queues / routing rules. ---
+	QueueListView: {
+		kind: 'page',
+		component: QueueListView,
+		_note: 'Bespoke routing-rule editor list with priority ordering; lib gap: no routing-rules list widget.',
+	},
+	QueueDetailView: {
+		kind: 'page',
+		component: QueueDetailView,
+		_note: 'Bespoke routing-rule condition + action builder; lib gap: no routing-rules detail widget.',
+	},
+
+	// --- Kennisbank wiki. ---
+	KennisbankHomeView: {
+		kind: 'page',
+		component: KennisbankHomeView,
+		_note: 'Wiki home with article listing + category filter; lib gap: no wiki/knowledge-base page type.',
+	},
+	ArticleDetailView: {
+		kind: 'page',
+		component: ArticleDetailView,
+		_note: 'Rendered markdown article view with related-articles panel; lib gap: no wiki article detail type.',
+	},
+	ArticleEditorView: {
+		kind: 'page',
+		component: ArticleEditorView,
+		_note: 'Markdown article editor; lib gap: no rich-text editor page type.',
+	},
+	CategoryManagerView: {
+		kind: 'page',
+		component: CategoryManagerView,
+		_note: 'Drag-and-drop category tree manager; lib gap: no taxonomy/tree-manager page type.',
+	},
+
+	// --- Surveys. ---
+	SurveyFormView: {
+		kind: 'page',
+		component: SurveyFormView,
+		_note: 'Survey builder with dynamic question types; lib gap: no form-builder page type.',
+	},
+	SurveyAnalyticsView: {
+		kind: 'page',
+		component: SurveyAnalyticsView,
+		_note: 'Chart-driven survey response analytics with apexcharts; lib gap: no chart-widget page type.',
+	},
+
+	// --- Forms visual builder. ---
+	FormBuilderView: {
+		kind: 'page',
+		component: FormBuilderView,
+		_note: 'Visual form builder with drag-and-drop field palette; lib gap: no form-builder page type. Forms list + FormSubmissions use declarative type:"index".',
+	},
+
+	// --- Automations visual builder. ---
+	AutomationBuilderView: {
+		kind: 'page',
+		component: AutomationBuilderView,
+		_note: 'Visual automation graph editor (trigger + actions); lib gap: no automation-graph page type. Automations list + AutomationHistory use declarative type:"index".',
+	},
+
+	// --- Reporting dashboards. ---
+	RapportageDashboardView: {
+		kind: 'page',
+		component: RapportageDashboardView,
+		_note: 'KPI reporting dashboard with apexcharts; lib gap: no chart-widget page type.',
+	},
+	ChannelAnalyticsView: {
+		kind: 'page',
+		component: ChannelAnalyticsView,
+		_note: 'Channel breakdown analytics with apexcharts; lib gap: no chart-widget page type.',
+	},
+	AgentPerformanceView: {
+		kind: 'page',
+		component: AgentPerformanceView,
+		_note: 'Per-agent performance charts with apexcharts; lib gap: no chart-widget page type.',
+	},
+
+	// --- Admin managers. ---
+	PipelineManagerView: {
+		kind: 'page',
+		component: PipelineManagerView,
+		_note: 'Pipeline stage + transition manager with drag-and-drop reordering; lib gap: no pipeline-designer page type.',
+	},
+	SyncSettingsView: {
+		kind: 'page',
+		component: SyncSettingsView,
+		_note: 'External integration sync configuration panel; lib gap: no settings rich-section type for complex integration config.',
+	},
+
+	// --- Features & Roadmap page (lib's CnFeaturesAndRoadmapView wrapper). ---
+	FeaturesRoadmap: {
+		kind: 'page',
+		component: FeaturesRoadmapView,
+		_note: 'Thin wrapper around the lib\'s CnFeaturesAndRoadmapView; in-product roadmap surface powered by OpenRegister\'s GitHub-issue proxy.',
+	},
+}
+
+export default registry


### PR DESCRIPTION
## Summary

Phase 2 of the v2 manifest rollout ([hydra ADR-036](https://github.com/ConductionNL/hydra/blob/development/openspec/architecture/adr-036-universal-widget-manifest.md)). The v1 manifest is now v2: unified `widgets[]` array, grid coordinates per widget, the 5-kind component registry, and (where applicable) `_note` fields on remaining `type: "custom"` pages.

### What changed
- `@conduction/nextcloud-vue`: `^1.0.0-beta.40` → `^1.0.0-beta.58` (Ajv CSP hotfix from nc-vue #259 included)
- `src/manifest.json`: codemod-migrated v1 → v2
- `src/registry.js` (new): 5-kind component registry
- `src/main.js` + `src/App.vue`: `registry` prop wired on `CnAppRoot` alongside existing `customComponents`

### References
- [procest #512](https://github.com/ConductionNL/procest/pull/512) — first reference migration (58 pages, merged today)
- [mydash #206](https://github.com/ConductionNL/mydash/pull/206) — runtime-manifest reference (merged today)

### Hydra labels
Not adding `ready-for-code-review` / `ready-for-security-review` — Hydra is paused. Ready for manual review.

## Test plan
- [ ] `npm run build` clean
- [ ] `validateManifestV2(manifest)` returns `{ valid: true, errors: [] }`
- [ ] App boots in browser; Vue mounts; no new CSP errors