### PR TITLE
fix(manifest): collapse single-widget dashboard pages to type:custom

### DIFF
--- a/openspec/changes/fix-dashboard-antipattern-manifest/design.md
+++ b/openspec/changes/fix-dashboard-antipattern-manifest/design.md
@@ -1,0 +1,184 @@
+# Design: Fix dashboard-in-widget anti-pattern across Pipelinq manifest
+
+## Affected entries
+
+All line numbers refer to `src/manifest.json` at the
+`origin/development` tip (commit b657976) that this change branches
+from.
+
+| # | Page id | Route | Lines | Slot component (target) |
+|---|--------------------------|----------------------------|-----------|-----------------------------|
+| 1 | `Dashboard` | `/` | 154–181 | `DashboardView` |
+| 2 | `SurveyAnalyticsView` | `/surveys/:id/analytics` | 656–683 | `SurveyAnalyticsView` |
+| 3 | `MyWork` | `/my-work` | 698–725 | `MyWorkView` |
+| 4 | `Rapportage` | `/rapportage` | 744–771 | `RapportageDashboardView` |
+| 5 | `ChannelAnalyticsView` | `/rapportage/channels` | 772–799 | `ChannelAnalyticsView` |
+| 6 | `AgentPerformanceView` | `/rapportage/agents` | 800–827 | `AgentPerformanceView` |
+
+The `Kennisbank` route (`/kennisbank`, `src/manifest.json:501–538`)
+also uses `type: "dashboard"` but is legitimate — it composes two
+distinct widgets (`CnTreeView` + `CnIndexPage`) and is left
+untouched. It is the canonical example of when `type: "dashboard"` is
+correct.
+
+## Per-route transformation
+
+For each of the six entries, replace:
+
+```json
+{
+    "id": "<Id>",
+    "route": "<route>",
+    "type": "dashboard",
+    "title": "<title>",
+    "config": {
+        "widgets": [
+            {
+                "id": "<widgetId>",
+                "title": "<title>",
+                "type": "custom"
+            }
+        ],
+        "layout": [
+            {
+                "id": "1",
+                "widgetId": "<widgetId>",
+                "gridX": 0,
+                "gridY": 0,
+                "gridWidth": 12,
+                "gridHeight": 12
+            }
+        ]
+    },
+    "slots": {
+        "widget-<widgetId>": "<ComponentName>"
+    }
+}
+```
+
+with:
+
+```json
+{
+    "id": "<Id>",
+    "route": "<route>",
+    "type": "custom",
+    "title": "<title>",
+    "component": "<ComponentName>"
+}
+```
+
+This matches the existing canonical custom-page shape already in use
+at `src/manifest.json:464` (`Pipeline` → `PipelineBoardView`) and
+`src/manifest.json:626` (`SurveyCreate` → `CnFormBuilder`).
+
+The slot component name (`<ComponentName>`) maps to the existing
+top-level key in `src/registry.js`. All six target names are already
+registered (`src/registry.js:69, 74, 107, 128, 133, 138`). No
+registry or `src/customComponents.js` changes are required.
+
+## Field preservation
+
+| Field | Before | After | Notes |
+|------|--------|------|------|
+| `id` | preserved | preserved | Critical — referenced by IA-alignment menu restructure |
+| `route` | preserved | preserved | Critical — preserves deep-links and bookmarks |
+| `title` | preserved | preserved | Same string, just moves to render via the custom component's own page title |
+| `type` | `"dashboard"` | `"custom"` | The fix |
+| `component` | (absent) | added | New canonical pointer to the registry entry |
+| `config.widgets` | present | removed | Single-widget shape is the smell — replaced by direct component |
+| `config.layout` | present | removed | Layout is meaningless for a single 12×12 widget |
+| `slots` | present | removed | Slot maps to the same component now reached via `component` |
+
+The `config` object is removed entirely for these six routes (it
+only ever held `widgets` + `layout`). No other config keys are
+present on these entries.
+
+## Rendering impact
+
+Before — three layered chrome elements before the page body:
+
+```
+CnDashboardPage  (from manifest type:"dashboard")
+  └ CnWidgetWrapper  (from layout entry)
+      └ DashboardView (which itself uses CnDashboardPage)
+          └ actual widgets
+```
+
+After — manifest-side chrome collapses to a generic custom container:
+
+```
+<custom-page container>  (from manifest type:"custom")
+  └ DashboardView (still uses CnDashboardPage internally — see follow-up)
+      └ actual widgets
+```
+
+For the five non-Dashboard routes (`MyWork`, `Rapportage`,
+`ChannelAnalyticsView`, `AgentPerformanceView`,
+`SurveyAnalyticsView`) the rendered DOM is even cleaner — none of
+those five view files use `<CnDashboardPage>` internally (verified
+2026-05-23 with `grep -n CnDashboardPage src/views/...`), so the
+nesting collapses entirely:
+
+```
+<custom-page container>
+  └ MyWorkView (already a self-contained page with its own h2 / layout)
+```
+
+## Deferred follow-up
+
+`src/views/Dashboard.vue:3,183,213,253` uses `<CnDashboardPage>` as
+its root with eight declarative widget slots
+(`count-open-leads`, `count-open-requests`, `count-pipeline-value`,
+`count-overdue`, `deals-by-stage`, `complaints-overview`, `my-work`,
+`client-overview`) and a `DEFAULT_LAYOUT` constant. Removing this
+cleanly requires either (a) moving all eight widget definitions and
+the default layout into `src/manifest.json` (so the manifest's
+`type: "dashboard"` legitimately becomes a multi-widget grid), or
+(b) keeping the layout in Vue but eliminating one of the two
+`CnDashboardPage` instances by promoting the inner one to a layout
+primitive.
+
+Both options are non-trivial. A follow-up issue will be filed against
+this repo after the PR is open; this change deliberately stops at the
+manifest fix.
+
+## Coordination with `refactor-pipelinq-ia-alignment`
+
+The IA-alignment change (committed at
+`openspec/changes/refactor-pipelinq-ia-alignment/`, PR #517 merged)
+proposes restructuring the **menu** topology in `src/manifest.json`
+(adding parent groups, reordering, retitling labels in Dutch). Its
+WIP working-tree edits (held in
+`apps-extra/pipelinq/src/manifest.json` outside this worktree) do
+not yet alter the six `pages[]` entries this change touches —
+their work is confined to the `menu[]` array (lines 7–152) and adds
+a single new `pages[]` entry (`Prospects`).
+
+This change touches only:
+
+- The six listed `pages[]` entries' fields (lines 154–181, 656–683,
+  698–725, 744–771, 772–799, 800–827).
+
+It does not modify:
+
+- The `menu[]` array (lines 7–152) — owned by IA-alignment.
+- Page IDs or route paths — IA-alignment depends on these staying
+  stable.
+- Any other `pages[]` entry.
+
+Conflict risk: low. Both changes touch the same file, but in
+disjoint regions. A `git rebase` of IA-alignment onto this change's
+merge commit should auto-resolve. If IA-alignment lands first, this
+change is unaffected (it depends only on the page IDs/routes the IA
+work also preserves).
+
+## Schema validity
+
+The output shape (`type: "custom"` + `component: "<Name>"`) is the
+canonical custom-page shape already used six times in this manifest
+(`PipelineBoardView`, `CnTreeView`, `CnFormBuilder`, `CnFormBuilder`,
+plus two `CnWizardDialog` create dialogs) and is documented in
+`@conduction/nextcloud-vue`'s `app-manifest-v2.schema.json`. No
+schema or validator change is required for this PR; the schema-rule
+to actively flag the **before** shape is the work of hydra#318.

--- a/openspec/changes/fix-dashboard-antipattern-manifest/proposal.md
+++ b/openspec/changes/fix-dashboard-antipattern-manifest/proposal.md
@@ -1,0 +1,85 @@
+# Proposal: Fix dashboard-in-widget anti-pattern across Pipelinq manifest
+
+## Why
+
+Six routes in `src/manifest.json` are declared as `type: "dashboard"` with
+a single 12×12 custom widget whose body is a one-off Vue component
+(`DashboardView`, `MyWorkView`, `RapportageDashboardView`,
+`ChannelAnalyticsView`, `AgentPerformanceView`, `SurveyAnalyticsView`).
+The manifest's `type: "dashboard"` page wraps the route in
+`CnDashboardPage` → `CnWidgetWrapper`. The slot then loads the custom
+component, which is itself a self-contained page (and in the case of
+`DashboardView`, *also* uses `<CnDashboardPage>` internally — see
+issue #521).
+
+Result on the Dashboard route (`/`): three nested "Dashboard" headings
+(`outer h2 → middle h3 → inner h2`). On the other five routes the same
+pattern produces a redundant `CnDashboardPage` + `CnWidgetWrapper`
+chrome around a page that already renders its own headers/layout.
+
+This is the page-type the dashboard `type` was designed for: pages
+with **multiple** real widgets laid out in a grid (e.g. the
+`Kennisbank` route at `src/manifest.json:502`, which legitimately uses
+two widgets: a `CnTreeView` + a `CnIndexPage`). Using it as a wrapper
+around a single full-grid bespoke component is a code-smell — it's a
+custom page in disguise.
+
+Cross-references:
+
+- ConductionNL/pipelinq#521 — original A1 report (visual confirmation
+  + sweep result identifying all six instances).
+- ConductionNL/hydra#317 — ADR-017 patch to explicitly forbid
+  `CnDashboardPage` inside a dashboard widget slot.
+- ConductionNL/hydra#318 — schema rule (in
+  `app-manifest-v2.schema.json`) to flag single-12×12-widget
+  dashboards at validation time.
+
+## What Changes
+
+For each of the six affected page entries in `src/manifest.json`,
+swap the `type: "dashboard"` + single-widget `config.widgets` /
+`config.layout` / `slots` block for the canonical custom-page shape:
+
+```jsonc
+{
+    "id": "...",
+    "route": "...",
+    "type": "custom",
+    "title": "...",
+    "component": "<NameFromRegistry>"
+}
+```
+
+The component names referenced by the slots already exist as
+top-level entries in `src/registry.js` (`DashboardView`, `MyWorkView`,
+`RapportageDashboardView`, `ChannelAnalyticsView`,
+`AgentPerformanceView`, `SurveyAnalyticsView`), so no registry change
+is required.
+
+**Scope boundary — what this change does NOT do:**
+
+- It does NOT remove `<CnDashboardPage>` from `src/views/Dashboard.vue`.
+  That file legitimately uses `CnDashboardPage` to render eight real
+  widgets in a grid — refactoring it cleanly requires moving all eight
+  widgets + layout into the manifest, which is a much larger change.
+  After this proposal lands, the Dashboard route will collapse from
+  triple to double nesting (outer manifest CnDashboardPage gone; inner
+  Dashboard.vue's own CnDashboardPage retained). A follow-up issue
+  will be filed to either migrate Dashboard.vue's grid into the
+  manifest or split it into N declarative widgets.
+- It does NOT touch any menu entries, route IDs, paths, titles, or
+  widget config that the in-flight
+  `refactor-pipelinq-ia-alignment` change is restructuring.
+  Specifically: the six page IDs (`Dashboard`, `MyWork`, `Rapportage`,
+  `ChannelAnalyticsView`, `AgentPerformanceView`,
+  `SurveyAnalyticsView`) and their route paths are preserved
+  verbatim, so the IA-alignment change can rebase its menu-topology
+  edits cleanly on top.
+
+## Out of scope
+
+- Removing `<CnDashboardPage>` from `src/views/Dashboard.vue` —
+  separate follow-up.
+- Renaming any of the six routes / IDs — owned by the
+  `refactor-pipelinq-ia-alignment` change.
+- Hydra ADR-017 / schema patches — owned by hydra#317 and hydra#318.

--- a/openspec/changes/fix-dashboard-antipattern-manifest/specs.md
+++ b/openspec/changes/fix-dashboard-antipattern-manifest/specs.md
@@ -1,0 +1,86 @@
+---
+name: fix-dashboard-antipattern-manifest
+status: draft
+version: draft
+---
+
+# Manifest page-type deltas
+
+This file consolidates the per-spec deltas for the manifest
+anti-pattern fix. Each section targets one of the existing specs
+under `openspec/specs/{spec-slug}/spec.md` and lists the placement
+requirements ADDED.
+
+The deltas describe **manifest declaration shape** only — they do
+not change the feature contracts, data models, or rendered UX of
+the affected pages. Where a spec already states "dashboard route
+uses `type: dashboard`" or similar, the existing prose is implicitly
+superseded by the ADDED Requirement below.
+
+Only two of the six affected pages have a dedicated spec
+(`dashboard` and `my-work`). The other four (`Rapportage`,
+`ChannelAnalyticsView`, `AgentPerformanceView`,
+`SurveyAnalyticsView`) do not currently have a `openspec/specs/`
+entry, so they are not deltaed here — the manifest changes for
+those are described in `design.md` and `tasks.md` only.
+
+---
+
+## Spec: dashboard
+
+### ADDED Requirements
+
+#### Requirement: Dashboard route MUST declare type "custom" in the manifest
+
+The `Dashboard` page entry in `src/manifest.json` MUST declare
+`type: "custom"` with `component: "DashboardView"`. It MUST NOT use
+`type: "dashboard"` with a single full-grid widget that wraps the
+custom `DashboardView` component.
+
+##### Scenario: Manifest declares Dashboard as a custom page
+- GIVEN the manifest at `src/manifest.json`
+- WHEN the entry with `id: "Dashboard"` and `route: "/"` is parsed
+- THEN `type` MUST equal `"custom"`
+- AND `component` MUST equal `"DashboardView"`
+- AND there MUST NOT be a `config.widgets` array on this entry
+- AND there MUST NOT be a `config.layout` array on this entry
+- AND there MUST NOT be a `slots` object on this entry
+
+##### Scenario: Rendered dashboard route does not stack two CnDashboardPage instances at the manifest layer
+- GIVEN the user navigates to `/apps/pipelinq/`
+- WHEN the dashboard route renders
+- THEN the page MUST NOT be wrapped in a manifest-driven `CnDashboardPage`
+  before the route component (`DashboardView`) is mounted
+- AND the page MUST NOT be wrapped in a manifest-driven `CnWidgetWrapper`
+  before the route component is mounted
+- AND the page title heading MUST come from the route component itself
+  (or from a single canonical manifest layer), not from both
+
+---
+
+## Spec: my-work
+
+### ADDED Requirements
+
+#### Requirement: MyWork route MUST declare type "custom" in the manifest
+
+The `MyWork` page entry in `src/manifest.json` MUST declare
+`type: "custom"` with `component: "MyWorkView"`. It MUST NOT use
+`type: "dashboard"` with a single full-grid widget that wraps the
+custom `MyWorkView` component.
+
+##### Scenario: Manifest declares MyWork as a custom page
+- GIVEN the manifest at `src/manifest.json`
+- WHEN the entry with `id: "MyWork"` and `route: "/my-work"` is parsed
+- THEN `type` MUST equal `"custom"`
+- AND `component` MUST equal `"MyWorkView"`
+- AND there MUST NOT be a `config.widgets` array on this entry
+- AND there MUST NOT be a `config.layout` array on this entry
+- AND there MUST NOT be a `slots` object on this entry
+
+##### Scenario: Rendered My Work route does not double-wrap the page header
+- GIVEN the user navigates to `/my-work`
+- WHEN the MyWork route renders
+- THEN exactly one "My Work" page title heading MUST be visible
+- AND the manifest layer MUST NOT contribute a `CnDashboardPage` wrapper
+  around `MyWorkView`

--- a/openspec/changes/fix-dashboard-antipattern-manifest/tasks.md
+++ b/openspec/changes/fix-dashboard-antipattern-manifest/tasks.md
@@ -1,0 +1,25 @@
+# Tasks: Fix dashboard-in-widget anti-pattern across Pipelinq manifest
+
+All edits target `src/manifest.json`. Each task is atomic and edits
+exactly one of the six `pages[]` entries. Line numbers are the
+ranges at the `origin/development` tip (commit b657976) this change
+branches from.
+
+## 1. Manifest fixes (`src/manifest.json`)
+
+1. Edit the `Dashboard` page entry (lines 154–181, `route: "/"`): change `type` from `"dashboard"` to `"custom"`, add `"component": "DashboardView"`, remove the `config` object, remove the `slots` object. Preserve `id`, `route`, `title`. Preserve the surrounding tab-indent style (the file uses hard tabs).
+2. Edit the `SurveyAnalyticsView` page entry (lines 656–683, `route: "/surveys/:id/analytics"`): change `type` to `"custom"`, add `"component": "SurveyAnalyticsView"`, remove `config`, remove `slots`. Preserve `id`, `route`, `title`.
+3. Edit the `MyWork` page entry (lines 698–725, `route: "/my-work"`): change `type` to `"custom"`, add `"component": "MyWorkView"`, remove `config`, remove `slots`. Preserve `id`, `route`, `title`.
+4. Edit the `Rapportage` page entry (lines 744–771, `route: "/rapportage"`): change `type` to `"custom"`, add `"component": "RapportageDashboardView"`, remove `config`, remove `slots`. Preserve `id`, `route`, `title`.
+5. Edit the `ChannelAnalyticsView` page entry (lines 772–799, `route: "/rapportage/channels"`): change `type` to `"custom"`, add `"component": "ChannelAnalyticsView"`, remove `config`, remove `slots`. Preserve `id`, `route`, `title`.
+6. Edit the `AgentPerformanceView` page entry (lines 800–827, `route: "/rapportage/agents"`): change `type` to `"custom"`, add `"component": "AgentPerformanceView"`, remove `config`, remove `slots`. Preserve `id`, `route`, `title`.
+
+## 2. Validation
+
+7. Re-parse `src/manifest.json` to confirm it is still valid JSON (`node -e "JSON.parse(require('fs').readFileSync('src/manifest.json'))"` or equivalent).
+8. Confirm none of the six target page entries still contain the substring `"type": "dashboard"` (grep should return only the legitimate `Kennisbank` entry).
+9. Confirm all six target component names (`DashboardView`, `SurveyAnalyticsView`, `MyWorkView`, `RapportageDashboardView`, `ChannelAnalyticsView`, `AgentPerformanceView`) remain registered as top-level keys in `src/registry.js`.
+
+## 3. Deferred follow-up (out of scope; file as separate issue)
+
+10. File a follow-up GitHub issue tracking removal of `<CnDashboardPage>` from `src/views/Dashboard.vue:3,183,213,253`. Two viable paths to mention: (a) migrate the eight declarative widgets + `DEFAULT_LAYOUT` constant into the manifest so the route legitimately becomes `type: "dashboard"`, or (b) eliminate the inner `CnDashboardPage` by promoting it to a layout primitive while keeping widgets in Vue. Cross-link this PR and pipelinq#521.

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -154,30 +154,9 @@
 		{
 			"id": "Dashboard",
 			"route": "/",
-			"type": "dashboard",
+			"type": "custom",
 			"title": "Dashboard",
-			"config": {
-				"widgets": [
-					{
-						"id": "dashboardMain",
-						"title": "Dashboard",
-						"type": "custom"
-					}
-				],
-				"layout": [
-					{
-						"id": "1",
-						"widgetId": "dashboardMain",
-						"gridX": 0,
-						"gridY": 0,
-						"gridWidth": 12,
-						"gridHeight": 12
-					}
-				]
-			},
-			"slots": {
-				"widget-dashboardMain": "DashboardView"
-			}
+			"component": "DashboardView"
 		},
 		{
 			"id": "Clients",
@@ -656,30 +635,9 @@
 		{
 			"id": "SurveyAnalyticsView",
 			"route": "/surveys/:id/analytics",
-			"type": "dashboard",
+			"type": "custom",
 			"title": "Survey analytics",
-			"config": {
-				"widgets": [
-					{
-						"id": "surveyAnalytics",
-						"title": "Survey analytics",
-						"type": "custom"
-					}
-				],
-				"layout": [
-					{
-						"id": "1",
-						"widgetId": "surveyAnalytics",
-						"gridX": 0,
-						"gridY": 0,
-						"gridWidth": 12,
-						"gridHeight": 12
-					}
-				]
-			},
-			"slots": {
-				"widget-surveyAnalytics": "SurveyAnalyticsView"
-			}
+			"component": "SurveyAnalyticsView"
 		},
 		{
 			"id": "PublicSurvey",
@@ -698,30 +656,9 @@
 		{
 			"id": "MyWork",
 			"route": "/my-work",
-			"type": "dashboard",
+			"type": "custom",
 			"title": "My Work",
-			"config": {
-				"widgets": [
-					{
-						"id": "myWorkBoard",
-						"title": "My Work",
-						"type": "custom"
-					}
-				],
-				"layout": [
-					{
-						"id": "1",
-						"widgetId": "myWorkBoard",
-						"gridX": 0,
-						"gridY": 0,
-						"gridWidth": 12,
-						"gridHeight": 12
-					}
-				]
-			},
-			"slots": {
-				"widget-myWorkBoard": "MyWorkView"
-			}
+			"component": "MyWorkView"
 		},
 		{
 			"id": "SyncSettings",
@@ -744,86 +681,23 @@
 		{
 			"id": "Rapportage",
 			"route": "/rapportage",
-			"type": "dashboard",
+			"type": "custom",
 			"title": "Reporting",
-			"config": {
-				"widgets": [
-					{
-						"id": "rapportageKpis",
-						"title": "Reporting",
-						"type": "custom"
-					}
-				],
-				"layout": [
-					{
-						"id": "1",
-						"widgetId": "rapportageKpis",
-						"gridX": 0,
-						"gridY": 0,
-						"gridWidth": 12,
-						"gridHeight": 12
-					}
-				]
-			},
-			"slots": {
-				"widget-rapportageKpis": "RapportageDashboardView"
-			}
+			"component": "RapportageDashboardView"
 		},
 		{
 			"id": "ChannelAnalyticsView",
 			"route": "/rapportage/channels",
-			"type": "dashboard",
+			"type": "custom",
 			"title": "Channel analytics",
-			"config": {
-				"widgets": [
-					{
-						"id": "channelAnalytics",
-						"title": "Channel analytics",
-						"type": "custom"
-					}
-				],
-				"layout": [
-					{
-						"id": "1",
-						"widgetId": "channelAnalytics",
-						"gridX": 0,
-						"gridY": 0,
-						"gridWidth": 12,
-						"gridHeight": 12
-					}
-				]
-			},
-			"slots": {
-				"widget-channelAnalytics": "ChannelAnalyticsView"
-			}
+			"component": "ChannelAnalyticsView"
 		},
 		{
 			"id": "AgentPerformanceView",
 			"route": "/rapportage/agents",
-			"type": "dashboard",
+			"type": "custom",
 			"title": "Agent performance",
-			"config": {
-				"widgets": [
-					{
-						"id": "agentPerformance",
-						"title": "Agent performance",
-						"type": "custom"
-					}
-				],
-				"layout": [
-					{
-						"id": "1",
-						"widgetId": "agentPerformance",
-						"gridX": 0,
-						"gridY": 0,
-						"gridWidth": 12,
-						"gridHeight": 12
-					}
-				]
-			},
-			"slots": {
-				"widget-agentPerformance": "AgentPerformanceView"
-			}
+			"component": "AgentPerformanceView"
 		},
 		{
 			"id": "Pipelines",


### PR DESCRIPTION
## Summary

Six routes in `src/manifest.json` were declared as `type: "dashboard"` with a single 12×12 custom widget wrapping a bespoke Vue component. The manifest's dashboard wrapper (`CnDashboardPage` → `CnWidgetWrapper`) then nested around components that already render their own page chrome, producing redundant headers and (for the Dashboard route at `/apps/pipelinq/`) three nested "Dashboard" `h2`/`h3` elements.

This PR switches the six routes to the canonical `type: "custom"` + `component: "<Name>"` shape that already exists six times in the same manifest (e.g. `PipelineBoardView`, `CnFormBuilder`).

| # | Page id | Route | Component (already in `src/registry.js`) |
|---|---|---|---|
| 1 | `Dashboard` | `/` | `DashboardView` |
| 2 | `SurveyAnalyticsView` | `/surveys/:id/analytics` | `SurveyAnalyticsView` |
| 3 | `MyWork` | `/my-work` | `MyWorkView` |
| 4 | `Rapportage` | `/rapportage` | `RapportageDashboardView` |
| 5 | `ChannelAnalyticsView` | `/rapportage/channels` | `ChannelAnalyticsView` |
| 6 | `AgentPerformanceView` | `/rapportage/agents` | `AgentPerformanceView` |

`Kennisbank` (`/kennisbank`) — the only legitimate `type: "dashboard"` route, with two real widgets (`CnTreeView` + `CnIndexPage`) — is left untouched.

Closes #521.

## What this PR does NOT do (out of scope)

- **`src/views/Dashboard.vue` still uses `<CnDashboardPage>` internally** with eight declarative widget slots + a `DEFAULT_LAYOUT` constant. Cleaning that up requires either migrating the whole grid into the manifest (so the route legitimately becomes `type: "dashboard"`) or eliminating the inner `CnDashboardPage` as a layout primitive — both non-trivial. After this PR, the Dashboard route collapses from **triple** to **double** nesting. The other five routes (none of which use `<CnDashboardPage>` internally) collapse **fully**. Follow-up issue will be filed after merge.
- **Menu topology / IDs / route paths.** All six page IDs, route paths, and titles are preserved verbatim.

## Coordination with the in-flight `refactor-pipelinq-ia-alignment` change

Heads up to the IA-alignment author: this PR edits the **same file** (`src/manifest.json`) but in **disjoint regions** — only the six `pages[]` entries above are touched, and only their `type` / `config` / `slots` / `component` fields. The `menu[]` array (lines 7–152) and every other `pages[]` entry are untouched. Page IDs and route paths the IA work depends on are preserved verbatim, so an IA-alignment rebase onto this commit should auto-resolve. If IA-alignment lands first, this PR is unaffected.

## Cross-links

- ConductionNL/hydra#317 — ADR-017 patch to forbid `CnDashboardPage` inside a manifest dashboard widget slot.
- ConductionNL/hydra#318 — `app-manifest-v2.schema.json` rule to flag single-12×12-widget dashboards at validation time.

## Test plan

- [x] `node -e "JSON.parse(...)"` — manifest still parses
- [x] `grep '"type": "dashboard"' src/manifest.json` — only `Kennisbank` left
- [x] All six target component names confirmed registered in `src/registry.js`
- [ ] Reviewer: open `/apps/pipelinq/` in the dev container and confirm only one "Dashboard" heading remains (was three)
- [ ] Reviewer: open `/apps/pipelinq/#/my-work` and confirm no redundant widget wrapper around `MyWorkView`
- [ ] Reviewer: open `/apps/pipelinq/#/rapportage` (+ `/channels`, `/agents`) and confirm no redundant chrome