### PR TITLE
fix(PipelineBoard): register object type + select labels (closes #530, #531)

### DIFF
--- a/src/views/pipeline/PipelineBoard.vue
+++ b/src/views/pipeline/PipelineBoard.vue
@@ -10,6 +10,7 @@
 					label="label"
 					:reduce="o => o.value"
 					:placeholder="t('pipelinq', 'Select pipeline')"
+					:input-label="t('pipelinq', 'Select pipeline')"
 					class="pipeline-selector"
 					@input="onPipelineChange" />
 				<NcSelect
@@ -17,6 +18,7 @@
 					v-model="showFilter"
 					:options="showFilterOptions"
 					:clearable="false"
+					:input-label="t('pipelinq', 'Filter by type')"
 					class="show-filter" />
 				<NcTextField
 					:value="searchQuery"
@@ -210,6 +212,7 @@ import FormatListBulleted from 'vue-material-design-icons/FormatListBulleted.vue
 import Cog from 'vue-material-design-icons/Cog.vue'
 import PipelineCard from './PipelineCard.vue'
 import { useObjectStore } from '../../store/modules/object.js'
+import { useSettingsStore } from '../../store/modules/settings.js'
 import { getPriorityLabel, getPriorityColor } from '../../services/requestStatus.js'
 import { getDaysAge, isStale, getAgingClass, formatAge } from '../../services/pipelineUtils.js'
 import { formatDate } from '../../services/localeUtils.js'
@@ -245,6 +248,9 @@ export default {
 	computed: {
 		objectStore() {
 			return useObjectStore()
+		},
+		settingsStore() {
+			return useSettingsStore()
 		},
 		pipelines() {
 			return this.objectStore.collections.pipeline || []
@@ -361,6 +367,16 @@ export default {
 		}
 
 		this.loading = true
+
+		// Defensive: this page is `type: "custom"` in the manifest, so the v2
+		// renderer's auto-registration (which fires for type:"index" / "detail")
+		// does NOT run. initializeStores() is fire-and-forget in main.js, so
+		// when /pipeline is the landing route we can race ahead of the global
+		// registration and fetchCollection('pipeline') throws "type not
+		// registered". Ensure the types we use are registered before fetching.
+		// (See issue #530.)
+		await this.ensureObjectTypes(['pipeline', 'lead', 'request'])
+
 		await this.objectStore.fetchCollection('pipeline', { _limit: 100 })
 
 		// Auto-select first pipeline
@@ -381,6 +397,38 @@ export default {
 	methods: {
 		getPriorityLabel,
 		getPriorityColor,
+
+		/**
+		 * Ensure each of the given object-type slugs is registered on the
+		 * shared object store. Resolves the missing UUIDs from settingsStore
+		 * (fetching the config on demand if it hasn't loaded yet) and calls
+		 * registerObjectType for any slug that isn't already in the registry.
+		 *
+		 * Needed because this page is `type: "custom"` in the manifest, so
+		 * the v2 renderer doesn't auto-register types for us, and the
+		 * `initializeStores()` call in main.js is fire-and-forget — it can
+		 * still be in flight when /pipeline is the landing route.
+		 *
+		 * @param {string[]} slugs Object-type slugs to register (e.g. 'pipeline').
+		 */
+		async ensureObjectTypes(slugs) {
+			const registry = this.objectStore.objectTypeRegistry || {}
+			const missing = slugs.filter(s => !registry[s])
+			if (missing.length === 0) return
+
+			let config = this.settingsStore.getConfig
+			if (!config) {
+				config = await this.settingsStore.fetchSettings()
+			}
+			if (!config || !config.register) return
+
+			for (const slug of missing) {
+				const schemaId = config[slug + '_schema']
+				if (schemaId) {
+					this.objectStore.registerObjectType(slug, schemaId, config.register)
+				}
+			}
+		},
 
 		syncSidebarState(pipeline) {
 			if (this.pipelineSidebarState) {


### PR DESCRIPTION
## Summary

Two issues fixed in `src/views/pipeline/PipelineBoard.vue` — same file, so combined into a single PR.

### #530 — Pipeline board never loads (race with `initializeStores`)

`fetchCollection('pipeline', ...)` ran in `mounted()` before `registerObjectType('pipeline', ...)` had completed. The `/pipeline` route is declared `type: \"custom\"` in `manifest.json`, so the v2 renderer's auto-registration (which fires for `type:\"index\"`/`\"detail\"`) doesn't apply. The shared `initializeStores()` call in `main.js` IS fire-and-forget, so when `/pipeline` is the landing route the board races ahead of registration and the object store throws \"type 'pipeline' is not registered\".

**Fix:** added a defensive `ensureObjectTypes(['pipeline', 'lead', 'request'])` helper called at the top of `mounted()`. It inspects `objectTypeRegistry`, lazily fetches the app settings (cached after first call), and calls `registerObjectType` for any missing slug. UUIDs come from the same `pipelinq_settings` config that `store.js::initializeStores` already reads (`config.register`, `config.pipeline_schema`, etc.) — single source of truth, no manifest change needed.

### #531 — NcSelect missing inputLabel warning

Two `<NcSelect>` instances in the header (pipeline picker, type filter) emitted `[NcSelect] An inputLabel or ariaLabelCombobox should be set.` on every mount.

**Fix:** added `:input-label=\"t('pipelinq', 'Select pipeline')\"` and `:input-label=\"t('pipelinq', 'Filter by type')\"`.

## Reproduction

1. Hard-reload `/index.php/apps/pipelinq/pipeline` (so `/pipeline` is the landing route, not navigated to from another page).
2. Before the fix: board stays empty, console shows the \"type not registered\" error from the object store, plus two `[NcSelect] An inputLabel or ariaLabelCombobox should be set.` warnings.
3. After the fix: pipelines fetch on first paint, no warnings.

## Test plan

- [ ] Hard-reload `/pipeline` directly — board populates
- [ ] Navigate Dashboard → Pipeline — board still populates (path that already worked stays working)
- [ ] Browser console is clean of `NcSelect`/`type not registered` messages
- [ ] No other PipelineBoard interaction regressed (pipeline picker, type filter, kanban/list toggle, search)

Closes #530
Closes #531