### PR TITLE
chore(deps): bump @conduction/nextcloud-vue to ^1.0.0-beta.66

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
 			"version": "0.1.0",
 			"license": "EUPL-1.2",
 			"dependencies": {
-				"@conduction/nextcloud-vue": "^1.0.0-beta.63",
+				"@conduction/nextcloud-vue": "^1.0.0-beta.66",
 				"@nextcloud/axios": "~2.5.2",
 				"@nextcloud/dialogs": "^3.2.0",
 				"@nextcloud/initial-state": "^2.2.0",
@@ -1797,9 +1797,9 @@
 			}
 		},
 		"node_modules/@conduction/nextcloud-vue": {
-			"version": "1.0.0-beta.64",
-			"resolved": "https://registry.npmjs.org/@conduction/nextcloud-vue/-/nextcloud-vue-1.0.0-beta.64.tgz",
-			"integrity": "sha512-gbfCHr3PNtvGjXkGGcdItioF53IABDIot7xKvLsaHmMU4OxZXwMbWrQxmF7boIZV7fUs0zt4ENT5HPJoYa23ug==",
+			"version": "1.0.0-beta.66",
+			"resolved": "https://registry.npmjs.org/@conduction/nextcloud-vue/-/nextcloud-vue-1.0.0-beta.66.tgz",
+			"integrity": "sha512-Igd9KdaA90JA0i96CG4zyQxM7NmAyYfkdrT6rBWjuNZBkNwwW2TnxbP1NG3Qev6bc99yqWYbRcBVgnnP8SJnNw==",
 			"license": "EUPL-1.2",
 			"dependencies": {
 				"@codemirror/autocomplete": "^6.0.0",
@@ -18488,9 +18488,9 @@
 			}
 		},
 		"@conduction/nextcloud-vue": {
-			"version": "1.0.0-beta.64",
-			"resolved": "https://registry.npmjs.org/@conduction/nextcloud-vue/-/nextcloud-vue-1.0.0-beta.64.tgz",
-			"integrity": "sha512-gbfCHr3PNtvGjXkGGcdItioF53IABDIot7xKvLsaHmMU4OxZXwMbWrQxmF7boIZV7fUs0zt4ENT5HPJoYa23ug==",
+			"version": "1.0.0-beta.66",
+			"resolved": "https://registry.npmjs.org/@conduction/nextcloud-vue/-/nextcloud-vue-1.0.0-beta.66.tgz",
+			"integrity": "sha512-Igd9KdaA90JA0i96CG4zyQxM7NmAyYfkdrT6rBWjuNZBkNwwW2TnxbP1NG3Qev6bc99yqWYbRcBVgnnP8SJnNw==",
 			"requires": {
 				"@codemirror/autocomplete": "^6.0.0",
 				"@codemirror/commands": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
 		"extends @nextcloud/browserslist-config"
 	],
 	"dependencies": {
-		"@conduction/nextcloud-vue": "^1.0.0-beta.63",
+		"@conduction/nextcloud-vue": "^1.0.0-beta.66",
 		"@nextcloud/axios": "~2.5.2",
 		"@nextcloud/dialogs": "^3.2.0",
 		"@nextcloud/initial-state": "^2.2.0",


### PR DESCRIPTION
Picks up schema 2.7.0 + CnPageRenderer top-level field forwarding + CnDetailPage `_lockState` rename + `config.schema → objectType` bridging from nextcloud-vue#317/#319/#320. Mechanical dependency bump.