### PR TITLE
fix(webpack): bundle vue-router/vue-i18n/axios into shared vendor chunk

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -115,7 +115,7 @@ webpackConfig.optimization = {
 			},
 			vendor: {
 				name: appId + '-shared-vendor',
-				test: /[\\/]node_modules[\\/](vue|pinia|vue-material-design-icons|@vueuse|core-js)[\\/]/,
+				test: /[\\/]node_modules[\\/](vue|vue-router|vue-i18n|pinia|vue-material-design-icons|@vueuse|core-js|axios)[\\/]/,
 				priority: 20,
 				reuseExistingChunk: true,
 				enforce: true,


### PR DESCRIPTION
The splitChunks config disables defaults (`default:false` + `defaultVendors:false`), so anything not matched by the `ncVue` or `vendor` regex stays inlined in whichever entry imported it.

nc-vue's CJS bundle imports `vue-router` internally, while `main.js` imports it directly — which produced a runtime `ReferenceError: t is not defined` when the ncVue chunk tried to reach a `vue-router` copy that only lived in the main entry.

Extends the vendor regex with `vue-router`, `vue-i18n`, and `axios` so they end up in the shared chunk every entry already loads. Verified in browser — app renders cleanly with 0 console errors.