### PR TITLE
refactor(manifest): pipelinq customs → new lib components (real cleanup)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
 			"version": "0.1.0",
 			"license": "EUPL-1.2",
 			"dependencies": {
-				"@conduction/nextcloud-vue": "^1.0.0-beta.61",
+				"@conduction/nextcloud-vue": "^1.0.0-beta.63",
 				"@nextcloud/axios": "~2.5.2",
 				"@nextcloud/dialogs": "^3.2.0",
 				"@nextcloud/initial-state": "^2.2.0",
@@ -1797,9 +1797,9 @@
 			}
 		},
 		"node_modules/@conduction/nextcloud-vue": {
-			"version": "1.0.0-beta.61",
-			"resolved": "https://registry.npmjs.org/@conduction/nextcloud-vue/-/nextcloud-vue-1.0.0-beta.61.tgz",
-			"integrity": "sha512-VIN6p+I5Lh0NQ62/hpBQ88ezZ9V+GP21Vp8RddsouYp1iVvXVwlsXryQVVFbyPCDHya7RQ3hXLnWwhj1ok8Dmg==",
+			"version": "1.0.0-beta.63",
+			"resolved": "https://registry.npmjs.org/@conduction/nextcloud-vue/-/nextcloud-vue-1.0.0-beta.63.tgz",
+			"integrity": "sha512-qMJ2PLNSiK0w7F+ttFvJI1WEJBxTE9kTCoH6V1G0PRsCiI91SD+cyFfQidWuIpAUlkpApmWhueFaIxijpTYUwQ==",
 			"license": "EUPL-1.2",
 			"dependencies": {
 				"@codemirror/autocomplete": "^6.0.0",
@@ -18488,9 +18488,9 @@
 			}
 		},
 		"@conduction/nextcloud-vue": {
-			"version": "1.0.0-beta.61",
-			"resolved": "https://registry.npmjs.org/@conduction/nextcloud-vue/-/nextcloud-vue-1.0.0-beta.61.tgz",
-			"integrity": "sha512-VIN6p+I5Lh0NQ62/hpBQ88ezZ9V+GP21Vp8RddsouYp1iVvXVwlsXryQVVFbyPCDHya7RQ3hXLnWwhj1ok8Dmg==",
+			"version": "1.0.0-beta.63",
+			"resolved": "https://registry.npmjs.org/@conduction/nextcloud-vue/-/nextcloud-vue-1.0.0-beta.63.tgz",
+			"integrity": "sha512-qMJ2PLNSiK0w7F+ttFvJI1WEJBxTE9kTCoH6V1G0PRsCiI91SD+cyFfQidWuIpAUlkpApmWhueFaIxijpTYUwQ==",
 			"requires": {
 				"@codemirror/autocomplete": "^6.0.0",
 				"@codemirror/commands": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
 		"extends @nextcloud/browserslist-config"
 	],
 	"dependencies": {
-		"@conduction/nextcloud-vue": "^1.0.0-beta.61",
+		"@conduction/nextcloud-vue": "^1.0.0-beta.63",
 		"@nextcloud/axios": "~2.5.2",
 		"@nextcloud/dialogs": "^3.2.0",
 		"@nextcloud/initial-state": "^2.2.0",

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -504,32 +504,10 @@
 		{
 			"id": "ContactmomentNew",
 			"route": "/contactmomenten/new",
-			"type": "dashboard",
+			"type": "custom",
 			"title": "New contactmoment",
-			"config": {
-				"widgets": [
-					{
-						"id": "ContactmomentFormWidget",
-						"title": "New contactmoment",
-						"type": "custom"
-					}
-				],
-				"layout": [
-					{
-						"id": 1,
-						"widgetId": "ContactmomentFormWidget",
-						"gridX": 0,
-						"gridY": 0,
-						"gridWidth": 12,
-						"gridHeight": 12,
-						"showTitle": false
-					}
-				]
-			},
-			"slots": {
-				"widget-ContactmomentFormWidget": "ContactmomentForm"
-			},
-			"_note": "Bespoke create wizard with client/contact resolution; lib gap: no multi-step create flow in declarative index type."
+			"component": "ContactmomentForm",
+			"_note": "Bespoke create wizard — channel-selector buttons + CallTimer don't fit declarative type:\"form\" fields[]. Lib gap: multi-step form actions."
 		},
 		{
 			"id": "ContactmomentDetail",
@@ -595,32 +573,10 @@
 		{
 			"id": "TaskNew",
 			"route": "/tasks/new",
-			"type": "dashboard",
+			"type": "custom",
 			"title": "New task",
-			"config": {
-				"widgets": [
-					{
-						"id": "TaskFormWidget",
-						"title": "New task",
-						"type": "custom"
-					}
-				],
-				"layout": [
-					{
-						"id": 1,
-						"widgetId": "TaskFormWidget",
-						"gridX": 0,
-						"gridY": 0,
-						"gridWidth": 12,
-						"gridHeight": 12,
-						"showTitle": false
-					}
-				]
-			},
-			"slots": {
-				"widget-TaskFormWidget": "TaskForm"
-			},
-			"_note": "Bespoke create wizard with assignee lookup and recurrence controls; lib gap: no multi-step create flow."
+			"component": "TaskForm",
+			"_note": "Bespoke create wizard — multi-step layout + dynamic channel-driven fields don't fit type:\"form\". Lib gap: multi-step form actions."
 		},
 		{
 			"id": "TaskDetail",
@@ -724,32 +680,10 @@
 		{
 			"id": "Pipeline",
 			"route": "/pipeline",
-			"type": "dashboard",
+			"type": "custom",
 			"title": "Pipeline",
-			"config": {
-				"widgets": [
-					{
-						"id": "PipelineBoardViewWidget",
-						"title": "Pipeline",
-						"type": "custom"
-					}
-				],
-				"layout": [
-					{
-						"id": 1,
-						"widgetId": "PipelineBoardViewWidget",
-						"gridX": 0,
-						"gridY": 0,
-						"gridWidth": 12,
-						"gridHeight": 12,
-						"showTitle": false
-					}
-				]
-			},
-			"slots": {
-				"widget-PipelineBoardViewWidget": "PipelineBoardView"
-			},
-			"_note": "Kanban board with drag-and-drop lane management; lib gap: no kanban/board page type."
+			"component": "PipelineBoardView",
+			"_note": "Bespoke kanban board with drag-drop column reorder + per-card status transitions. No lib analogue."
 		},
 		{
 			"id": "Queues",
@@ -788,152 +722,42 @@
 		{
 			"id": "Kennisbank",
 			"route": "/kennisbank",
-			"type": "dashboard",
+			"type": "custom",
 			"title": "Kennisbank",
-			"config": {
-				"widgets": [
-					{
-						"id": "KennisbankHomeViewWidget",
-						"title": "Kennisbank",
-						"type": "custom"
-					}
-				],
-				"layout": [
-					{
-						"id": 1,
-						"widgetId": "KennisbankHomeViewWidget",
-						"gridX": 0,
-						"gridY": 0,
-						"gridWidth": 12,
-						"gridHeight": 12,
-						"showTitle": false
-					}
-				]
-			},
-			"slots": {
-				"widget-KennisbankHomeViewWidget": "KennisbankHomeView"
-			},
-			"_note": "Wiki home with article listing + category filter; lib gap: no wiki/knowledge-base page type."
+			"component": "KennisbankHomeView",
+			"_note": "Knowledge-base landing page (article browser + category tree + search). Could be a type:\"dashboard\" widget composition once tree-widget lands."
 		},
 		{
 			"id": "KennisbankNew",
 			"route": "/kennisbank/articles/new",
-			"type": "dashboard",
+			"type": "custom",
 			"title": "New article",
-			"config": {
-				"widgets": [
-					{
-						"id": "ArticleEditorViewWidget",
-						"title": "New article",
-						"type": "custom"
-					}
-				],
-				"layout": [
-					{
-						"id": 1,
-						"widgetId": "ArticleEditorViewWidget",
-						"gridX": 0,
-						"gridY": 0,
-						"gridWidth": 12,
-						"gridHeight": 12,
-						"showTitle": false
-					}
-				]
-			},
-			"slots": {
-				"widget-ArticleEditorViewWidget": "ArticleEditorView"
-			},
-			"_note": "Markdown article editor with category picker; lib gap: no rich-text editor page type."
+			"component": "ArticleEditorView",
+			"_note": "Rich-text article editor (TipTap-based). Lib gap: no markdown/wysiwyg widget yet."
 		},
 		{
 			"id": "KennisbankDetail",
 			"route": "/kennisbank/articles/:id",
-			"type": "dashboard",
+			"type": "custom",
 			"title": "Article",
-			"config": {
-				"widgets": [
-					{
-						"id": "ArticleDetailViewWidget",
-						"title": "Article",
-						"type": "custom"
-					}
-				],
-				"layout": [
-					{
-						"id": 1,
-						"widgetId": "ArticleDetailViewWidget",
-						"gridX": 0,
-						"gridY": 0,
-						"gridWidth": 12,
-						"gridHeight": 12,
-						"showTitle": false
-					}
-				]
-			},
-			"slots": {
-				"widget-ArticleDetailViewWidget": "ArticleDetailView"
-			},
-			"_note": "Rendered markdown article view with related-articles panel; lib gap: no wiki article detail type."
+			"component": "ArticleDetailView",
+			"_note": "Article reader with rendered markdown + sidebar metadata. Could be type:\"wiki\" once that page-type stabilises across the fleet."
 		},
 		{
 			"id": "KennisbankEdit",
 			"route": "/kennisbank/articles/:id/edit",
-			"type": "dashboard",
+			"type": "custom",
 			"title": "Edit article",
-			"config": {
-				"widgets": [
-					{
-						"id": "ArticleEditorViewWidget",
-						"title": "Edit article",
-						"type": "custom"
-					}
-				],
-				"layout": [
-					{
-						"id": 1,
-						"widgetId": "ArticleEditorViewWidget",
-						"gridX": 0,
-						"gridY": 0,
-						"gridWidth": 12,
-						"gridHeight": 12,
-						"showTitle": false
-					}
-				]
-			},
-			"slots": {
-				"widget-ArticleEditorViewWidget": "ArticleEditorView"
-			},
-			"_note": "Markdown article editor (edit path); lib gap: no rich-text editor page type."
+			"component": "ArticleEditorView",
+			"_note": "Rich-text article editor (TipTap-based). Lib gap: no markdown/wysiwyg widget yet."
 		},
 		{
 			"id": "KennisbankCategories",
 			"route": "/kennisbank/categories",
-			"type": "dashboard",
+			"type": "custom",
 			"title": "Categories",
-			"config": {
-				"widgets": [
-					{
-						"id": "CategoryManagerViewWidget",
-						"title": "Categories",
-						"type": "custom"
-					}
-				],
-				"layout": [
-					{
-						"id": 1,
-						"widgetId": "CategoryManagerViewWidget",
-						"gridX": 0,
-						"gridY": 0,
-						"gridWidth": 12,
-						"gridHeight": 12,
-						"showTitle": false
-					}
-				]
-			},
-			"slots": {
-				"widget-CategoryManagerViewWidget": "CategoryManagerView"
-			},
-			"_note": "Drag-and-drop category tree manager; lib gap: no taxonomy/tree-manager page type."
+			"component": "CategoryManagerView",
+			"_note": "Hierarchical category tree with drag-drop reorder + nested CRUD. Lib gap: tree widget."
 		},
 		{
 			"id": "Surveys",
@@ -958,32 +782,10 @@
 		{
 			"id": "SurveyCreate",
 			"route": "/surveys/new",
-			"type": "dashboard",
+			"type": "custom",
 			"title": "New survey",
-			"config": {
-				"widgets": [
-					{
-						"id": "SurveyFormViewWidget",
-						"title": "New survey",
-						"type": "custom"
-					}
-				],
-				"layout": [
-					{
-						"id": 1,
-						"widgetId": "SurveyFormViewWidget",
-						"gridX": 0,
-						"gridY": 0,
-						"gridWidth": 12,
-						"gridHeight": 12,
-						"showTitle": false
-					}
-				]
-			},
-			"slots": {
-				"widget-SurveyFormViewWidget": "SurveyFormView"
-			},
-			"_note": "Survey builder with dynamic question types; lib gap: no form-builder page type."
+			"component": "SurveyFormView",
+			"_note": "Visual survey builder (drag-drop question blocks). Lib gap: form-builder page type."
 		},
 		{
 			"id": "SurveyDetail",
@@ -1027,32 +829,10 @@
 		{
 			"id": "SurveyEdit",
 			"route": "/surveys/:id/edit",
-			"type": "dashboard",
+			"type": "custom",
 			"title": "Edit survey",
-			"config": {
-				"widgets": [
-					{
-						"id": "SurveyFormViewWidget",
-						"title": "Edit survey",
-						"type": "custom"
-					}
-				],
-				"layout": [
-					{
-						"id": 1,
-						"widgetId": "SurveyFormViewWidget",
-						"gridX": 0,
-						"gridY": 0,
-						"gridWidth": 12,
-						"gridHeight": 12,
-						"showTitle": false
-					}
-				]
-			},
-			"slots": {
-				"widget-SurveyFormViewWidget": "SurveyFormView"
-			},
-			"_note": "Survey builder (edit path); lib gap: no form-builder page type."
+			"component": "SurveyFormView",
+			"_note": "Visual survey builder (drag-drop question blocks). Lib gap: form-builder page type."
 		},
 		{
 			"id": "SurveyAnalyticsView",
@@ -1085,32 +865,10 @@
 		{
 			"id": "PublicSurvey",
 			"route": "/public/survey/:token",
-			"type": "dashboard",
+			"type": "custom",
 			"title": "Survey",
-			"config": {
-				"widgets": [
-					{
-						"id": "PublicSurveyFormViewWidget",
-						"title": "Survey",
-						"type": "custom"
-					}
-				],
-				"layout": [
-					{
-						"id": 1,
-						"widgetId": "PublicSurveyFormViewWidget",
-						"gridX": 0,
-						"gridY": 0,
-						"gridWidth": 12,
-						"gridHeight": 12,
-						"showTitle": false
-					}
-				]
-			},
-			"slots": {
-				"widget-PublicSurveyFormViewWidget": "PublicSurveyFormView"
-			},
-			"_note": "Anonymous-public survey response form (no auth required); genuine exception — no typed-page analogue for tokenised public routes."
+			"component": "PublicSurveyFormView",
+			"_note": "Public survey response page (unauthenticated, token-scoped). Lib gap: type:\"form\" with mode:\"public\" + token route binding."
 		},
 		{
 			"id": "MyWork",

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -506,8 +506,11 @@
 			"route": "/contactmomenten/new",
 			"type": "custom",
 			"title": "New contactmoment",
-			"component": "ContactmomentForm",
-			"_note": "Bespoke create wizard — channel-selector buttons + CallTimer don't fit declarative type:\"form\" fields[]. Lib gap: multi-step form actions."
+			"component": "CnWizardDialog",
+			"config": {
+				"register": "pipelinq",
+				"schema": "contactmoment"
+			}
 		},
 		{
 			"id": "ContactmomentDetail",
@@ -575,8 +578,11 @@
 			"route": "/tasks/new",
 			"type": "custom",
 			"title": "New task",
-			"component": "TaskForm",
-			"_note": "Bespoke create wizard — multi-step layout + dynamic channel-driven fields don't fit type:\"form\". Lib gap: multi-step form actions."
+			"component": "CnWizardDialog",
+			"config": {
+				"register": "pipelinq",
+				"schema": "task"
+			}
 		},
 		{
 			"id": "TaskDetail",
@@ -722,42 +728,104 @@
 		{
 			"id": "Kennisbank",
 			"route": "/kennisbank",
-			"type": "custom",
+			"type": "dashboard",
 			"title": "Kennisbank",
-			"component": "KennisbankHomeView",
-			"_note": "Knowledge-base landing page (article browser + category tree + search). Could be a type:\"dashboard\" widget composition once tree-widget lands."
+			"config": {
+				"widgets": [
+					{
+						"id": "kennisbankCategories",
+						"title": "Categories",
+						"type": "CnTreeView"
+					},
+					{
+						"id": "kennisbankArticles",
+						"title": "Articles",
+						"type": "CnIndexPage"
+					}
+				],
+				"layout": [
+					{
+						"id": "kennisbankCategories",
+						"widgetId": "kennisbankCategories",
+						"gridX": 0,
+						"gridY": 0,
+						"gridWidth": 3,
+						"gridHeight": 12
+					},
+					{
+						"id": "kennisbankArticles",
+						"widgetId": "kennisbankArticles",
+						"gridX": 3,
+						"gridY": 0,
+						"gridWidth": 9,
+						"gridHeight": 12
+					}
+				]
+			}
 		},
 		{
 			"id": "KennisbankNew",
 			"route": "/kennisbank/articles/new",
-			"type": "custom",
+			"type": "form",
 			"title": "New article",
-			"component": "ArticleEditorView",
-			"_note": "Rich-text article editor (TipTap-based). Lib gap: no markdown/wysiwyg widget yet."
+			"config": {
+				"register": "pipelinq",
+				"schema": "article",
+				"mode": "create",
+				"submitEndpoint": "/index.php/apps/openregister/api/objects/pipelinq/article",
+				"submitMethod": "POST",
+				"fieldWidgets": [
+					{
+						"field": "body",
+						"component": "CnMarkdownEditor"
+					}
+				]
+			}
 		},
 		{
 			"id": "KennisbankDetail",
 			"route": "/kennisbank/articles/:id",
-			"type": "custom",
+			"type": "wiki",
 			"title": "Article",
-			"component": "ArticleDetailView",
-			"_note": "Article reader with rendered markdown + sidebar metadata. Could be type:\"wiki\" once that page-type stabilises across the fleet."
+			"config": {
+				"register": "pipelinq",
+				"schema": "article",
+				"titleField": "title",
+				"contentField": "body",
+				"categoryField": "category"
+			}
 		},
 		{
 			"id": "KennisbankEdit",
 			"route": "/kennisbank/articles/:id/edit",
-			"type": "custom",
+			"type": "form",
 			"title": "Edit article",
-			"component": "ArticleEditorView",
-			"_note": "Rich-text article editor (TipTap-based). Lib gap: no markdown/wysiwyg widget yet."
+			"config": {
+				"register": "pipelinq",
+				"schema": "article",
+				"mode": "edit",
+				"submitEndpoint": "/index.php/apps/openregister/api/objects/pipelinq/article/:id",
+				"submitMethod": "PUT",
+				"fieldWidgets": [
+					{
+						"field": "body",
+						"component": "CnMarkdownEditor"
+					}
+				]
+			}
 		},
 		{
 			"id": "KennisbankCategories",
 			"route": "/kennisbank/categories",
 			"type": "custom",
 			"title": "Categories",
-			"component": "CategoryManagerView",
-			"_note": "Hierarchical category tree with drag-drop reorder + nested CRUD. Lib gap: tree widget."
+			"component": "CnTreeView",
+			"config": {
+				"register": "pipelinq",
+				"schema": "articleCategory",
+				"parentField": "parent",
+				"editable": true
+			}
 		},
 		{
 			"id": "Surveys",
@@ -784,8 +852,11 @@
 			"route": "/surveys/new",
 			"type": "custom",
 			"title": "New survey",
-			"component": "SurveyFormView",
-			"_note": "Visual survey builder (drag-drop question blocks). Lib gap: form-builder page type."
+			"component": "CnFormBuilder",
+			"config": {
+				"register": "pipelinq",
+				"schema": "survey"
+			}
 		},
 		{
 			"id": "SurveyDetail",
@@ -831,8 +902,11 @@
 			"route": "/surveys/:id/edit",
 			"type": "custom",
 			"title": "Edit survey",
-			"component": "SurveyFormView",
-			"_note": "Visual survey builder (drag-drop question blocks). Lib gap: form-builder page type."
+			"component": "CnFormBuilder",
+			"config": {
+				"register": "pipelinq",
+				"schema": "survey"
+			}
 		},
 		{
 			"id": "SurveyAnalyticsView",
@@ -865,10 +939,16 @@
 		{
 			"id": "PublicSurvey",
 			"route": "/public/survey/:token",
-			"type": "custom",
+			"type": "form",
 			"title": "Survey",
-			"component": "PublicSurveyFormView",
-			"_note": "Public survey response page (unauthenticated, token-scoped). Lib gap: type:\"form\" with mode:\"public\" + token route binding."
+			"config": {
+				"register": "pipelinq",
+				"schema": "surveyResponse",
+				"mode": "public",
+				"token": "@route.token",
+				"submitEndpoint": "/index.php/apps/pipelinq/api/public/surveys/:token/responses",
+				"submitMethod": "POST"
+			}
 		},
 		{
 			"id": "MyWork",


### PR DESCRIPTION
## Summary

Decomposes 10 of the 11 pipelinq `type:'custom'` pages onto lib-provided declarative shapes now that `@conduction/nextcloud-vue@1.0.0-beta.63` ships the missing primitives. Replaces the prior "honest customs / revert holding pattern" — the lib gaps are closed, so the manifest no longer carries `_note` rationales for the flipped pages.

## What changed

| Custom id | New target |
|---|---|
| `ContactmomentNew` | `type:custom` + `component:CnWizardDialog` (from lib) |
| `TaskNew` | `type:custom` + `component:CnWizardDialog` (from lib) |
| `Kennisbank` | `type:dashboard` composing `CnTreeView` (categories) + `CnIndexPage` (articles) via `widgets[]` / `layout[]` |
| `KennisbankNew` | `type:form` with `fieldWidgets[].component:CnMarkdownEditor` for the `body` field |
| `KennisbankEdit` | `type:form` with `fieldWidgets[].component:CnMarkdownEditor` for the `body` field |
| `KennisbankDetail` | `type:wiki` (typed `contentField` / `titleField` / `categoryField` per schema 2.4.0) |
| `KennisbankCategories` | `type:custom` + `component:CnTreeView` (hierarchical edit) |
| `SurveyCreate` | `type:custom` + `component:CnFormBuilder` (from lib) |
| `SurveyEdit` | `type:custom` + `component:CnFormBuilder` (from lib) |
| `PublicSurvey` | `type:form` with `config.mode:'public'` + `@route.token` sentinel |

**Kept as `type:'custom'`** (no lib analogue):
- `Pipeline` — bespoke kanban board with drag-drop column reorder + per-card status transitions. `_note` retained.

## Dependencies

- Bumps `@conduction/nextcloud-vue` to `^1.0.0-beta.63` (was `^1.0.0-beta.61`).

## Out of scope (follow-up)

- The legacy `.vue` view files in `src/views/` (`ContactmomentForm`, `TaskForm`, `KennisbankHomeView`, `ArticleEditorView`, `ArticleDetailView`, `CategoryManagerView`, `SurveyFormView`, `PublicSurveyFormView`) are left in place. Now that the manifest re-targets to lib components, those files are dead code — cleanup PR to follow.

## Validation

- `python3 -c "import json; json.load(open('src/manifest.json'))"` → parses, 48 pages.
- Duplicate-key check (object_pairs_hook strict) → clean.
- `node tests/validate-manifest.js` → Ajv FAIL count dropped from 29 (base) to 18, every remaining error is **pre-existing** (`layout.id` int-vs-string on Dashboard/MyWork/Rapportage/etc., `actions[0]` additionalProperties on Forms/Automations) — not introduced by this PR. Will be addressed in a separate sweep.

## Test plan

- [ ] Smoke-test each flipped page in the dev container (browser-2):
  - [ ] `/contactmomenten/new` renders CnWizardDialog
  - [ ] `/tasks/new` renders CnWizardDialog
  - [ ] `/kennisbank` shows tree + article list
  - [ ] `/kennisbank/articles/new` + `/edit` renders form with markdown editor
  - [ ] `/kennisbank/articles/:id` renders wiki view
  - [ ] `/kennisbank/categories` renders editable tree
  - [ ] `/surveys/new` + `/edit` renders CnFormBuilder
  - [ ] `/public/survey/:token` renders public form
  - [ ] `/pipeline` still renders the bespoke kanban (unchanged)

Closes pipelinq#415 holding-pattern.