### PR TITLE
fix(manifest): restore detail-page widgets[] + sidebarTabs[] declarations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1797,9 +1797,9 @@
 			}
 		},
 		"node_modules/@conduction/nextcloud-vue": {
-			"version": "1.0.0-beta.63",
-			"resolved": "https://registry.npmjs.org/@conduction/nextcloud-vue/-/nextcloud-vue-1.0.0-beta.63.tgz",
-			"integrity": "sha512-qMJ2PLNSiK0w7F+ttFvJI1WEJBxTE9kTCoH6V1G0PRsCiI91SD+cyFfQidWuIpAUlkpApmWhueFaIxijpTYUwQ==",
+			"version": "1.0.0-beta.64",
+			"resolved": "https://registry.npmjs.org/@conduction/nextcloud-vue/-/nextcloud-vue-1.0.0-beta.64.tgz",
+			"integrity": "sha512-gbfCHr3PNtvGjXkGGcdItioF53IABDIot7xKvLsaHmMU4OxZXwMbWrQxmF7boIZV7fUs0zt4ENT5HPJoYa23ug==",
 			"license": "EUPL-1.2",
 			"dependencies": {
 				"@codemirror/autocomplete": "^6.0.0",
@@ -18488,9 +18488,9 @@
 			}
 		},
 		"@conduction/nextcloud-vue": {
-			"version": "1.0.0-beta.63",
-			"resolved": "https://registry.npmjs.org/@conduction/nextcloud-vue/-/nextcloud-vue-1.0.0-beta.63.tgz",
-			"integrity": "sha512-qMJ2PLNSiK0w7F+ttFvJI1WEJBxTE9kTCoH6V1G0PRsCiI91SD+cyFfQidWuIpAUlkpApmWhueFaIxijpTYUwQ==",
+			"version": "1.0.0-beta.64",
+			"resolved": "https://registry.npmjs.org/@conduction/nextcloud-vue/-/nextcloud-vue-1.0.0-beta.64.tgz",
+			"integrity": "sha512-gbfCHr3PNtvGjXkGGcdItioF53IABDIot7xKvLsaHmMU4OxZXwMbWrQxmF7boIZV7fUs0zt4ENT5HPJoYa23ug==",
 			"requires": {
 				"@codemirror/autocomplete": "^6.0.0",
 				"@codemirror/commands": "^6.0.0",

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -207,8 +207,49 @@
 			"title": "Client",
 			"config": {
 				"register": "pipelinq",
-				"schema": "client"
-			}
+				"schema": "client",
+				"sidebarTabs": [
+					{
+						"id": "overview",
+						"label": "Overview",
+						"order": 1
+					},
+					{
+						"id": "audit",
+						"label": "Audit trail",
+						"order": 2
+					}
+				]
+			},
+			"widgets": [
+				{
+					"widgetKey": "data",
+					"slot": "sidebar",
+					"tabGroup": "overview",
+					"gridX": 0,
+					"gridY": 0,
+					"gridWidth": 1,
+					"gridHeight": 1
+				},
+				{
+					"widgetKey": "metadata",
+					"slot": "sidebar",
+					"tabGroup": "overview",
+					"gridX": 0,
+					"gridY": 1,
+					"gridWidth": 1,
+					"gridHeight": 1
+				},
+				{
+					"widgetKey": "audit-trail",
+					"slot": "sidebar",
+					"tabGroup": "audit",
+					"gridX": 0,
+					"gridY": 2,
+					"gridWidth": 1,
+					"gridHeight": 1
+				}
+			]
 		},
 		{
 			"id": "Requests",
@@ -238,8 +279,49 @@
 			"title": "Request",
 			"config": {
 				"register": "pipelinq",
-				"schema": "request"
-			}
+				"schema": "request",
+				"sidebarTabs": [
+					{
+						"id": "overview",
+						"label": "Overview",
+						"order": 1
+					},
+					{
+						"id": "audit",
+						"label": "Audit trail",
+						"order": 2
+					}
+				]
+			},
+			"widgets": [
+				{
+					"widgetKey": "data",
+					"slot": "sidebar",
+					"tabGroup": "overview",
+					"gridX": 0,
+					"gridY": 0,
+					"gridWidth": 1,
+					"gridHeight": 1
+				},
+				{
+					"widgetKey": "metadata",
+					"slot": "sidebar",
+					"tabGroup": "overview",
+					"gridX": 0,
+					"gridY": 1,
+					"gridWidth": 1,
+					"gridHeight": 1
+				},
+				{
+					"widgetKey": "audit-trail",
+					"slot": "sidebar",
+					"tabGroup": "audit",
+					"gridX": 0,
+					"gridY": 2,
+					"gridWidth": 1,
+					"gridHeight": 1
+				}
+			]
 		},
 		{
 			"id": "Complaints",
@@ -270,8 +352,49 @@
 			"title": "Complaint",
 			"config": {
 				"register": "pipelinq",
-				"schema": "complaint"
-			}
+				"schema": "complaint",
+				"sidebarTabs": [
+					{
+						"id": "overview",
+						"label": "Overview",
+						"order": 1
+					},
+					{
+						"id": "audit",
+						"label": "Audit trail",
+						"order": 2
+					}
+				]
+			},
+			"widgets": [
+				{
+					"widgetKey": "data",
+					"slot": "sidebar",
+					"tabGroup": "overview",
+					"gridX": 0,
+					"gridY": 0,
+					"gridWidth": 1,
+					"gridHeight": 1
+				},
+				{
+					"widgetKey": "metadata",
+					"slot": "sidebar",
+					"tabGroup": "overview",
+					"gridX": 0,
+					"gridY": 1,
+					"gridWidth": 1,
+					"gridHeight": 1
+				},
+				{
+					"widgetKey": "audit-trail",
+					"slot": "sidebar",
+					"tabGroup": "audit",
+					"gridX": 0,
+					"gridY": 2,
+					"gridWidth": 1,
+					"gridHeight": 1
+				}
+			]
 		},
 		{
 			"id": "Contacts",
@@ -300,8 +423,49 @@
 			"title": "Contact",
 			"config": {
 				"register": "pipelinq",
-				"schema": "contact"
-			}
+				"schema": "contact",
+				"sidebarTabs": [
+					{
+						"id": "overview",
+						"label": "Overview",
+						"order": 1
+					},
+					{
+						"id": "audit",
+						"label": "Audit trail",
+						"order": 2
+					}
+				]
+			},
+			"widgets": [
+				{
+					"widgetKey": "data",
+					"slot": "sidebar",
+					"tabGroup": "overview",
+					"gridX": 0,
+					"gridY": 0,
+					"gridWidth": 1,
+					"gridHeight": 1
+				},
+				{
+					"widgetKey": "metadata",
+					"slot": "sidebar",
+					"tabGroup": "overview",
+					"gridX": 0,
+					"gridY": 1,
+					"gridWidth": 1,
+					"gridHeight": 1
+				},
+				{
+					"widgetKey": "audit-trail",
+					"slot": "sidebar",
+					"tabGroup": "audit",
+					"gridX": 0,
+					"gridY": 2,
+					"gridWidth": 1,
+					"gridHeight": 1
+				}
+			]
 		},
 		{
 			"id": "Leads",
@@ -332,8 +496,49 @@
 			"title": "Lead",
 			"config": {
 				"register": "pipelinq",
-				"schema": "lead"
-			}
+				"schema": "lead",
+				"sidebarTabs": [
+					{
+						"id": "overview",
+						"label": "Overview",
+						"order": 1
+					},
+					{
+						"id": "audit",
+						"label": "Audit trail",
+						"order": 2
+					}
+				]
+			},
+			"widgets": [
+				{
+					"widgetKey": "data",
+					"slot": "sidebar",
+					"tabGroup": "overview",
+					"gridX": 0,
+					"gridY": 0,
+					"gridWidth": 1,
+					"gridHeight": 1
+				},
+				{
+					"widgetKey": "metadata",
+					"slot": "sidebar",
+					"tabGroup": "overview",
+					"gridX": 0,
+					"gridY": 1,
+					"gridWidth": 1,
+					"gridHeight": 1
+				},
+				{
+					"widgetKey": "audit-trail",
+					"slot": "sidebar",
+					"tabGroup": "audit",
+					"gridX": 0,
+					"gridY": 2,
+					"gridWidth": 1,
+					"gridHeight": 1
+				}
+			]
 		},
 		{
 			"id": "Contactmomenten",
@@ -374,8 +579,49 @@
 			"title": "Contactmoment",
 			"config": {
 				"register": "pipelinq",
-				"schema": "contactmoment"
-			}
+				"schema": "contactmoment",
+				"sidebarTabs": [
+					{
+						"id": "overview",
+						"label": "Overview",
+						"order": 1
+					},
+					{
+						"id": "audit",
+						"label": "Audit trail",
+						"order": 2
+					}
+				]
+			},
+			"widgets": [
+				{
+					"widgetKey": "data",
+					"slot": "sidebar",
+					"tabGroup": "overview",
+					"gridX": 0,
+					"gridY": 0,
+					"gridWidth": 1,
+					"gridHeight": 1
+				},
+				{
+					"widgetKey": "metadata",
+					"slot": "sidebar",
+					"tabGroup": "overview",
+					"gridX": 0,
+					"gridY": 1,
+					"gridWidth": 1,
+					"gridHeight": 1
+				},
+				{
+					"widgetKey": "audit-trail",
+					"slot": "sidebar",
+					"tabGroup": "audit",
+					"gridX": 0,
+					"gridY": 2,
+					"gridWidth": 1,
+					"gridHeight": 1
+				}
+			]
 		},
 		{
 			"id": "Tasks",
@@ -417,8 +663,49 @@
 			"title": "Task",
 			"config": {
 				"register": "pipelinq",
-				"schema": "task"
-			}
+				"schema": "task",
+				"sidebarTabs": [
+					{
+						"id": "overview",
+						"label": "Overview",
+						"order": 1
+					},
+					{
+						"id": "audit",
+						"label": "Audit trail",
+						"order": 2
+					}
+				]
+			},
+			"widgets": [
+				{
+					"widgetKey": "data",
+					"slot": "sidebar",
+					"tabGroup": "overview",
+					"gridX": 0,
+					"gridY": 0,
+					"gridWidth": 1,
+					"gridHeight": 1
+				},
+				{
+					"widgetKey": "metadata",
+					"slot": "sidebar",
+					"tabGroup": "overview",
+					"gridX": 0,
+					"gridY": 1,
+					"gridWidth": 1,
+					"gridHeight": 1
+				},
+				{
+					"widgetKey": "audit-trail",
+					"slot": "sidebar",
+					"tabGroup": "audit",
+					"gridX": 0,
+					"gridY": 2,
+					"gridWidth": 1,
+					"gridHeight": 1
+				}
+			]
 		},
 		{
 			"id": "Products",
@@ -448,15 +735,57 @@
 			"title": "Product",
 			"config": {
 				"register": "pipelinq",
-				"schema": "product"
-			}
+				"schema": "product",
+				"sidebarTabs": [
+					{
+						"id": "overview",
+						"label": "Overview",
+						"order": 1
+					},
+					{
+						"id": "audit",
+						"label": "Audit trail",
+						"order": 2
+					}
+				]
+			},
+			"widgets": [
+				{
+					"widgetKey": "data",
+					"slot": "sidebar",
+					"tabGroup": "overview",
+					"gridX": 0,
+					"gridY": 0,
+					"gridWidth": 1,
+					"gridHeight": 1
+				},
+				{
+					"widgetKey": "metadata",
+					"slot": "sidebar",
+					"tabGroup": "overview",
+					"gridX": 0,
+					"gridY": 1,
+					"gridWidth": 1,
+					"gridHeight": 1
+				},
+				{
+					"widgetKey": "audit-trail",
+					"slot": "sidebar",
+					"tabGroup": "audit",
+					"gridX": 0,
+					"gridY": 2,
+					"gridWidth": 1,
+					"gridHeight": 1
+				}
+			]
 		},
 		{
 			"id": "Pipeline",
 			"route": "/pipeline",
 			"type": "custom",
 			"title": "Pipeline",
-			"component": "PipelineBoardView"
+			"component": "PipelineBoardView",
+			"_note": "Bespoke kanban board with drag-drop column reorder + per-card status transitions. No lib analogue."
 		},
 		{
 			"id": "Queues",
@@ -543,8 +872,8 @@
 				"submitMethod": "POST",
 				"fieldWidgets": [
 					{
-						"field": "body",
-						"component": "CnMarkdownEditor"
+						"component": "CnMarkdownEditor",
+						"id": "body"
 					}
 				]
 			}
@@ -575,8 +904,8 @@
 				"submitMethod": "PUT",
 				"fieldWidgets": [
 					{
-						"field": "body",
-						"component": "CnMarkdownEditor"
+						"component": "CnMarkdownEditor",
+						"id": "body"
 					}
 				]
 			}
@@ -632,8 +961,49 @@
 			"title": "Survey",
 			"config": {
 				"register": "pipelinq",
-				"schema": "survey"
-			}
+				"schema": "survey",
+				"sidebarTabs": [
+					{
+						"id": "overview",
+						"label": "Overview",
+						"order": 1
+					},
+					{
+						"id": "audit",
+						"label": "Audit trail",
+						"order": 2
+					}
+				]
+			},
+			"widgets": [
+				{
+					"widgetKey": "data",
+					"slot": "sidebar",
+					"tabGroup": "overview",
+					"gridX": 0,
+					"gridY": 0,
+					"gridWidth": 1,
+					"gridHeight": 1
+				},
+				{
+					"widgetKey": "metadata",
+					"slot": "sidebar",
+					"tabGroup": "overview",
+					"gridX": 0,
+					"gridY": 1,
+					"gridWidth": 1,
+					"gridHeight": 1
+				},
+				{
+					"widgetKey": "audit-trail",
+					"slot": "sidebar",
+					"tabGroup": "audit",
+					"gridX": 0,
+					"gridY": 2,
+					"gridWidth": 1,
+					"gridHeight": 1
+				}
+			]
 		},
 		{
 			"id": "SurveyEdit",


### PR DESCRIPTION
## Smoke test discovery

While smoke-testing #428 in the browser, found that CnDetailPage sidebar tabs (data/metadata/audit-trail) are NOT lib defaults — they only render when explicitly declared via `widgets[]` with `slot:'sidebar'` + `tabGroup:'<id>'`. #428 removed those arrays assuming they were redundant defaults; they weren't.

## What this PR does

**1. Restores widgets[] on 9 detail pages** (ClientDetail, RequestDetail, ComplaintDetail, ContactDetail, LeadDetail, ContactmomentDetail, TaskDetail, ProductDetail, SurveyDetail).
Three widgets each — `data`, `metadata`, `audit-trail` — mapped to `overview` and `audit` tab groups. Matches the pre-#428 state.

**2. Adds `config.sidebarTabs[]` declaration** to each restored page. Required by the lib's `validateSidebarTabGroupRefs` cross-check: every widget with `slot:'sidebar' + tabGroup:'<id>'` must reference a declared sidebar tab.

**3. Renames KennisbankNew/Edit `fieldWidgets[]`** entries from `{ field }` → `{ id }`. The typed `fieldWidget` shape introduced in nextcloud-vue schema 2.7.0 (#314) requires `id` as the key name.

**4. Adds back the missing `_note` on Pipeline** (`type:'custom'` with `component:'PipelineBoardView'`). PipelineBoardView is a host-app SFC, not a lib `Cn*` component, so per schema 2.7.0 `_note` is still required there (#315 only relaxed the rule for lib-Cn components).

**5. Bumps `@conduction/nextcloud-vue` ^1.0.0-beta.63 → ^1.0.0-beta.64** to pick up the new typed fieldWidget shape.

## Validation

`node tests/validate-manifest.js` → Ajv-clean (0 errors against schema 2.7.0).

## Known follow-up

Visible improvement in the browser is currently gated on **ConductionNL/nextcloud-vue#318**: CnDetailPage has a `_lockState` Vue 2 reactivity bug — `setup()` strips `_`-prefixed variables. The manifest is correct independent of that bug; once the lib bug is fixed, these detail pages will render their sidebar tabs as expected.