### PR TITLE
docs(openspec): IA alignment refactor (10 drifts: 6 domain groupings)

### DIFF
--- a/openspec/changes/refactor-pipelinq-ia-alignment/design.md
+++ b/openspec/changes/refactor-pipelinq-ia-alignment/design.md
@@ -1,0 +1,126 @@
+# Design: Pipelinq IA Alignment
+
+## Target IA topology
+
+The post-refactor left-nav looks like this (top-menu → sub-pages):
+
+```
+Mijn werk
+  ├── Dashboard                       (route: /,            id: Dashboard)
+  └── Werkvoorraad                    (route: /my-work,     id: MyWork)
+
+Contacten
+  ├── Lijst                           (route: /clients,     id: Clients)
+  ├── Contactpersonen                 (route: /contacts,    id: Contacts)
+  └── Synchronisatie                  (route: /sync-settings, id: SyncSettings)
+
+Pipeline
+  ├── Kanban                          (route: /pipeline,    id: Pipeline)
+  ├── Leads                           (route: /leads,       id: Leads)
+  └── Prospects                       (route: /prospects,   id: Prospects)  ← NEW
+
+Klachten & Verzoeken
+  ├── Verzoeken                       (route: /requests,    id: Requests)
+  └── Klachten                        (route: /complaints,  id: Complaints)
+
+Catalogus
+  └── Producten & diensten            (route: /products,    id: Products)
+
+Beheer (Nextcloud admin settings panel — unchanged shell)
+  ├── Algemeen                        (admin-settings spec)
+  └── Observability  (future)         (prometheus-metrics SETTING surface)
+```
+
+The Settings section (in-app, lower-left) keeps its current entries
+(Pipelines, Forms, Automations, Features & roadmap) — they are not in
+the audited spec list.
+
+The top-menus **Tasks**, **Contactmomenten**, **Surveys**, **Queues**,
+**Kennisbank**, and **Rapportage** are out of scope for this change
+(their owning specs are not in the audited IA input). They remain as
+top-level menu entries for now and may be re-grouped in a follow-up
+audit when those specs land on the IA input.
+
+## Why parent menus instead of separate routes per spec
+
+- The current 15-entry flat menu does not scan well — users have to
+  read every entry to find a relationship feature vs. a pipeline
+  feature vs. a klacht workflow.
+- Grouping by domain (klant / pipeline / klacht / catalogus /
+  mijn werk / beheer) gives a 6-row top menu that mirrors how the
+  product is talked about in stakeholder conversations and tender
+  requirements.
+- Sub-pages are first-class routes (each gets its own URL, breadcrumb,
+  and direct link), so deep-linking from notifications, dashboard
+  widgets, and external systems continues to work without redirects.
+
+## Backwards-compat: keep route paths stable
+
+- All existing route paths under `/clients`, `/leads`, `/pipeline`,
+  `/requests`, `/complaints`, `/products`, `/my-work`, and
+  `/sync-settings` are **preserved**. Only the `menu` structure in
+  `src/manifest.json` is rewritten.
+- Existing bookmarks, deep-links from notifications, and dashboard
+  widget routes (e.g. `#/leads/{objectId}`) keep working.
+- The new `/prospects` route is the only fresh path introduced.
+
+## Manifest schema fit
+
+The manifest schema (`@conduction/nextcloud-vue` app-manifest-v2) uses
+flat `menu[]` entries with `section` (`"primary"` default, `"settings"`
+for the lower group) and `order`. Parent/child grouping is expressed
+either by:
+
+- **a `parent` field on child entries pointing to the parent menu id**, or
+- **a `children: []` array on the parent**,
+
+depending on the lib's current grouping primitive. The implementing
+PR MUST verify which form `@conduction/nextcloud-vue` consumes — if
+neither is supported yet, file a lib gap and use the closest available
+visual hierarchy (e.g. ordered groups by `order` ranges) as an interim.
+
+## Prospects sub-page (new)
+
+`prospect-discovery` currently has only a dashboard widget
+(`ProspectWidget.vue`) plus admin ICP config under
+`views/settings/ProspectSettings.vue`. The IA wants a full-page
+"Prospects" sub-page under Pipeline that shows discovered prospects
+with their fit scores, drill-down, and convert-to-lead actions.
+
+- **Route:** `/prospects`
+- **Type:** `custom` page rendering a new `ProspectsView.vue` (lib gap
+  — no declarative type covers a scored prospect list with
+  external-source enrichment). The existing widget logic in
+  `ProspectWidget.vue` is the starting point; the new view is the
+  full-page expansion of it.
+- The admin ICP config (`ProspectSettings.vue`) stays where it is —
+  the IA places admin configuration of prospect discovery under
+  Beheer, separate from the user-facing Prospects browsing page.
+
+## Catalogus merge
+
+`product-catalog` and `product-service-catalog` are explicitly merged
+per the IA rationale ("Merged with `product-catalog` — single
+canonical list"). The merge resolution:
+
+- The existing `Products` page (`/products`, schema `product`) is the
+  canonical list under `Catalogus → Producten & diensten`.
+- The `product-service-catalog` spec describes a richer
+  IPDC/UPL-compliant `pdc` register. The two specs do not conflict on
+  IA placement (both want the same single page); the data-model
+  reconciliation is tracked separately and is **not** part of this
+  IA-alignment change.
+- This change covers only the menu placement. The data-model merge
+  remains a separate spec change.
+
+## Out-of-scope (explicit non-changes)
+
+- No Vue component file renames or moves.
+- No route path changes (only menu structure).
+- No backend / schema / API contract changes.
+- No changes to the Settings section (Pipelines, Forms, Automations,
+  Features & roadmap).
+- No changes to Tasks, Contactmomenten, Surveys, Queues, Kennisbank,
+  Rapportage menu entries (not in audited input).
+- The Observability pane for prometheus-metrics is a future additive
+  change, not a relocation.

--- a/openspec/changes/refactor-pipelinq-ia-alignment/proposal.md
+++ b/openspec/changes/refactor-pipelinq-ia-alignment/proposal.md
@@ -1,0 +1,89 @@
+# Proposal: Pipelinq IA Alignment
+
+## Why
+
+The current Pipelinq left-nav menu is a flat list of 15 top-level entries
+(Dashboard, Clients, Contacts, Leads, Requests, Tasks, Contactmomenten,
+Complaints, Products, Pipeline, Surveys, Queues, Kennisbank, MyWork,
+Rapportage), plus a Settings section. This forces users into a wide
+"all-siblings" navigation that does not reflect the conceptual domain
+groupings the product is actually organised around (klant, pipeline,
+klacht/verzoek, catalogus, mijn werk, beheer).
+
+A fresh IA proposal collapses these into six top-menu domains with
+sub-pages, and pulls "loose" features (e.g. notifications, activity
+timelines, lead-product link) into either widgets or detail tabs rather
+than dedicated top-level routes. This proposal aligns the implementation
+with that target IA.
+
+## What Changes
+
+This change refactors the left-nav topology and the manifest routes:
+
+- **Mijn werk** becomes a top-menu wrapper for `Dashboard` and `MyWork`
+  (today both are top-level siblings).
+- **Contacten** becomes a top-menu wrapper for `Clients` (renamed
+  "Lijst") and `Sync settings` (renamed "Synchronisatie") — the latter
+  currently exists as an orphaned `/sync-settings` route with no menu
+  entry.
+- **Pipeline** becomes a top-menu wrapper for `Kanban` (today's
+  `Pipeline`), `Leads`, and a new `Prospects` page (prospect-discovery
+  currently has only a dashboard widget + admin config).
+- **Klachten & Verzoeken** becomes a top-menu wrapper for `Verzoeken`
+  (today's `Requests`) and `Klachten` (today's `Complaints`).
+- **Catalogus** becomes a top-menu wrapper for `Producten & diensten`
+  (today's `Products`). `product-catalog` and `product-service-catalog`
+  are explicitly merged into a single canonical list per the IA.
+- **Beheer** stays as it is today (Nextcloud admin settings panel +
+  in-app settings section), unchanged structurally but with an
+  Observability pane added later for prometheus-metrics status.
+
+## Drifted specs (require relocation)
+
+| Spec | Current placement | Target placement | Reason |
+|------|-------------------|------------------|--------|
+| `dashboard` | Top-menu `Dashboard` at `/` | Sub-page under `Mijn werk` | IA: SUB_PAGE → Mijn werk → Dashboard |
+| `my-work` | Top-menu `My Work` at `/my-work` | Sub-page under `Mijn werk` | IA: SUB_PAGE → Mijn werk → Werkvoorraad |
+| `client-management` | Top-menu `Clients` at `/clients` | Sub-page under `Contacten` (renamed "Lijst") | IA: SUB_PAGE → Contacten → Lijst |
+| `contacts-sync` | Orphan route `/sync-settings` (not in menu) | Sub-page under `Contacten` (renamed "Synchronisatie") | IA: SUB_PAGE → Contacten → Synchronisatie |
+| `pipeline` | Top-menu `Pipeline` at `/pipeline` | Sub-page under `Pipeline` (renamed "Kanban") | IA: SUB_PAGE → Pipeline → Kanban |
+| `lead-management` | Top-menu `Leads` at `/leads` | Sub-page under `Pipeline` | IA: SUB_PAGE → Pipeline → Leads |
+| `prospect-discovery` | Dashboard widget + admin settings only | New sub-page under `Pipeline` | IA: SUB_PAGE → Pipeline → Prospects |
+| `request-management` | Top-menu `Requests` at `/requests` | Sub-page under `Klachten & Verzoeken` (renamed "Verzoeken") | IA: SUB_PAGE → Klachten & Verzoeken → Verzoeken |
+| `product-catalog` | Top-menu `Products` at `/products` | Sub-page under `Catalogus` (renamed "Producten & diensten") | IA: SUB_PAGE → Catalogus |
+| `product-service-catalog` | Conceptually overlapping `Products` page | Merged into the single `Catalogus → Producten & diensten` sub-page | IA: explicitly merged with `product-catalog` |
+
+## Verified aligned (no change required)
+
+| Spec | Why it's aligned |
+|------|------------------|
+| `activity-timeline` | IA: DETAIL_TAB. Currently embedded as a card on entity detail views (and recommended for the generic `CnDetailPage` tabs config); no separate top-level route exists. |
+| `entity-notes` | IA: DETAIL_TAB. `EntityNotes.vue` component exists for embedding on detail views; no separate top-level route exists. |
+| `lead-product-link` | IA: DETAIL_TAB on Deal/Lead detail. `LeadProducts.vue` is embedded as a card on the Lead detail view; no separate route. |
+| `notifications-activity` | IA: WIDGET (header bell + Mijn werk). Implementation uses Nextcloud `INotificationManager` + activity stream; no dedicated menu entry. |
+| `admin-settings` | IA: SETTING → Beheer → Algemeen. Already registered as a Nextcloud admin settings panel (`OCA\Pipelinq\Settings\AdminSettings`); not in main nav. |
+| `openregister-integration` | IA: INFRA, no UI. No UI surface to misplace. |
+| `register-i18n` | IA: INFRA, no UI. Locale formatting only. |
+| `prometheus-metrics` | IA: INFRA+SETTING. Backend endpoint exists (`/api/metrics`); no UI currently exists, so no current placement to drift from. An Observability pane under Beheer is additive and out of scope for this IA-alignment change — track separately. |
+
+## Impact
+
+- **Manifest:** `src/manifest.json` — the `menu` array is reduced from 15
+  flat entries to ~6 top-level wrappers; menu items gain a `children`
+  array (or equivalent parent/order grouping per the manifest schema)
+  for grouping.
+- **Routes:** Existing route paths under `/clients`, `/leads`,
+  `/pipeline`, `/requests`, `/complaints`, `/products`, `/my-work`,
+  `/sync-settings` are retained as-is for backwards compatibility (no
+  bookmark breakage); only the **menu** structure changes. New entries
+  under `Pipeline → Prospects` get a new `/prospects` route.
+- **Vue:** No file renames or component moves are required for the
+  menu reorg itself — components stay under their current
+  `src/views/{domain}/` directories. The Prospects sub-page needs a
+  new `ProspectsView.vue` (or declarative `type: "index"` if the schema
+  supports it).
+- **No data model changes.** No backend / schema impact.
+- **Out of scope:** The Tasks, Contactmomenten, Surveys, Queues,
+  Kennisbank, Rapportage, and Settings-section entries (Pipelines,
+  Forms, Automations, Features & roadmap) are NOT in the audited
+  spec list and remain untouched by this change.

--- a/openspec/changes/refactor-pipelinq-ia-alignment/specs.md
+++ b/openspec/changes/refactor-pipelinq-ia-alignment/specs.md
@@ -1,0 +1,292 @@
+---
+name: refactor-pipelinq-ia-alignment
+status: draft
+version: draft
+---
+
+# IA Relocation Deltas
+
+This file consolidates the per-spec deltas for the IA alignment change.
+Each section below targets one of the existing specs under
+`openspec/specs/{spec-slug}/spec.md` and lists the placement
+requirements ADDED and REMOVED.
+
+The deltas describe **information-architecture placement** only — they
+do not change feature contracts, data models, or API surfaces. Where a
+spec already has placement text in its Purpose section, the existing
+prose is implicitly superseded by the ADDED Requirement below.
+
+---
+
+## Spec: dashboard
+
+### ADDED Requirements
+
+#### Requirement: Dashboard MUST be placed under the Mijn werk top-menu
+
+The CRM dashboard page MUST be exposed in the left-nav as a sub-page
+under the `Mijn werk` top-menu group (alongside `Werkvoorraad`). The
+route path `/` MUST be retained for backwards compatibility.
+
+##### Scenario: User navigates to Dashboard via the Mijn werk menu
+- GIVEN the user opens the Pipelinq app
+- WHEN they expand the `Mijn werk` top-menu in the left-nav
+- THEN a `Dashboard` sub-entry MUST be visible
+- AND clicking it MUST navigate to the existing dashboard route
+- AND the dashboard page itself MUST render unchanged
+
+##### Scenario: Existing dashboard URL still works
+- GIVEN any existing bookmark, notification deep-link, or external link to the dashboard route
+- WHEN the link is followed
+- THEN the dashboard page MUST render
+- AND the `Mijn werk → Dashboard` menu entry MUST be marked active
+
+### REMOVED Requirements
+
+#### Requirement: Dashboard appears as a top-level menu entry
+
+**Reason:** Replaced by the Mijn werk top-menu grouping; Dashboard is now a sub-page, not a sibling of every other domain.
+
+---
+
+## Spec: my-work
+
+### ADDED Requirements
+
+#### Requirement: My Work MUST be placed under the Mijn werk top-menu
+
+The My Work (Werkvoorraad) view MUST be exposed in the left-nav as a
+sub-page under the `Mijn werk` top-menu group (alongside `Dashboard`).
+The route path `/my-work` MUST be retained.
+
+##### Scenario: User navigates to My Work via the Mijn werk menu
+- GIVEN the user opens the Pipelinq app
+- WHEN they expand the `Mijn werk` top-menu in the left-nav
+- THEN a `Werkvoorraad` sub-entry MUST be visible
+- AND clicking it MUST navigate to `/my-work`
+- AND the My Work page MUST render unchanged
+
+### REMOVED Requirements
+
+#### Requirement: My Work appears as a top-level menu entry
+
+**Reason:** Replaced by the Mijn werk top-menu grouping; My Work is now a sub-page next to Dashboard.
+
+---
+
+## Spec: client-management
+
+### ADDED Requirements
+
+#### Requirement: Clients MUST be placed under the Contacten top-menu
+
+The clients list MUST be exposed in the left-nav as a sub-page named
+`Lijst` under the `Contacten` top-menu group (alongside
+`Contactpersonen` and `Synchronisatie`). The route path `/clients`
+MUST be retained for backwards compatibility.
+
+##### Scenario: User navigates to Clients via the Contacten menu
+- GIVEN the user opens the Pipelinq app
+- WHEN they expand the `Contacten` top-menu in the left-nav
+- THEN a `Lijst` sub-entry MUST be visible
+- AND clicking it MUST navigate to `/clients`
+- AND the clients list page MUST render unchanged
+
+##### Scenario: Contacts and Clients share the Contacten parent
+- GIVEN the `Contacten` top-menu is expanded
+- THEN both the clients list (`Lijst`) and the contacts list (`Contactpersonen`) MUST be visible as sibling sub-entries
+
+### REMOVED Requirements
+
+#### Requirement: Clients appears as a top-level menu entry
+
+**Reason:** Replaced by the Contacten top-menu grouping; Clients is now a sub-page (`Lijst`) under Contacten.
+
+---
+
+## Spec: contacts-sync
+
+### ADDED Requirements
+
+#### Requirement: Sync Settings MUST be placed under the Contacten top-menu
+
+The Nextcloud Contacts sync settings page MUST be exposed in the
+left-nav as a sub-page named `Synchronisatie` under the `Contacten`
+top-menu group. The route path `/sync-settings` MUST be retained.
+
+##### Scenario: User navigates to Sync settings via the Contacten menu
+- GIVEN the user opens the Pipelinq app
+- WHEN they expand the `Contacten` top-menu
+- THEN a `Synchronisatie` sub-entry MUST be visible
+- AND clicking it MUST navigate to `/sync-settings`
+- AND the sync settings page MUST render the existing `SyncSettingsView`
+
+### REMOVED Requirements
+
+#### Requirement: Sync settings is reachable only by direct URL
+
+**Reason:** The current `/sync-settings` route has no menu entry, leaving the page orphaned. The new placement gives it a discoverable home under Contacten → Synchronisatie.
+
+---
+
+## Spec: pipeline
+
+### ADDED Requirements
+
+#### Requirement: Pipeline kanban MUST be placed under the Pipeline top-menu
+
+The kanban board MUST be exposed in the left-nav as a sub-page named
+`Kanban` under the `Pipeline` top-menu group (alongside `Leads` and
+`Prospects`). The route path `/pipeline` MUST be retained.
+
+##### Scenario: User navigates to Kanban via the Pipeline menu
+- GIVEN the user opens the Pipelinq app
+- WHEN they expand the `Pipeline` top-menu
+- THEN a `Kanban` sub-entry MUST be visible
+- AND clicking it MUST navigate to `/pipeline`
+- AND the existing `PipelineBoardView` MUST render unchanged
+
+### REMOVED Requirements
+
+#### Requirement: Pipeline appears as a top-level menu entry
+
+**Reason:** Replaced by the Pipeline top-menu grouping; the kanban view is now a sub-page (`Kanban`) under the Pipeline parent.
+
+---
+
+## Spec: lead-management
+
+### ADDED Requirements
+
+#### Requirement: Leads MUST be placed under the Pipeline top-menu
+
+The leads list MUST be exposed in the left-nav as a sub-page named
+`Leads` under the `Pipeline` top-menu group (alongside `Kanban` and
+`Prospects`). The route path `/leads` MUST be retained.
+
+##### Scenario: User navigates to Leads via the Pipeline menu
+- GIVEN the user opens the Pipelinq app
+- WHEN they expand the `Pipeline` top-menu
+- THEN a `Leads` sub-entry MUST be visible
+- AND clicking it MUST navigate to `/leads`
+- AND the leads list page MUST render unchanged
+
+### REMOVED Requirements
+
+#### Requirement: Leads appears as a top-level menu entry
+
+**Reason:** Replaced by the Pipeline top-menu grouping; Leads is now a sub-page under the Pipeline parent.
+
+---
+
+## Spec: prospect-discovery
+
+### ADDED Requirements
+
+#### Requirement: Prospects MUST be exposed as a sub-page under the Pipeline top-menu
+
+In addition to the existing dashboard widget and admin ICP
+configuration, the prospect discovery results MUST be reachable as a
+full-page view at `/prospects`, exposed in the left-nav as a sub-page
+named `Prospects` under the `Pipeline` top-menu group (alongside
+`Kanban` and `Leads`).
+
+##### Scenario: User navigates to Prospects via the Pipeline menu
+- GIVEN the user opens the Pipelinq app
+- WHEN they expand the `Pipeline` top-menu
+- THEN a `Prospects` sub-entry MUST be visible
+- AND clicking it MUST navigate to `/prospects`
+- AND the page MUST render the discovered prospects with fit scores, source attribution, and a "convert to lead" action per row
+
+##### Scenario: Dashboard widget remains in place
+- GIVEN the new Prospects page exists
+- THEN the existing dashboard widget for prospect discovery MUST continue to render on the dashboard
+- AND the admin ICP configuration MUST continue to live under the admin settings panel (unchanged)
+
+### REMOVED Requirements
+
+(None — this is purely additive for prospect-discovery; no existing
+placement is being removed.)
+
+---
+
+## Spec: request-management
+
+### ADDED Requirements
+
+#### Requirement: Requests MUST be placed under the Klachten & Verzoeken top-menu
+
+The requests list MUST be exposed in the left-nav as a sub-page named
+`Verzoeken` under the `Klachten & Verzoeken` top-menu group (alongside
+`Klachten`). The route path `/requests` MUST be retained.
+
+##### Scenario: User navigates to Verzoeken via the Klachten & Verzoeken menu
+- GIVEN the user opens the Pipelinq app
+- WHEN they expand the `Klachten & Verzoeken` top-menu
+- THEN a `Verzoeken` sub-entry MUST be visible
+- AND clicking it MUST navigate to `/requests`
+- AND the requests list page MUST render unchanged
+
+##### Scenario: Klachten lives next to Verzoeken
+- GIVEN the `Klachten & Verzoeken` top-menu is expanded
+- THEN both `Verzoeken` (requests) and `Klachten` (complaints) MUST be visible as sibling sub-entries
+
+### REMOVED Requirements
+
+#### Requirement: Requests appears as a top-level menu entry
+
+**Reason:** Replaced by the Klachten & Verzoeken top-menu grouping; Requests is now a sub-page (`Verzoeken`) under that parent.
+
+---
+
+## Spec: product-catalog
+
+### ADDED Requirements
+
+#### Requirement: Products MUST be placed under the Catalogus top-menu
+
+The product catalog list MUST be exposed in the left-nav as a sub-page
+named `Producten & diensten` under the `Catalogus` top-menu group. The
+route path `/products` MUST be retained.
+
+##### Scenario: User navigates to Producten & diensten via the Catalogus menu
+- GIVEN the user opens the Pipelinq app
+- WHEN they expand the `Catalogus` top-menu
+- THEN a `Producten & diensten` sub-entry MUST be visible
+- AND clicking it MUST navigate to `/products`
+- AND the products list page MUST render unchanged
+
+### REMOVED Requirements
+
+#### Requirement: Products appears as a top-level menu entry
+
+**Reason:** Replaced by the Catalogus top-menu grouping; Products is now a sub-page (`Producten & diensten`) under Catalogus.
+
+---
+
+## Spec: product-service-catalog
+
+### ADDED Requirements
+
+#### Requirement: Product & Service Catalog MUST share the single Catalogus sub-page with product-catalog
+
+The PDC functionality MUST be surfaced in the same `Catalogus →
+Producten & diensten` left-nav sub-page as `product-catalog`. There
+MUST NOT be a separate top-menu entry, separate sub-page, or separate
+route for the PDC view.
+
+##### Scenario: Only one Catalogus sub-page exists
+- GIVEN the `Catalogus` top-menu is expanded
+- THEN exactly one sub-entry — `Producten & diensten` — MUST be visible for the merged product catalog
+- AND there MUST NOT be a separate "PDC" or "Service catalog" menu entry
+
+##### Scenario: Data-model reconciliation tracked separately
+- GIVEN this change covers IA placement only
+- THEN any divergence between the `pipelinq.product` schema and the IPDC/UPL `pdc.product` schema MUST be reconciled in a separate non-IA spec change
+- AND this IA-alignment change MUST NOT modify either schema
+
+### REMOVED Requirements
+
+#### Requirement: Product & Service Catalog has an independent menu placement
+
+**Reason:** The IA explicitly merges PDC presentation with the canonical product catalog under one Catalogus sub-page.

--- a/openspec/changes/refactor-pipelinq-ia-alignment/tasks.md
+++ b/openspec/changes/refactor-pipelinq-ia-alignment/tasks.md
@@ -1,0 +1,69 @@
+# Tasks: Pipelinq IA Alignment
+
+Each task is atomic and scoped to be completable by a junior dev in
+under ~15 minutes. Tasks are grouped by file. Route paths are
+preserved throughout — only the `menu` structure and one new route
+(`/prospects`) change.
+
+## 1. Manifest menu restructure (`src/manifest.json`)
+
+1. Add a `Mijn werk` parent menu entry: `id: "MijnWerk"`, `label: "Mijn werk"`, `icon: "icon-user"`, `order: 10`, no `route` (parent only).
+2. Change the existing `Dashboard` menu entry to set `parent: "MijnWerk"` (or move it into a `children` array on `MijnWerk` — match whichever grouping form the manifest schema supports today; verify against `@conduction/nextcloud-vue` app-manifest-v2 schema before committing).
+3. Change the existing `MyWork` menu entry: rename `label` to `"Werkvoorraad"`, set `parent: "MijnWerk"`, leave `route: "MyWork"` and `order` as a child-relative value.
+4. Add a `Contacten` parent menu entry: `id: "Contacten"`, `label: "Contacten"`, `icon: "icon-group"`, `order: 20`, no `route`.
+5. Change the existing `Clients` menu entry: rename `label` to `"Lijst"`, set `parent: "Contacten"`.
+6. Change the existing `Contacts` menu entry: rename `label` to `"Contactpersonen"`, set `parent: "Contacten"`.
+7. Add a new menu entry for `SyncSettings`: `id: "SyncSettings"`, `label: "Synchronisatie"`, `icon: "icon-category-integration"` (or closest icon — confirm token), `route: "SyncSettings"`, `parent: "Contacten"`. (The route already exists in `pages`; this exposes it in the menu.)
+8. Add a `Pipeline` parent menu entry: `id: "PipelineMenu"`, `label: "Pipeline"`, `icon: "icon-category-organization"`, `order: 30`, no `route`. (Rename the parent id to avoid colliding with the existing leaf id `Pipeline`.)
+9. Change the existing `Pipeline` menu entry: rename `label` to `"Kanban"`, set `parent: "PipelineMenu"`, keep `route: "Pipeline"`.
+10. Change the existing `Leads` menu entry: set `parent: "PipelineMenu"`.
+11. Add a new menu entry for Prospects: `id: "Prospects"`, `label: "Prospects"`, `icon: "icon-search"`, `route: "Prospects"`, `parent: "PipelineMenu"`.
+12. Add a `KlachtenVerzoeken` parent menu entry: `id: "KlachtenVerzoeken"`, `label: "Klachten & Verzoeken"`, `icon: "icon-error"`, `order: 40`, no `route`.
+13. Change the existing `Requests` menu entry: rename `label` to `"Verzoeken"`, set `parent: "KlachtenVerzoeken"`.
+14. Change the existing `Complaints` menu entry: rename `label` to `"Klachten"`, set `parent: "KlachtenVerzoeken"`.
+15. Add a `Catalogus` parent menu entry: `id: "Catalogus"`, `label: "Catalogus"`, `icon: "icon-files"`, `order: 50`, no `route`.
+16. Change the existing `Products` menu entry: rename `label` to `"Producten & diensten"`, set `parent: "Catalogus"`.
+17. Re-order remaining out-of-scope top-menu entries (Tasks, Contactmomenten, Surveys, Queues, Kennisbank, MyWork-replaced-by-MijnWerk, Rapportage, Documentation) so their `order` values do not collide with the new parent groups — keep them as flat top-level entries pending a future audit pass.
+18. Validate the manifest against the schema referenced in `$schema` (run the project's manifest-validate script if one exists, otherwise `node -e "require('ajv')..."` or visual JSON-parse check).
+
+## 2. New Prospects page (`src/manifest.json` + `src/views/`)
+
+19. Add a new `pages` entry to `src/manifest.json`: `id: "Prospects"`, `route: "/prospects"`, `type: "custom"`, `title: "Prospects"`, `component: "ProspectsView"`, `_note: "Full-page expansion of ProspectWidget; lib gap: no declarative type for scored-prospect list with external-source enrichment."`.
+20. Create `src/views/prospects/ProspectsView.vue` based on the existing `src/components/ProspectWidget.vue` — promote it from widget-card to full `CnPage` layout, keep the same Pinia store (`store/modules/prospect.js`), render scored results in a `CnIndexPage`-like list with sortable columns, and add row-level actions: "View details", "Convert to lead".
+21. Register `ProspectsView` in `src/registry.js` with `kind: "page"`, `_note` capturing the lib gap.
+22. Register `ProspectsView` in `src/customComponents.js` for v1-fallback compatibility (mirror how `DashboardView` is registered in both files).
+23. Verify in dev container that `/prospects` resolves and that `Pipeline → Prospects` menu entry routes there.
+
+## 3. Sync settings menu exposure (`src/manifest.json`)
+
+(Covered by task 7 above; no additional file changes needed — `SyncSettings` already has a `pages` entry, `customComponents.js` already exports `SyncSettingsView`, and `registry.js` already maps it.)
+
+## 4. Backwards-compat smoke tests
+
+24. With the new menu live, navigate directly to each preserved URL and confirm the page renders and the correct (new) menu entry is marked active:
+    - `/` → Mijn werk → Dashboard
+    - `/my-work` → Mijn werk → Werkvoorraad
+    - `/clients` → Contacten → Lijst
+    - `/contacts` → Contacten → Contactpersonen
+    - `/sync-settings` → Contacten → Synchronisatie
+    - `/pipeline` → Pipeline → Kanban
+    - `/leads` → Pipeline → Leads
+    - `/prospects` → Pipeline → Prospects (new)
+    - `/requests` → Klachten & Verzoeken → Verzoeken
+    - `/complaints` → Klachten & Verzoeken → Klachten
+    - `/products` → Catalogus → Producten & diensten
+25. Run any existing manifest/route validation tests (`composer test`, `npm test`, or `npm run lint`) and fix any failures introduced by the menu restructure.
+
+## 5. Translations
+
+26. Update `l10n/nl.json` (and the English source `l10n/en.json` if maintained) with new menu labels: `Mijn werk`, `Werkvoorraad`, `Contacten`, `Lijst`, `Contactpersonen`, `Synchronisatie`, `Pipeline`, `Kanban`, `Prospects`, `Klachten & Verzoeken`, `Verzoeken`, `Klachten`, `Catalogus`, `Producten & diensten`. Re-run `genl10n` (or the project's translation extract command) and commit the regenerated files.
+
+## 6. Documentation
+
+27. Update `README.md` and any screenshots in `docs/` that show the old flat left-nav so they reflect the six-group IA. (Skip if no screenshots reference the nav.)
+
+## 7. Open follow-up issues (not part of this change)
+
+28. File a separate GitHub issue: "Add Observability pane under Beheer for prometheus-metrics SETTING surface" — out of scope here, referenced from proposal.md.
+29. File a separate GitHub issue: "Reconcile pipelinq.product schema with pdc.product (IPDC/UPL)" — data-model merge tracked separately from this IA change.
+30. File a separate GitHub issue: "IA audit pass for Tasks, Contactmomenten, Surveys, Queues, Kennisbank, Rapportage" — out of scope here; these specs were not in the audited input.


### PR DESCRIPTION
## Information Architecture audit

Generated from the 2026-05-22 IA pass. Compares 18 implemented pipelinq specs against the proposed IA topology.

**Result: 8 aligned · 10 drift · 0 uncertain**

### Root cause

The current left-nav is a flat list of **15 top-level entries** (Dashboard, Clients, Contacts, Leads, Requests, Tasks, Contactmomenten, Complaints, Products, Pipeline, Surveys, Queues, Kennisbank, MyWork, Rapportage) plus Settings. The proposed IA collapses these into **six top-menu domains** with sub-pages.

### Drifts (10)

- `dashboard`, `my-work` → both top-level today, should sit under **Mijn werk**.
- `client-management`, `contacts-sync` → Clients is top-level, sync is an orphan `/sync-settings` route. Both belong under **Contacten**.
- `pipeline`, `lead-management`, `prospect-discovery` → Pipeline + Leads are top-level siblings; Prospects has no full page yet. All three belong under **Pipeline**.
- `request-management` → top-level Requests, should be under **Klachten & Verzoeken** alongside Complaints.
- `product-catalog`, `product-service-catalog` → top-level Products + overlapping PDC concept, must merge under **Catalogus**.

### Aligned (8)

`activity-timeline`, `entity-notes`, `lead-product-link` (detail cards); `notifications-activity` (header + activity stream); `admin-settings` (NC admin panel); `openregister-integration`, `register-i18n` (INFRA); `prometheus-metrics` (backend exists; Observability is additive).

### What's in this change

- `proposal.md` — drift rationale per spec
- `design.md` — new 6-domain IA topology
- `specs.md` — per-spec ADDED/REMOVED requirements
- `tasks.md` — 30 atomic tasks (manifest restructure, one new `/prospects` route, route paths preserved for backwards compat)

To execute: label with `ready-to-build` + `yolo` once approved.