### PR TITLE
fix: Documentation nav link + Task schema description re-import

### DIFF
--- a/lib/Settings/pipelinq_register.json
+++ b/lib/Settings/pipelinq_register.json
@@ -1202,7 +1202,7 @@
         "slug": "task",
         "title": "Task",
         "icon": "ClipboardCheck",
-        "version": "1.0.0",
+        "version": "1.0.1",
         "summary": "A callback request or follow-up task (terugbelverzoek / opvolgtaak / informatievraag)",
         "description": "Represents an internal task — a callback request (terugbelverzoek), follow-up task (opvolgtaak), or information request (informatievraag) assigned to a user or department. Maps to VNG InterneTaak and Schema.org Action.",
         "@type": "schema:Action",

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -114,7 +114,7 @@
 			"id": "Documentation",
 			"label": "Documentation",
 			"icon": "icon-info",
-			"href": "https://conduction.gitbook.io/pipelinq-nextcloud",
+			"href": "https://pipelinq.conduction.nl/",
 			"order": 160
 		},
 		{


### PR DESCRIPTION
## Summary

Two unrelated small fixes bundled into one PR.

### A9 — Documentation nav link (closes #527)

`src/manifest.json` Documentation menu entry was pointing at the legacy GitBook URL (`https://conduction.gitbook.io/pipelinq-nextcloud`). The canonical docs site is live at `https://pipelinq.conduction.nl/` (HTTP 200; Docusaurus build deployed from `main`). Updated the `href` to the new canonical URL. `Settings.vue` already pointed at `pipelinq.conduction.nl/docs/intro` so this aligns the in-app docs link.

### A12 — Task schema description (closes #532)

`lib/Settings/pipelinq_register.json` already had the correct description as of commit `439e073` (2026-03-22):

> Represents an internal task — a callback request (terugbelverzoek), follow-up task (opvolgtaak), or information request (informatievraag) assigned to a user or department. Maps to VNG InterneTaak and Schema.org Action.

The stale "A task within a case" text only lives in live OR databases that imported the old version. Bumped the schema `version` from `1.0.0` to `1.0.1` so the next app upgrade re-runs the InitializeSettings repair step and overwrites the description.

## Test plan

- [ ] After merge + app upgrade, sidebar on `/apps/pipelinq/tasks` shows the long canonical task description.
- [ ] Documentation nav entry opens `https://pipelinq.conduction.nl/`.

Closes #527
Closes #532