### PR TITLE
chore: sync canonical root configs + mechanical phpmd cleanup

### DIFF
--- a/lib/BackgroundJob/ScheduledTaskJob.php
+++ b/lib/BackgroundJob/ScheduledTaskJob.php
@@ -66,11 +66,13 @@ class ScheduledTaskJob extends TimedJob
      * Delegates all processing to ScheduledTaskService::processScheduledTasks().
      * Catches every Throwable so the job queue remains healthy.
      *
-     * @param mixed $argument The job argument (unused).
+     * @param mixed $argument The job argument (unused; required by TimedJob).
      *
      * @return void
      *
      * @spec openspec/changes/task-background-jobs/tasks.md#task-4
+     *
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     protected function run($argument): void
     {

--- a/lib/Service/ActivityTimelineService.php
+++ b/lib/Service/ActivityTimelineService.php
@@ -29,11 +29,16 @@ declare(strict_types=1);
 
 namespace OCA\Pipelinq\Service;
 
+use DateInterval;
+use DateTimeImmutable;
+use DateTimeInterface;
 use OCA\Pipelinq\AppInfo\Application;
 use OCP\IAppConfig;
 use OCP\IUserSession;
 use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
+use RuntimeException;
+use Throwable;
 
 /**
  * Aggregates CRM activity data from multiple OpenRegister schemas.
@@ -87,8 +92,8 @@ class ActivityTimelineService
     {
         try {
             return $this->container->get('OCA\OpenRegister\Service\ObjectService');
-        } catch (\Throwable $e) {
-            throw new \RuntimeException('OpenRegister service is not available.');
+        } catch (Throwable $e) {
+            throw new RuntimeException('OpenRegister service is not available.');
         }
     }//end getObjectService()
 
@@ -546,7 +551,7 @@ class ActivityTimelineService
     {
         $config = $this->getConfig();
         if ($config['register'] === '' || $config['contactmoment'] === '') {
-            throw new \RuntimeException('Contactmoment register or schema not configured.');
+            throw new RuntimeException('Contactmoment register or schema not configured.');
         }
 
         $user = $this->userSession->getUser();
@@ -558,7 +563,7 @@ class ActivityTimelineService
 
         $duration = $this->stringOrNull(value: ($data['duration'] ?? null));
         $summary  = $this->stringOrNull(value: ($data['description'] ?? null));
-        $date     = $this->stringOrNull(value: ($data['date'] ?? null)) ?? (new \DateTimeImmutable())->format(\DateTimeInterface::ATOM);
+        $date     = $this->stringOrNull(value: ($data['date'] ?? null)) ?? (new DateTimeImmutable())->format(DateTimeInterface::ATOM);
 
         $payload = [
             'channel'     => 'worklog',
@@ -738,8 +743,8 @@ class ActivityTimelineService
         }
 
         try {
-            $interval = new \DateInterval($duration);
-        } catch (\Throwable $e) {
+            $interval = new DateInterval($duration);
+        } catch (Throwable $e) {
             return 0;
         }
 

--- a/lib/Service/NoteEventService.php
+++ b/lib/Service/NoteEventService.php
@@ -21,11 +21,16 @@ declare(strict_types=1);
 
 namespace OCA\Pipelinq\Service;
 
+use OC\Security\CSRF\CsrfTokenManager;
+use OCP\Http\Client\IClientService;
+use OCP\IURLGenerator;
 use OCP\IUserSession;
 use Psr\Log\LoggerInterface;
 
 /**
  * Service for triggering note-related events and notifications.
+ *
+ * @psalm-suppress UndefinedClass CsrfTokenManager is an internal Nextcloud class (no OCP interface yet); tracked as fleet debt.
  */
 class NoteEventService
 {
@@ -43,13 +48,21 @@ class NoteEventService
      * @param ActivityService     $activityService     The activity service.
      * @param SettingsService     $settingsService     The settings service.
      * @param IUserSession        $userSession         The user session.
+     * @param IURLGenerator       $urlGenerator        The URL generator.
+     * @param IClientService      $clientService       The HTTP client service.
+     * @param CsrfTokenManager    $csrfTokenManager    The CSRF token manager.
      * @param LoggerInterface     $logger              The logger.
+     *
+     * @psalm-suppress UndefinedClass CsrfTokenManager is an internal Nextcloud class (no OCP interface yet).
      */
     public function __construct(
         private NotificationService $notificationService,
         private ActivityService $activityService,
         private SettingsService $settingsService,
         private IUserSession $userSession,
+        private IURLGenerator $urlGenerator,
+        private IClientService $clientService,
+        private CsrfTokenManager $csrfTokenManager,
         private LoggerInterface $logger,
     ) {
     }//end __construct()
@@ -109,6 +122,7 @@ class NoteEventService
      * @return ?array The entity data with title and assignee, or null on failure.
      *
      * @psalm-suppress UnusedParam $objectId is used in URL interpolation
+     * @psalm-suppress UndefinedClass CsrfTokenManager is an internal Nextcloud class (no OCP interface yet).
      */
     private function fetchEntityData(string $entityType, string $objectId): ?array
     {
@@ -121,17 +135,17 @@ class NoteEventService
             return null;
         }
 
-        $url = \OC::$server->getURLGenerator()->getAbsoluteURL(
+        $url = $this->urlGenerator->getAbsoluteURL(
             "/apps/openregister/api/objects/{$register}/{$schema}/{$objectId}"
         );
 
-        $client   = \OC::$server->getHTTPClientService()->newClient();
+        $client   = $this->clientService->newClient();
         $response = $client->get(
                 $url,
                 [
                     'headers'   => [
                         'OCS-APIREQUEST' => 'true',
-                        'requesttoken'   => \OC::$server->getCsrfTokenManager()->getToken()->getEncryptedValue(),
+                        'requesttoken'   => $this->csrfTokenManager->getToken()->getEncryptedValue(),
                     ],
                     'nextcloud' => ['allow_local_address' => true],
                 ]

--- a/lib/Service/ScheduledTaskService.php
+++ b/lib/Service/ScheduledTaskService.php
@@ -29,6 +29,9 @@ declare(strict_types=1);
 
 namespace OCA\Pipelinq\Service;
 
+use DateTimeImmutable;
+use DateTimeInterface;
+use InvalidArgumentException;
 use OCA\Pipelinq\AppInfo\Application;
 use OCP\AppFramework\OCS\OCSForbiddenException;
 use OCP\IAppConfig;
@@ -36,6 +39,8 @@ use OCP\IGroupManager;
 use OCP\IUserSession;
 use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
+use RuntimeException;
+use Throwable;
 
 /**
  * Service for the Schedules API.
@@ -142,11 +147,11 @@ class ScheduledTaskService
         }
 
         if (isset($params['to']) === true && $params['to'] !== '') {
-            if (isset($filters['deadline']) === true && is_array($filters['deadline']) === true) {
-                $filters['deadline']['<='] = $params['to'];
-            } else {
-                $filters['deadline'] = ['<=' => $params['to']];
+            if (isset($filters['deadline']) === false || is_array($filters['deadline']) === false) {
+                $filters['deadline'] = [];
             }
+
+            $filters['deadline']['<='] = $params['to'];
         }
 
         try {
@@ -160,7 +165,7 @@ class ScheduledTaskService
                 _rbac: false,
                 _multitenancy: false
             );
-        } catch (\Throwable $e) {
+        } catch (Throwable $e) {
             $this->logger->error(
                 'ScheduledTaskService: findAll failed',
                 ['exception' => $e]
@@ -186,7 +191,7 @@ class ScheduledTaskService
      *
      * @return array<string, mixed> The task object.
      *
-     * @throws \RuntimeException If the task is not found.
+     * @throws RuntimeException If the task is not found.
      *
      * @spec openspec/changes/task-background-jobs/tasks.md#task-1
      */
@@ -194,7 +199,7 @@ class ScheduledTaskService
     {
         [$registerId, $schemaId] = $this->getRegisterAndSchema();
         if ($registerId === '' || $schemaId === '') {
-            throw new \RuntimeException('Task not found');
+            throw new RuntimeException('Task not found');
         }
 
         try {
@@ -205,16 +210,16 @@ class ScheduledTaskService
                 _rbac: false,
                 _multitenancy: false
             );
-        } catch (\Throwable $e) {
+        } catch (Throwable $e) {
             $this->logger->error(
                 'ScheduledTaskService: findObject failed',
                 ['exception' => $e, 'id' => $id]
             );
-            throw new \RuntimeException('Task not found');
+            throw new RuntimeException('Task not found');
         }
 
         if ($object === null) {
-            throw new \RuntimeException('Task not found');
+            throw new RuntimeException('Task not found');
         }
 
         return $this->normalizeToArray(object: $object);
@@ -231,7 +236,7 @@ class ScheduledTaskService
      *
      * @return array<string, mixed> The saved task object.
      *
-     * @throws \InvalidArgumentException On validation failure.
+     * @throws InvalidArgumentException On validation failure.
      *
      * @spec openspec/changes/task-background-jobs/tasks.md#task-1
      */
@@ -240,27 +245,26 @@ class ScheduledTaskService
         if (isset($data['type']) === false
             || in_array($data['type'], self::VALID_TYPES, true) === false
         ) {
-            throw new \InvalidArgumentException('Invalid input');
+            throw new InvalidArgumentException('Invalid input');
         }
 
         if (isset($data['subject']) === false || trim((string) $data['subject']) === '') {
-            throw new \InvalidArgumentException('Invalid input');
+            throw new InvalidArgumentException('Invalid input');
         }
 
         if (isset($data['deadline']) === false || trim((string) $data['deadline']) === '') {
-            throw new \InvalidArgumentException('Invalid input');
+            throw new InvalidArgumentException('Invalid input');
         }
 
         [$registerId, $schemaId] = $this->getRegisterAndSchema();
         if ($registerId === '' || $schemaId === '') {
-            throw new \RuntimeException('Register or task schema not configured');
+            throw new RuntimeException('Register or task schema not configured');
         }
 
         $user = $this->userSession->getUser();
+        $data['createdBy'] = 'system';
         if ($user !== null) {
             $data['createdBy'] = $user->getUID();
-        } else {
-            $data['createdBy'] = 'system';
         }
 
         if (isset($data['status']) === false || $data['status'] === '') {
@@ -360,7 +364,7 @@ class ScheduledTaskService
             return [];
         }
 
-        $now    = new \DateTimeImmutable('now');
+        $now    = new DateTimeImmutable('now');
         $cutoff = $now->modify(sprintf('+%d minutes', $windowMinutes));
 
         try {
@@ -371,8 +375,8 @@ class ScheduledTaskService
                         'schema'   => $schemaId,
                         'status'   => 'open',
                         'deadline' => [
-                            '>=' => $now->format(\DateTimeInterface::ATOM),
-                            '<=' => $cutoff->format(\DateTimeInterface::ATOM),
+                            '>=' => $now->format(DateTimeInterface::ATOM),
+                            '<=' => $cutoff->format(DateTimeInterface::ATOM),
                         ],
                     ],
                     'limit'   => 100,
@@ -381,7 +385,7 @@ class ScheduledTaskService
                 _rbac: false,
                 _multitenancy: false
             );
-        } catch (\Throwable $e) {
+        } catch (Throwable $e) {
             $this->logger->error(
                 'ScheduledTaskService: getPendingTasks failed',
                 ['exception' => $e]
@@ -413,7 +417,7 @@ class ScheduledTaskService
     public function processScheduledTasks(): void
     {
         $candidates = $this->getPendingTasks(windowMinutes: self::EXPIRY_THRESHOLD_MINUTES);
-        $now        = new \DateTimeImmutable('now');
+        $now        = new DateTimeImmutable('now');
         $expiryCut  = $now->modify('-4 hours');
 
         [$registerId, $schemaId] = $this->getRegisterAndSchema();
@@ -437,8 +441,8 @@ class ScheduledTaskService
             }
 
             try {
-                $deadline = new \DateTimeImmutable((string) $deadlineRaw);
-            } catch (\Throwable $e) {
+                $deadline = new DateTimeImmutable((string) $deadlineRaw);
+            } catch (Throwable $e) {
                 continue;
             }
 
@@ -452,7 +456,7 @@ class ScheduledTaskService
                 $attempts = [];
             }
 
-            $timestamp = $now->format(\DateTimeInterface::ATOM);
+            $timestamp = $now->format(DateTimeInterface::ATOM);
 
             if ($deadline < $expiryCut) {
                 $task['status'] = 'verlopen';
@@ -460,7 +464,9 @@ class ScheduledTaskService
                     'timestamp' => $timestamp,
                     'result'    => 'expired',
                 ];
-            } else {
+            }
+
+            if ($deadline >= $expiryCut) {
                 $task['status'] = 'in_behandeling';
                 $attempts[]     = [
                     'timestamp' => $timestamp,
@@ -477,7 +483,7 @@ class ScheduledTaskService
                             objectId: (string) ($task['id'] ?? ''),
                             author: 'system'
                         );
-                    } catch (\Throwable $e) {
+                    } catch (Throwable $e) {
                         $this->logger->error(
                             'ScheduledTaskService: notification dispatch failed',
                             ['exception' => $e]
@@ -498,7 +504,7 @@ class ScheduledTaskService
                     _rbac: false,
                     _multitenancy: false
                 );
-            } catch (\Throwable $e) {
+            } catch (Throwable $e) {
                 $this->logger->error(
                     'ScheduledTaskService: task update failed',
                     ['exception' => $e, 'id' => $task['id'] ?? null]

--- a/phpcs-custom-sniffs/CustomSniffs/Sniffs/Nextcloud/NoLegacyServerAccessorsSniff.php
+++ b/phpcs-custom-sniffs/CustomSniffs/Sniffs/Nextcloud/NoLegacyServerAccessorsSniff.php
@@ -1,0 +1,180 @@
+<?php
+/**
+ * Forbid the legacy named accessors on \OC::$server that were removed in Nextcloud 34.
+ *
+ * Flags patterns like:
+ *   \OC::$server->getDatabaseConnection()
+ *   \OC::$server->getSystemConfig()
+ *   \OC::$server->getLogger()
+ *
+ * These named accessors were removed in Nextcloud 34. The replacement pattern
+ * is constructor dependency injection of the equivalent OCP interface.
+ *
+ * PSR-11 lookups such as \OC::$server->get(SomeClass::class) are NOT flagged
+ * here; service-locator deprecation is tracked separately (design.md, D4).
+ *
+ * @author  Conduction
+ * @package CustomSniffs
+ */
+
+namespace CustomSniffs\Sniffs\Nextcloud;
+
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Files\File;
+
+/**
+ * NoLegacyServerAccessorsSniff — forbids removed \OC::$server->getX() accessors.
+ */
+class NoLegacyServerAccessorsSniff implements Sniff
+{
+
+
+    /**
+     * Map of known named accessors to their approved OCP replacement interface.
+     *
+     * Covers the accessors that still appeared in this codebase plus the most
+     * frequently used Nextcloud 34 removals. The error message interpolates the
+     * accessor name and the replacement from this table so engineers see the
+     * intended DI target at the violation site.
+     *
+     * @var array<string, string>
+     */
+    private const REPLACEMENTS = [
+        'getSystemConfig'           => '\OCP\IConfig',
+        'getConfig'                 => '\OCP\IConfig',
+        'getDatabaseConnection'     => '\OCP\IDBConnection',
+        'getLogger'                 => '\Psr\Log\LoggerInterface',
+        'getL10NFactory'            => '\OCP\L10N\IFactory',
+        'getL10N'                   => '\OCP\IL10N (via \OCP\L10N\IFactory)',
+        'getUserSession'            => '\OCP\IUserSession',
+        'getUserManager'            => '\OCP\IUserManager',
+        'getGroupManager'           => '\OCP\IGroupManager',
+        'getURLGenerator'           => '\OCP\IURLGenerator',
+        'getRequest'                => '\OCP\IRequest',
+        'getRootFolder'             => '\OCP\Files\IRootFolder',
+        'getAppManager'             => '\OCP\App\IAppManager',
+        'getSession'                => '\OCP\ISession',
+        'getMemCacheFactory'        => '\OCP\ICacheFactory',
+        'getEventDispatcher'        => '\OCP\EventDispatcher\IEventDispatcher',
+        'getNotificationManager'    => '\OCP\Notification\IManager',
+        'getTempManager'            => '\OCP\ITempManager',
+        'getMimeTypeDetector'       => '\OCP\Files\IMimeTypeDetector',
+        'getMimeTypeLoader'         => '\OCP\Files\IMimeTypeLoader',
+        'getActivityManager'        => '\OCP\Activity\IManager',
+        'getDateTimeFormatter'      => '\OCP\IDateTimeFormatter',
+        'getDateTimeZone'           => '\OCP\IDateTimeZone',
+        'getTrustedDomainHelper'    => '\OCP\Security\ITrustedDomainHelper',
+        'getRegisteredAppContainer' => 'explicit constructor injection of the specific service',
+    ];
+
+    /**
+     * Returns tokens this sniff listens for.
+     *
+     * Anchors on T_DOUBLE_COLON so we can reconstruct the full pattern
+     * \OC :: $server -> getX ( in a single process() call.
+     *
+     * @return array<int>
+     */
+    public function register(): array
+    {
+        return [T_DOUBLE_COLON];
+
+    }//end register()
+
+    /**
+     * Process a T_DOUBLE_COLON token — flag if part of \OC::$server->getX().
+     *
+     * @param File $phpcsFile The file being scanned.
+     * @param int  $stackPtr  Position of the T_DOUBLE_COLON token.
+     *
+     * @return void
+     */
+    public function process(File $phpcsFile, $stackPtr): void
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        // Previous non-whitespace token must be T_STRING "OC".
+        $prev = $phpcsFile->findPrevious(
+            types: [T_WHITESPACE],
+            start: ($stackPtr - 1),
+            end: null,
+            exclude: true
+        );
+        if ($prev === false
+            || $tokens[$prev]['code'] !== T_STRING
+            || $tokens[$prev]['content'] !== 'OC'
+        ) {
+            return;
+        }
+
+        // Next non-whitespace token must be T_VARIABLE "$server".
+        $afterColon = $phpcsFile->findNext(
+            types: [T_WHITESPACE],
+            start: ($stackPtr + 1),
+            end: null,
+            exclude: true
+        );
+        if ($afterColon === false
+            || $tokens[$afterColon]['code'] !== T_VARIABLE
+            || $tokens[$afterColon]['content'] !== '$server'
+        ) {
+            return;
+        }
+
+        // Expect T_OBJECT_OPERATOR '->'.
+        $arrow = $phpcsFile->findNext(
+            types: [T_WHITESPACE],
+            start: ($afterColon + 1),
+            end: null,
+            exclude: true
+        );
+        if ($arrow === false || $tokens[$arrow]['code'] !== T_OBJECT_OPERATOR) {
+            return;
+        }
+
+        // Expect T_STRING method name.
+        $methodPtr = $phpcsFile->findNext(
+            types: [T_WHITESPACE],
+            start: ($arrow + 1),
+            end: null,
+            exclude: true
+        );
+        if ($methodPtr === false || $tokens[$methodPtr]['code'] !== T_STRING) {
+            return;
+        }
+
+        // Must be followed by ( to be a call.
+        $openParen = $phpcsFile->findNext(
+            types: [T_WHITESPACE],
+            start: ($methodPtr + 1),
+            end: null,
+            exclude: true
+        );
+        if ($openParen === false || $tokens[$openParen]['code'] !== T_OPEN_PARENTHESIS) {
+            return;
+        }
+
+        $methodName = $tokens[$methodPtr]['content'];
+
+        // PSR-11 ->get(...) is deferred (D4 in design.md) — not flagged here.
+        if ($methodName === 'get') {
+            return;
+        }
+
+        // Only flag named accessors: getX where X starts with an uppercase letter.
+        if (preg_match(pattern: '/^get[A-Z]/', subject: $methodName) !== 1) {
+            return;
+        }
+
+        $replacement = self::REPLACEMENTS[$methodName] ?? 'the corresponding OCP interface';
+
+        $error = 'Named accessor \\OC::$server->%s() is removed in Nextcloud 34. Inject %s via the constructor instead.';
+        $phpcsFile->addError(
+            $error,
+            $stackPtr,
+            'LegacyNamedAccessor',
+            [$methodName, $replacement]
+        );
+
+    }//end process()
+}//end class

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -6,17 +6,21 @@
 
     <!-- Exclude external and vendor files -->
     <exclude-pattern>*/vendor/*</exclude-pattern>
+    <exclude-pattern>*/vendor-bin/*</exclude-pattern>
     <exclude-pattern>*/node_modules/*</exclude-pattern>
     <exclude-pattern>composer-setup.php</exclude-pattern>
+    <!-- Apps that ship a verbatim template snapshot under lib/Resources/template/ (e.g. openbuilt)
+         keep it out of lint scope; no-op for apps without the directory. -->
+    <exclude-pattern>lib/Resources/template/*</exclude-pattern>
+
+    <!-- Surface phpcs warnings (e.g. SpecTagSniff) in CI logs without failing the build. -->
+    <config name="ignore_warnings_on_exit" value="1"/>
 
     <arg name="basepath" value="."/>
     <arg name="colors"/>
     <arg name="parallel" value="75"/>
     <arg name="extensions" value="php"/>
     <arg value="p"/>
-
-    <!-- Advisory warnings (e.g. missing @spec tags) surface in reports but must not fail the run. -->
-    <config name="ignore_warnings_on_exit" value="1"/>
 
     <!-- Don't hide tokenizer exceptions -->
     <rule ref="Internal.Tokenizer.Exception">
@@ -41,7 +45,6 @@
     <rule ref="Squiz.Arrays.ArrayBracketSpacing"/>
     <rule ref="Squiz.ControlStructures.ControlSignature"/>
     <rule ref="Squiz.ControlStructures.ElseIfDeclaration"/>
-    <rule ref="Squiz.PHP.DisallowInlineIf"/>
     <rule ref="Squiz.Commenting.ClosingDeclarationComment"/>
     <rule ref="Squiz.Commenting.BlockComment"/>
     <rule ref="Squiz.Commenting.DocCommentAlignment"/>
@@ -52,8 +55,13 @@
     <rule ref="Squiz.Commenting.VariableComment"/>
     <rule ref="Squiz.Functions.FunctionDeclarationArgumentSpacing"/>
     <rule ref="Squiz.Operators.ComparisonOperatorUsage"/>
+    <rule ref="Squiz.PHP.DisallowInlineIf"/>
     <rule ref="Squiz.Scope.MethodScope"/>
-    <rule ref="Squiz.Strings.ConcatenationSpacing"/>
+    <rule ref="Squiz.Strings.ConcatenationSpacing">
+        <properties>
+            <property name="ignoreNewlines" value="true"/>
+        </properties>
+    </rule>
     <rule ref="Squiz.WhiteSpace.ControlStructureSpacing"/>
     <rule ref="Squiz.WhiteSpace.FunctionSpacing">
         <properties>
@@ -75,14 +83,18 @@
     <rule ref="Generic.Formatting.SpaceAfterCast"/>
     <rule ref="Generic.Files.LineLength">
         <properties>
-            <property name="lineLimit" value="125"/>
+            <property name="lineLimit" value="150"/>
             <property name="absoluteLineLimit" value="150"/>
         </properties>
     </rule>
     <rule ref="Generic.NamingConventions.ConstructorName"/>
     <rule ref="Generic.PHP.DeprecatedFunctions"/>
     <rule ref="Generic.PHP.LowerCaseKeyword"/>
-    <rule ref="Generic.Strings.UnnecessaryStringConcat"/>
+    <rule ref="Generic.Strings.UnnecessaryStringConcat">
+        <properties>
+            <property name="allowMultiline" value="true"/>
+        </properties>
+    </rule>
     <rule ref="Generic.WhiteSpace.IncrementDecrementSpacing"/>
     <rule ref="PSR2.Classes.PropertyDeclaration"/>
     <rule ref="PSR2.Methods.MethodDeclaration"/>
@@ -208,8 +220,13 @@
         <type>error</type>
     </rule>
 
-    <!-- Custom rule: warn when a class or public method is missing the @spec PHPDoc tag (ADR-003). -->
-    <!-- Emitted as warnings (not errors) so CI surfaces the gap but doesn't block merges. -->
+    <!-- Block calls to \OC::$server->getX() / \OC::$server->query() removed in Nextcloud 34. -->
+    <rule ref="./phpcs-custom-sniffs/CustomSniffs/Sniffs/Nextcloud/NoLegacyServerAccessorsSniff.php">
+        <type>error</type>
+    </rule>
+
+    <!-- Warn when a class or public method is missing the @spec PHPDoc tag (hydra ADR-003).
+         Emitted as warnings (not errors) so CI surfaces the gap but doesn't block merges. -->
     <rule ref="./phpcs-custom-sniffs/CustomSniffs/Sniffs/Commenting/SpecTagSniff.php">
         <type>warning</type>
     </rule>

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,0 +1,131 @@
+# phpstan baseline for pipelinq lint debt.
+#
+# All 25 entries below are tracked in https://github.com/ConductionNL/pipelinq/issues/496
+# and consist of unread DI properties (feature-flag stubs), three unused
+# named-constants (escalation/expiry thresholds awaiting wire-up), one OC-namespace
+# class psalm/phpstan can't see (CsrfTokenManager — fleet decision pending), and
+# two logic warnings worth investigating.
+#
+# Do NOT regenerate this baseline without first triaging issue #496.
+
+parameters:
+	ignoreErrors:
+		-
+			message: "#^Property OCA\\\\Pipelinq\\\\BackgroundJob\\\\CallbackOverdueJob\\:\\:\\$notificationService is never read, only written\\.$#"
+			count: 1
+			path: lib/BackgroundJob/CallbackOverdueJob.php
+
+		-
+			message: "#^Property OCA\\\\Pipelinq\\\\BackgroundJob\\\\ComplaintSlaJob\\:\\:\\$complaintSlaService is never read, only written\\.$#"
+			count: 1
+			path: lib/BackgroundJob/ComplaintSlaJob.php
+
+		-
+			message: "#^Property OCA\\\\Pipelinq\\\\BackgroundJob\\\\EmailSyncJob\\:\\:\\$emailSyncService is never read, only written\\.$#"
+			count: 1
+			path: lib/BackgroundJob/EmailSyncJob.php
+
+		-
+			message: "#^Constant OCA\\\\Pipelinq\\\\BackgroundJob\\\\TaskEscalationJob\\:\\:ESCALATION_THRESHOLD_HOURS is unused\\.$#"
+			count: 1
+			path: lib/BackgroundJob/TaskEscalationJob.php
+
+		-
+			message: "#^Property OCA\\\\Pipelinq\\\\BackgroundJob\\\\TaskEscalationJob\\:\\:\\$taskService is never read, only written\\.$#"
+			count: 1
+			path: lib/BackgroundJob/TaskEscalationJob.php
+
+		-
+			message: "#^Constant OCA\\\\Pipelinq\\\\BackgroundJob\\\\TaskExpiryJob\\:\\:ESCALATION_THRESHOLD is unused\\.$#"
+			count: 1
+			path: lib/BackgroundJob/TaskExpiryJob.php
+
+		-
+			message: "#^Constant OCA\\\\Pipelinq\\\\BackgroundJob\\\\TaskExpiryJob\\:\\:IN_PROGRESS_GRACE is unused\\.$#"
+			count: 1
+			path: lib/BackgroundJob/TaskExpiryJob.php
+
+		-
+			message: "#^Property OCA\\\\Pipelinq\\\\BackgroundJob\\\\TaskExpiryJob\\:\\:\\$notificationService is never read, only written\\.$#"
+			count: 1
+			path: lib/BackgroundJob/TaskExpiryJob.php
+
+		-
+			message: "#^Property OCA\\\\Pipelinq\\\\Controller\\\\AutomationController\\:\\:\\$l10n is never read, only written\\.$#"
+			count: 1
+			path: lib/Controller/AutomationController.php
+
+		-
+			message: "#^Property OCA\\\\Pipelinq\\\\Controller\\\\SchedulesController\\:\\:\\$groupManager is never read, only written\\.$#"
+			count: 1
+			path: lib/Controller/SchedulesController.php
+
+		-
+			message: "#^Comparison operation \"\\<\" between int\\<0, max\\> and 0 is always false\\.$#"
+			count: 1
+			path: lib/Service/ActivityTimelineService.php
+
+		-
+			message: "#^Property OCA\\\\Pipelinq\\\\Service\\\\AutomationService\\:\\:\\$appConfig is never read, only written\\.$#"
+			count: 1
+			path: lib/Service/AutomationService.php
+
+		-
+			message: "#^Property OCA\\\\Pipelinq\\\\Service\\\\AutomationService\\:\\:\\$userSession is never read, only written\\.$#"
+			count: 1
+			path: lib/Service/AutomationService.php
+
+		-
+			message: "#^Property OCA\\\\Pipelinq\\\\Service\\\\CalendarSyncService\\:\\:\\$logger is never read, only written\\.$#"
+			count: 1
+			path: lib/Service/CalendarSyncService.php
+
+		-
+			message: "#^Property OCA\\\\Pipelinq\\\\Service\\\\CallbackService\\:\\:\\$logger is never read, only written\\.$#"
+			count: 1
+			path: lib/Service/CallbackService.php
+
+		-
+			message: "#^Property OCA\\\\Pipelinq\\\\Service\\\\EmailSyncService\\:\\:\\$logger is never read, only written\\.$#"
+			count: 1
+			path: lib/Service/EmailSyncService.php
+
+		-
+			message: "#^Property OCA\\\\Pipelinq\\\\Service\\\\IntakeFormService\\:\\:\\$appConfig is never read, only written\\.$#"
+			count: 1
+			path: lib/Service/IntakeFormService.php
+
+		-
+			message: "#^Property OCA\\\\Pipelinq\\\\Service\\\\IntakeFormService\\:\\:\\$logger is never read, only written\\.$#"
+			count: 1
+			path: lib/Service/IntakeFormService.php
+
+		-
+			message: "#^Property OCA\\\\Pipelinq\\\\Service\\\\KennisbankService\\:\\:\\$logger is never read, only written\\.$#"
+			count: 1
+			path: lib/Service/KennisbankService.php
+
+		-
+			message: "#^Parameter \\$csrfTokenManager of method OCA\\\\Pipelinq\\\\Service\\\\NoteEventService\\:\\:__construct\\(\\) has invalid type OC\\\\Security\\\\CSRF\\\\CsrfTokenManager\\.$#"
+			count: 2
+			path: lib/Service/NoteEventService.php
+
+		-
+			message: "#^Property OCA\\\\Pipelinq\\\\Service\\\\ReportingService\\:\\:\\$logger is never read, only written\\.$#"
+			count: 1
+			path: lib/Service/ReportingService.php
+
+		-
+			message: "#^Strict comparison using \\=\\=\\= between true and false will always evaluate to false\\.$#"
+			count: 1
+			path: lib/Service/ScheduledTaskService.php
+
+		-
+			message: "#^Property OCA\\\\Pipelinq\\\\Service\\\\TaskService\\:\\:\\$logger is never read, only written\\.$#"
+			count: 1
+			path: lib/Service/TaskService.php
+
+		-
+			message: "#^Property OCA\\\\Pipelinq\\\\Service\\\\TaskService\\:\\:\\$userSession is never read, only written\\.$#"
+			count: 1
+			path: lib/Service/TaskService.php

--- a/phpstan-bootstrap.php
+++ b/phpstan-bootstrap.php
@@ -1,0 +1,9 @@
+<?php
+
+/**
+ * PHPStan bootstrap file - registers OCP autoloader for static analysis.
+ */
+
+$autoloader = require __DIR__ . '/vendor/autoload.php';
+$autoloader->addPsr4('OCP\\', __DIR__ . '/vendor/nextcloud/ocp/OCP/');
+$autoloader->addPsr4('NCU\\', __DIR__ . '/vendor/nextcloud/ocp/NCU/');

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,23 +1,59 @@
+includes:
+    # Per-app tracked lint debt lives here (auto-generated via `phpstan --generate-baseline`).
+    # Apps without debt ship an empty baseline file; canonical includes are otherwise byte-identical
+    # across the fleet.
+    - phpstan-baseline.neon
+
 parameters:
     level: 5
     paths:
         - lib
     bootstrapFiles:
-        - vendor/autoload.php
+        - phpstan-bootstrap.php
+    excludePaths:
+        - vendor
+        - vendor-bin
+        # Apps that ship a verbatim template snapshot under lib/Resources/template/ (e.g. openbuilt).
+        - lib/Resources/template
     scanDirectories:
         - vendor/nextcloud/ocp
     reportUnmatchedIgnoredErrors: false
     ignoreErrors:
-        # Nextcloud internal classes that PHPStan might not recognize
+        # Nextcloud server internals (\OC, OC_App, OC\) not stubbed in nextcloud/ocp
         - '#Call to an undefined method OC::#'
         - '#Class OC not found#'
         - '#Access to static property \$server on an unknown class OC#'
-        # OpenRegister cross-app dependency (optional, loaded at runtime)
-        - '#OCA\\OpenRegister\\#'
-        # Framework-DI injected dependencies held for future handlers / subclasses.
-        # Promoted constructor properties appear "never read" until consumed by
-        # planned methods — removing them breaks DI wiring in app.php / Application.
-        - '#is never read, only written\.$#'
-        # Scheduling/threshold constants kept as documented defaults; some are
-        # currently only referenced in comments and configuration migrations.
-        - '#Constant OCA\\Pipelinq\\BackgroundJob\\.*(ESCALATION_THRESHOLD_HOURS|ESCALATION_THRESHOLD|IN_PROGRESS_GRACE) is unused\.$#'
+        - '#unknown class OC\\#'
+        - '#Caught class OC\\#'
+        - '#unknown class OC_App#'
+        - '#Class OC_App not found#'
+        # OCA\DAV is server-internal and not in nextcloud/ocp stubs
+        - '#unknown class OCA\\DAV\\#'
+        - '#Class OCA\\DAV\\#'
+        # OCA classes from other apps (OpenRegister) not available during static analysis
+        - '#unknown class OCA\\OpenRegister\\#'
+        - '#OCA\\OpenRegister\\[a-zA-Z\\]+.*not found#'
+        - '#on an unknown class OCA\\OpenRegister\\#'
+        - '#has invalid return type OCA\\OpenRegister\\#'
+        - '#has invalid type OCA\\OpenRegister\\#'
+        - '#implements unknown interface OCA\\OpenRegister\\#'
+        # GuzzleHttp is available at runtime via Nextcloud but not in composer require
+        - '#unknown class GuzzleHttp\\#'
+        - '#GuzzleHttp\\[a-zA-Z\\]+.*not found#'
+        - '#on an unknown class GuzzleHttp\\#'
+        - '#invalid type GuzzleHttp\\#'
+        - '#Caught class GuzzleHttp\\#'
+        # Doctrine\DBAL is shipped by Nextcloud server but not stubbed in nextcloud/ocp
+        - '#unknown class Doctrine\\DBAL\\#'
+        - '#Doctrine\\DBAL\\[a-zA-Z\\]+.*not found#'
+        - '#on an unknown class Doctrine\\DBAL\\#'
+        # Dynamic HTTP status codes from business rule validation results
+        # (matches both `Parameter $statusCode` and `Parameter #N $statusCode` forms emitted by phpstan)
+        - '#Parameter (\#\d+ )?\$statusCode of class OCP\\AppFramework\\Http\\JSONResponse constructor expects#'
+        # registerRepairStep exists on server; not yet in nextcloud/ocp stub used for analysis
+        - '#Call to an undefined method OCP\\AppFramework\\Bootstrap\\IRegistrationContext::registerRepairStep#'
+        # OCP stub gaps for methods that exist at runtime
+        - '#Call to an undefined method OCP\\IRequest::getContent\(\)#'
+        - '#Call to an undefined method OCP\\IRequest::setParameter\(\)#'
+        - '#Call to an undefined method OCP\\Mail\\IMessage::attachFile\(\)#'
+        - '#Call to an undefined method OCP\\AppFramework\\Db\\Entity::jsonSerialize#'

--- a/psalm.xml
+++ b/psalm.xml
@@ -59,14 +59,35 @@
                 <referencedClass name="OCP\Http\Client\IClientService"/>
                 <referencedClass name="OCP\Notification\IManager"/>
                 <referencedClass name="OCP\Share\IManager"/>
-                <!-- OpenRegister classes (optional dependency) -->
+                <!-- OpenRegister cross-app classes (loaded dynamically) -->
+                <referencedClass name="OCA\OpenRegister\Db\ObjectEntity"/>
+                <referencedClass name="OCA\OpenRegister\Db\RegisterMapper"/>
+                <referencedClass name="OCA\OpenRegister\Db\SchemaMapper"/>
                 <referencedClass name="OCA\OpenRegister\Event\DeepLinkRegistrationEvent"/>
+                <referencedClass name="OCA\OpenRegister\Event\ObjectCreatingEvent"/>
                 <referencedClass name="OCA\OpenRegister\Event\ObjectCreatedEvent"/>
+                <referencedClass name="OCA\OpenRegister\Event\ObjectUpdatingEvent"/>
                 <referencedClass name="OCA\OpenRegister\Event\ObjectUpdatedEvent"/>
+                <referencedClass name="OCA\OpenRegister\Event\ObjectDeletedEvent"/>
                 <referencedClass name="OCA\OpenRegister\Service\ObjectService"/>
                 <referencedClass name="OCA\OpenRegister\Service\ConfigurationService"/>
+                <referencedClass name="OCA\OpenRegister\Service\RegisterService"/>
+                <referencedClass name="OCA\OpenRegister\Service\FileService"/>
+                <referencedClass name="OCA\OpenRegister\Service\CalendarEventService"/>
+                <referencedClass name="OCA\OpenRegister\Mcp\IMcpToolProvider"/>
+                <!-- Additional OCP infrastructure types used across the fleet -->
+                <referencedClass name="OCP\AppFramework\Bootstrap\IBootContext"/>
+                <referencedClass name="OCP\AppFramework\Bootstrap\IRegistrationContext"/>
+                <referencedClass name="OCP\AppFramework\Db\DoesNotExistException"/>
+                <referencedClass name="OCP\DB\Exception"/>
+                <referencedClass name="OCP\IGroup"/>
+                <referencedClass name="OCP\IUser"/>
+                <referencedClass name="OCP\Migration\IRepairStep"/>
                 <!-- Nextcloud server internals -->
                 <referencedClass name="OC"/>
+                <!-- GuzzleHttp (loaded via composer at runtime) -->
+                <referencedClass name="GuzzleHttp\Client"/>
+                <referencedClass name="GuzzleHttp\Exception\GuzzleException"/>
             </errorLevel>
         </UndefinedClass>
         <UndefinedMagicMethod errorLevel="suppress"/>
@@ -97,6 +118,8 @@
         <EmptyArrayAccess errorLevel="suppress"/>
         <ImplementedReturnTypeMismatch errorLevel="suppress"/>
         <InvalidMethodCall errorLevel="suppress"/>
+        <UndefinedInterfaceMethod errorLevel="suppress"/>
+        <MissingTemplateParam errorLevel="suppress"/>
     </issueHandlers>
     <extraFiles>
         <directory name="vendor/nextcloud/ocp" />

--- a/tests/Unit/Service/NoteEventServiceTest.php
+++ b/tests/Unit/Service/NoteEventServiceTest.php
@@ -19,10 +19,13 @@ declare(strict_types=1);
 
 namespace OCA\Pipelinq\Tests\Unit\Service;
 
+use OC\Security\CSRF\CsrfTokenManager;
 use OCA\Pipelinq\Service\ActivityService;
 use OCA\Pipelinq\Service\NoteEventService;
 use OCA\Pipelinq\Service\NotificationService;
 use OCA\Pipelinq\Service\SettingsService;
+use OCP\Http\Client\IClientService;
+use OCP\IURLGenerator;
 use OCP\IUserSession;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
@@ -57,6 +60,9 @@ class NoteEventServiceTest extends TestCase
         $activityService     = $this->createMock(ActivityService::class);
         $settingsService     = $this->createMock(SettingsService::class);
         $userSession         = $this->createMock(IUserSession::class);
+        $urlGenerator        = $this->createMock(IURLGenerator::class);
+        $clientService       = $this->createMock(IClientService::class);
+        $csrfTokenManager    = $this->createMock(CsrfTokenManager::class);
         $this->logger        = $this->createMock(LoggerInterface::class);
 
         $this->service = new NoteEventService(
@@ -64,6 +70,9 @@ class NoteEventServiceTest extends TestCase
             $activityService,
             $settingsService,
             $userSession,
+            $urlGenerator,
+            $clientService,
+            $csrfTokenManager,
             $this->logger,
         );
     }//end setUp()


### PR DESCRIPTION
## Summary

Phase 2 fleet rollout of the root-config consolidation. Replaces per-app phpcs/phpmd/psalm/phpstan extensions with the canonical from `nextcloud-app-template`.

Lint-debt tracking: #496.

## Quality gates

| Gate | Status |
|---|---|
| phpcs | OK 0 errors / 405 SpecTag warnings |
| psalm | OK 0 errors |
| phpstan | OK 0 unmatched (25 baselined per #496) |
| phpmd | RED 21 architectural violations (tracked #496) |

phpmd has no native baseline support so CI stays red until #496 closes. Agreed-upon tracked-debt pattern.

## Source changes

- **3 phpcs errors** in `lib/Service/NoteEventService.php` fixed by injecting `IURLGenerator`, `IClientService` and `OC\Security\CSRF\CsrfTokenManager` via the constructor (replaces `\OC::$server->getURLGenerator() / getHTTPClientService() / getCsrfTokenManager()` legacy accessors). `CsrfTokenManager` lives in the `OC\Security\CSRF` private namespace because no OCP interface exists yet; class-level `@psalm-suppress UndefinedClass` added and PHPStan baselined per #496.
- `tests/Unit/Service/NoteEventServiceTest.php` `setUp()` updated for the new constructor signature.
- **3 ElseExpression** refactored to two-if pattern in `lib/Service/ScheduledTaskService.php` (`getScheduledTasks`, `createScheduledTask`, `processScheduledTasks`).
- **14 MissingImport** fixed: imported `Throwable`, `RuntimeException`, `InvalidArgumentException`, `DateTimeImmutable`, `DateTimeInterface`, `DateInterval` in `lib/Service/ActivityTimelineService.php` and `lib/Service/ScheduledTaskService.php`.
- **1 UnusedFormalParameter**: added `@SuppressWarnings(PHPMD.UnusedFormalParameter)` on `ScheduledTaskJob::run($argument)` (interface-required by `TimedJob`).

## Test plan

- [x] phpcs/psalm: clean
- [x] phpstan: 0 unmatched with baseline
- [x] `NoteEventService` unit test updated for new constructor signature
- [ ] phpmd CI red, tracked #496