### PR TITLE
fix(App.vue): drop legacy CnIndexSidebar — root cause of dup-sidebar bug

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -7,10 +7,15 @@
  channel so detail pages (CnDetailPage) can drive a single
  host-rendered CnObjectSidebar through the #sidebar slot.
 
- The legacy `sidebarState` and `pipelineSidebarState` channels are
- preserved so the bespoke pipeline kanban (PipelineBoard.vue) and any
- other custom view that injects them keep working through the
- transition.
+ The legacy `sidebarState` channel is still provided as a no-op
+ surface for any straggler view that injects it (notably the dead
+ `views/clients/ClientList.vue`), but App.vue no longer renders a
+ CnIndexSidebar — the lib's CnAppRoot auto-hoists CnIndexPage's
+ sidebar at NcContent level, so rendering one here too produced the
+ double-sidebar bug visible on every index page.
+
+ The `pipelineSidebarState` channel stays in active use by the
+ bespoke PipelineBoard kanban (PipelineSidebar component below).
 
  @spec openspec/changes/pipelinq-manifest-v1/tasks.md
 -->
@@ -36,18 +41,6 @@
 				:tabs="objectSidebarState.tabs"
 				:open="objectSidebarState.open"
 				@update:open="objectSidebarState.open = $event" />
-			<CnIndexSidebar
-				v-if="sidebarState.active"
-				:schema="sidebarState.schema"
-				:visible-columns="sidebarState.visibleColumns"
-				:search-value="sidebarState.searchValue"
-				:active-filters="sidebarState.activeFilters"
-				:facet-data="sidebarState.facetData"
-				:open="sidebarState.open"
-				@update:open="sidebarState.open = $event"
-				@search="onSidebarSearch"
-				@columns-change="onSidebarColumnsChange"
-				@filter-change="onSidebarFilterChange" />
 			<PipelineSidebar
 				v-if="pipelineSidebarState.active && !sidebarState.active"
 				:pipeline="pipelineSidebarState.pipeline"
@@ -61,7 +54,7 @@
 <script>
 import Vue from 'vue'
 import { translate as ncT } from '@nextcloud/l10n'
-import { CnAppRoot, CnIndexSidebar, CnObjectSidebar } from '@conduction/nextcloud-vue'
+import { CnAppRoot, CnObjectSidebar } from '@conduction/nextcloud-vue'
 import PipelineSidebar from './views/pipeline/PipelineSidebar.vue'
 
 export default {
@@ -69,7 +62,6 @@ export default {
 
 	components: {
 		CnAppRoot,
-		CnIndexSidebar,
 		CnObjectSidebar,
 		PipelineSidebar,
 	},
@@ -185,23 +177,6 @@ export default {
 		 */
 		translateForApp(key) {
 			return ncT('pipelinq', key)
-		},
-		onSidebarSearch(value) {
-			this.sidebarState.searchValue = value
-			if (typeof this.sidebarState.onSearch === 'function') {
-				this.sidebarState.onSearch(value)
-			}
-		},
-		onSidebarColumnsChange(columns) {
-			this.sidebarState.visibleColumns = columns
-			if (typeof this.sidebarState.onColumnsChange === 'function') {
-				this.sidebarState.onColumnsChange(columns)
-			}
-		},
-		onSidebarFilterChange(filter) {
-			if (typeof this.sidebarState.onFilterChange === 'function') {
-				this.sidebarState.onFilterChange(filter)
-			}
 		},
 		onPipelineSidebarSave(pipelineData) {
 			if (typeof this.pipelineSidebarState.onSave === 'function') {


### PR DESCRIPTION
## Summary

CnAppRoot (in \`@conduction/nextcloud-vue\` beta) now auto-hoists CnIndexPage's sidebar at \`NcContent\` level via the \`cnIndexSidebarConfig\` provide/inject contract. App.vue's \`#sidebar\` slot was still mounting a host-side \`<CnIndexSidebar>\` wired to the legacy \`sidebarState\` injection, so on every index page **two** sidebars rendered simultaneously — the bug visible on \`/clients\`, \`/leads\`, \`/contacts\`, \`/requests\`, \`/tasks\`, \`/forms\`, etc.

Visual evidence: user-supplied screenshot on \`/forms\` showing \"Intake Form\" (singular, from one mount) + \"Forms\" (plural, from the other) panels side-by-side, both with identical Search/Columns tabs and Filters.

## Diagnosis path

1. Looked at user's screenshot of dup sidebars.
2. Located the in-flight \`feat/index-sidebar-hoist\` branch (Ruben's own commit cc1e89b5 from May 10) thinking it needed promotion.
3. Discovered that branch's functionality is **already merged into beta** under a different PR (beta's CnAppRoot has the full \`cnIndexSidebarConfig\` provider + hoisted sidebar render; beta's CnIndexPage has \`shouldRenderInlineSidebar\` + the new injects).
4. So the lib is right — it's pipelinq's App.vue that's still rendering its own. Closed the redundant stale branch (\`feat/index-sidebar-hoist\` deleted on remote, nothing left to merge there).
5. Removed the legacy block from App.vue.

## What's removed / kept

| Removed | Kept |
|---|---|
| \`<CnIndexSidebar v-if=\"sidebarState.active\">\` block | \`sidebarState\` provide + data (as no-op surface for ClientList.vue legacy injection) |
| \`CnIndexSidebar\` import + components entry | \`<PipelineSidebar>\` (bespoke kanban sidebar, still in active use) |
| \`onSidebarSearch\` / \`onSidebarColumnsChange\` / \`onSidebarFilterChange\` handlers | \`objectSidebarState\` + \`<CnObjectSidebar>\` (detail-page sidebars) |

Net: -25 lines on App.vue. The lib's hoisted sidebar now owns the index-sidebar surface.

## Test plan

After this lands AND \`js/\` rebuild (tracking: #534), confirm:
- [ ] Only ONE sidebar visible on \`/clients\`, \`/leads\`, \`/contacts\`, \`/requests\`, \`/tasks\`, \`/forms\`
- [ ] Sidebar shows schema plural form (e.g. \"Clients\") and the descriptive paragraph
- [ ] Search input still functional; column toggles still work; filters still apply
- [ ] PipelineBoard kanban sidebar still works on \`/pipeline\`
- [ ] Detail-page object sidebar still works (open any \`/clients/:id\`)

Closes #522.

## Related

- nc-vue#340 (sidebar ownership contract) — already resolved upstream
- nc-vue#343 (just merged) — fixes the nested Search h3
- pipelinq#534 — bundle rebuild needed before the user sees this fix
- pipelinq#535 — A1 dashboard-anti-pattern fix (orthogonal manifest edits)