### PR TITLE
refactor(Dashboard): drop inner CnDashboardPage; render widgets via plain CSS grid

### DIFF
--- a/src/registry.js
+++ b/src/registry.js
@@ -69,7 +69,7 @@ const registry = {
 	DashboardView: {
 		kind: 'page',
 		component: DashboardView,
-		_note: 'Bespoke multi-widget dashboard with gridstack layout; lib gap: no declarative dashboard page type with grid-aware widget placement.',
+		_note: 'Bespoke multi-widget dashboard rendered via a plain CSS grid (no inner CnDashboardPage to avoid double Dashboard heading; see #536). Lib gap: no declarative dashboard page type with grid-aware widget placement — migration to manifest config.widgets[] is the future state.',
 	},
 	MyWorkView: {
 		kind: 'page',

--- a/src/views/Dashboard.vue
+++ b/src/views/Dashboard.vue
@@ -1,44 +1,50 @@
 <template>
-	<div>
-		<CnDashboardPage
-			:title="t('pipelinq', 'Dashboard')"
-			:widgets="widgetDefs"
-			:layout="dashboardLayout"
-			:loading="loading && !hasData"
-			:empty-label="t('pipelinq', 'No widgets configured')"
-			:unavailable-label="t('pipelinq', 'Widget not available')"
-			@layout-change="onLayoutChange">
-			<!-- Header actions: quick action buttons -->
-			<template #header-actions>
-				<NcButton type="primary" @click="showLeadDialog = true">
-					<template #icon>
-						<Plus :size="20" />
-					</template>
-					{{ t('pipelinq', 'New Lead') }}
-				</NcButton>
-				<NcButton @click="showRequestDialog = true">
-					<template #icon>
-						<Plus :size="20" />
-					</template>
-					{{ t('pipelinq', 'New Request') }}
-				</NcButton>
-				<NcButton @click="showClientDialog = true">
-					<template #icon>
-						<Plus :size="20" />
-					</template>
-					{{ t('pipelinq', 'New Client') }}
-				</NcButton>
-				<NcButton :disabled="loading"
-					:aria-label="t('pipelinq', 'Refresh dashboard')"
-					@click="fetchAll">
-					<template #icon>
-						<Refresh :size="20" :class="{ 'icon-spinning': loading }" />
-					</template>
-				</NcButton>
-			</template>
+	<div class="dashboard-root">
+		<!-- Header actions: quick action buttons (no heading — manifest supplies the page title) -->
+		<div class="dashboard-actions">
+			<NcButton type="primary" @click="showLeadDialog = true">
+				<template #icon>
+					<Plus :size="20" />
+				</template>
+				{{ t('pipelinq', 'New Lead') }}
+			</NcButton>
+			<NcButton @click="showRequestDialog = true">
+				<template #icon>
+					<Plus :size="20" />
+				</template>
+				{{ t('pipelinq', 'New Request') }}
+			</NcButton>
+			<NcButton @click="showClientDialog = true">
+				<template #icon>
+					<Plus :size="20" />
+				</template>
+				{{ t('pipelinq', 'New Client') }}
+			</NcButton>
+			<NcButton :disabled="loading"
+				:aria-label="t('pipelinq', 'Refresh dashboard')"
+				@click="fetchAll">
+				<template #icon>
+					<Refresh :size="20" :class="{ 'icon-spinning': loading }" />
+				</template>
+			</NcButton>
+		</div>
 
-			<!-- Open Leads count widget -->
-			<template #widget-count-open-leads>
+		<!-- Loading state -->
+		<NcEmptyContent v-if="loading && !hasData" :title="t('pipelinq', 'Loading dashboard…')">
+			<template #icon>
+				<NcLoadingIcon :size="64" />
+			</template>
+		</NcEmptyContent>
+
+		<!-- Empty welcome state (no data + not loading + no error) -->
+		<div v-else-if="isEmpty" class="welcome-message">
+			<p>{{ t('pipelinq', 'Welcome to Pipelinq! Get started by creating your first client, lead, or request using the buttons above.') }}</p>
+		</div>
+
+		<!-- Widget grid -->
+		<div v-else class="dashboard-grid">
+			<!-- Row 1: 4 KPI tiles -->
+			<section class="dashboard-cell dashboard-cell--kpi">
 				<CnStatsBlock
 					:title="t('pipelinq', 'Open Leads')"
 					:count="kpi.openLeads"
@@ -47,10 +53,9 @@
 					variant="primary"
 					horizontal
 					:route="{ name: 'Leads', query: { status: 'open' } }" />
-			</template>
+			</section>
 
-			<!-- Open Requests count widget -->
-			<template #widget-count-open-requests>
+			<section class="dashboard-cell dashboard-cell--kpi">
 				<CnStatsBlock
 					:title="t('pipelinq', 'Open Requests')"
 					:count="kpi.openRequests"
@@ -59,10 +64,9 @@
 					variant="primary"
 					horizontal
 					:route="{ name: 'Requests', query: { status: 'open' } }" />
-			</template>
+			</section>
 
-			<!-- Pipeline Value count widget -->
-			<template #widget-count-pipeline-value>
+			<section class="dashboard-cell dashboard-cell--kpi">
 				<CnStatsBlock
 					:title="t('pipelinq', 'Pipeline Value')"
 					:count="kpi.pipelineValue"
@@ -71,10 +75,9 @@
 					variant="success"
 					horizontal
 					:route="{ name: 'Pipeline' }" />
-			</template>
+			</section>
 
-			<!-- Overdue count widget -->
-			<template #widget-count-overdue>
+			<section class="dashboard-cell dashboard-cell--kpi">
 				<CnStatsBlock
 					:title="t('pipelinq', 'Overdue')"
 					:count="kpi.overdueItems"
@@ -83,10 +86,13 @@
 					:variant="kpi.overdueItems > 0 ? 'error' : 'default'"
 					horizontal
 					:route="{ name: 'Leads', query: { overdue: 'true' } }" />
-			</template>
+			</section>
 
-			<!-- Deals by Stage widget -->
-			<template #widget-deals-by-stage>
+			<!-- Row 2: Requests by Status (left) + Complaints (right) -->
+			<section class="dashboard-cell dashboard-cell--half">
+				<h3 class="dashboard-cell__title">
+					{{ t('pipelinq', 'Requests by Status') }}
+				</h3>
 				<div class="status-widget-content">
 					<div v-if="allRequests.length === 0" class="chart-empty">
 						{{ t('pipelinq', 'No requests yet') }}
@@ -106,10 +112,22 @@
 						</div>
 					</div>
 				</div>
-			</template>
+			</section>
 
-			<!-- My Work widget -->
-			<template #widget-my-work>
+			<section class="dashboard-cell dashboard-cell--half">
+				<h3 class="dashboard-cell__title">
+					{{ t('pipelinq', 'Complaints') }}
+				</h3>
+				<ComplaintsOverviewWidget
+					:complaints="allComplaints"
+					:loading="loading" />
+			</section>
+
+			<!-- Row 3: My Work (left) + Client Overview (right) -->
+			<section class="dashboard-cell dashboard-cell--half">
+				<h3 class="dashboard-cell__title">
+					{{ t('pipelinq', 'My Work') }}
+				</h3>
 				<div class="my-work-widget-content">
 					<div v-if="myWorkItems.length === 0" class="chart-empty">
 						{{ t('pipelinq', 'No items assigned to you') }}
@@ -139,10 +157,12 @@
 						</NcButton>
 					</div>
 				</div>
-			</template>
+			</section>
 
-			<!-- Client Overview widget -->
-			<template #widget-client-overview>
+			<section class="dashboard-cell dashboard-cell--half">
+				<h3 class="dashboard-cell__title">
+					{{ t('pipelinq', 'Client Overview') }}
+				</h3>
 				<div class="client-overview-content">
 					<div v-if="allClients.length === 0" class="chart-empty">
 						{{ t('pipelinq', 'No clients yet') }}
@@ -165,22 +185,8 @@
 						</NcButton>
 					</div>
 				</div>
-			</template>
-
-			<!-- Complaints Overview widget -->
-			<template #widget-complaints-overview>
-				<ComplaintsOverviewWidget
-					:complaints="allComplaints"
-					:loading="loading" />
-			</template>
-
-			<!-- Empty state override with welcome message -->
-			<template #empty>
-				<div v-if="isEmpty" class="welcome-message">
-					<p>{{ t('pipelinq', 'Welcome to Pipelinq! Get started by creating your first client, lead, or request using the buttons above.') }}</p>
-				</div>
-			</template>
-		</CnDashboardPage>
+			</section>
+		</div>
 
 		<!-- Error display -->
 		<div v-if="error" class="dashboard-error">
@@ -209,8 +215,8 @@
 </template>
 
 <script>
-import { NcButton } from '@nextcloud/vue'
-import { CnDashboardPage, CnStatsBlock } from '@conduction/nextcloud-vue'
+import { NcButton, NcEmptyContent, NcLoadingIcon } from '@nextcloud/vue'
+import { CnStatsBlock } from '@conduction/nextcloud-vue'
 import Plus from 'vue-material-design-icons/Plus.vue'
 import Refresh from 'vue-material-design-icons/Refresh.vue'
 import TrendingUp from 'vue-material-design-icons/TrendingUp.vue'
@@ -230,27 +236,12 @@ import { formatCurrency, formatDate } from '../services/localeUtils.js'
 
 const PRIORITY_ORDER = { urgent: 0, high: 1, normal: 2, low: 3 }
 
-/**
- * Default dashboard layout — 4 count tiles across the top row (3 cols each),
- * then deals-by-stage and my-work share the second row,
- * client-overview spans full width on third row.
- */
-const DEFAULT_LAYOUT = [
-	{ id: 1, widgetId: 'count-open-leads', gridX: 0, gridY: 0, gridWidth: 3, gridHeight: 2, showTitle: false },
-	{ id: 2, widgetId: 'count-open-requests', gridX: 3, gridY: 0, gridWidth: 3, gridHeight: 2, showTitle: false },
-	{ id: 3, widgetId: 'count-pipeline-value', gridX: 6, gridY: 0, gridWidth: 3, gridHeight: 2, showTitle: false },
-	{ id: 4, widgetId: 'count-overdue', gridX: 9, gridY: 0, gridWidth: 3, gridHeight: 2, showTitle: false },
-	{ id: 5, widgetId: 'deals-by-stage', gridX: 0, gridY: 2, gridWidth: 6, gridHeight: 4 },
-	{ id: 6, widgetId: 'complaints-overview', gridX: 6, gridY: 2, gridWidth: 6, gridHeight: 4 },
-	{ id: 7, widgetId: 'my-work', gridX: 0, gridY: 6, gridWidth: 6, gridHeight: 4 },
-	{ id: 8, widgetId: 'client-overview', gridX: 6, gridY: 6, gridWidth: 6, gridHeight: 3 },
-]
-
 export default {
 	name: 'Dashboard',
 	components: {
 		NcButton,
-		CnDashboardPage,
+		NcEmptyContent,
+		NcLoadingIcon,
 		CnStatsBlock,
 		Plus,
 		Refresh,
@@ -279,7 +270,6 @@ export default {
 			allClients: [],
 			myLeads: [],
 			myRequests: [],
-			dashboardLayout: [...DEFAULT_LAYOUT],
 		}
 	},
 	computed: {
@@ -293,19 +283,6 @@ export default {
 			return this.allLeads.length > 0
 				|| this.allRequests.length > 0
 				|| this.allClients.length > 0
-		},
-
-		widgetDefs() {
-			return [
-				{ id: 'count-open-leads', title: t('pipelinq', 'Open Leads'), type: 'custom' },
-				{ id: 'count-open-requests', title: t('pipelinq', 'Open Requests'), type: 'custom' },
-				{ id: 'count-pipeline-value', title: t('pipelinq', 'Pipeline Value'), type: 'custom' },
-				{ id: 'count-overdue', title: t('pipelinq', 'Overdue'), type: 'custom' },
-				{ id: 'deals-by-stage', title: t('pipelinq', 'Requests by Status'), type: 'custom' },
-				{ id: 'complaints-overview', title: t('pipelinq', 'Complaints'), type: 'custom' },
-				{ id: 'my-work', title: t('pipelinq', 'My Work'), type: 'custom' },
-				{ id: 'client-overview', title: t('pipelinq', 'Client Overview'), type: 'custom' },
-			]
 		},
 
 		// --- KPI computations ---
@@ -541,10 +518,6 @@ export default {
 			return data.results || data || []
 		},
 
-		onLayoutChange(newLayout) {
-			this.dashboardLayout = newLayout
-		},
-
 		formatCurrency(value) {
 			return formatCurrency(value)
 		},
@@ -580,9 +553,81 @@ export default {
 </script>
 
 <style scoped>
+.dashboard-root {
+	padding: 16px 20px 24px;
+	display: flex;
+	flex-direction: column;
+	gap: 16px;
+}
+
+.dashboard-actions {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 8px;
+	align-items: center;
+}
+
+/* Plain CSS-grid replacement for CnDashboardPage's gridstack layout.
+ * 4 KPI tiles on row 1; three rows of two half-width widgets below.
+ * Collapses gracefully on narrow viewports.
+ */
+.dashboard-grid {
+	display: grid;
+	grid-template-columns: repeat(4, 1fr);
+	gap: 16px;
+}
+
+.dashboard-cell {
+	background: var(--color-main-background);
+	border: 1px solid var(--color-border);
+	border-radius: var(--border-radius-large, 8px);
+	padding: 12px;
+	min-height: 0;
+	display: flex;
+	flex-direction: column;
+}
+
+.dashboard-cell--kpi {
+	grid-column: span 1;
+	padding: 0;
+	border: none;
+	background: transparent;
+}
+
+.dashboard-cell--half {
+	grid-column: span 2;
+	min-height: 280px;
+}
+
+.dashboard-cell__title {
+	margin: 0 0 12px;
+	font-size: 14px;
+	font-weight: 600;
+	color: var(--color-text-maxcontrast);
+}
+
+@media (max-width: 1100px) {
+	.dashboard-grid {
+		grid-template-columns: repeat(2, 1fr);
+	}
+	.dashboard-cell--kpi,
+	.dashboard-cell--half {
+		grid-column: span 2;
+	}
+}
+
+@media (max-width: 600px) {
+	.dashboard-grid {
+		grid-template-columns: 1fr;
+	}
+	.dashboard-cell--kpi,
+	.dashboard-cell--half {
+		grid-column: span 1;
+	}
+}
+
 /* Status chart widget */
 .status-widget-content {
-	padding: 12px;
 	height: 100%;
 }
 
@@ -637,7 +682,6 @@ export default {
 
 /* My Work widget */
 .my-work-widget-content {
-	padding: 4px 0;
 	height: 100%;
 	overflow: auto;
 }
@@ -719,7 +763,6 @@ export default {
 
 /* Client overview widget */
 .client-overview-content {
-	padding: 4px 0;
 	height: 100%;
 	overflow: auto;
 }


### PR DESCRIPTION
## Summary

- Replaces the `<CnDashboardPage>` template root in `src/views/Dashboard.vue` with a plain `<div class="dashboard-grid">` CSS-grid container so the main `/` route stops emitting a second nested "Dashboard" heading (the manifest's CustomShell already provides the page title).
- Eight widgets stay; their slot definitions become eight grid items (4 KPI tiles row-1, 2x2 list widgets rows 2-3) on a responsive grid (4 cols / 2 cols < 1100px / 1 col < 600px).
- Drops `widgetDefs`, `dashboardLayout`, `DEFAULT_LAYOUT`, and `onLayoutChange`. Gridstack reordering was only in-memory (never persisted), so no user-visible regression.
- Picks **Option B** from #536 (the lib gap mentioned in `registry.js` is real — manifest still has no grid-aware widget placement, so full Option A migration is out of scope for this PR).
- Adds an `NcEmptyContent` + `NcLoadingIcon` initial-load placeholder that previously came from `CnDashboardPage :loading`.
- Updates the `DashboardView` `_note` in `src/registry.js` to reflect the new shape and reaffirm the future-state Option A migration.

Last visible source of dashboard-heading nesting; with #535 already merged the live env will now show exactly one Dashboard h2 (#536 acceptance criterion), and KPI cards stop truncating (#523 side-effect).

## Test plan

- [ ] `npm run lint` clean for the touched files (verified: 0 errors, no new warnings; pre-existing `OC.currentUser` deprecation on the unchanged `currentUser` getter line)
- [ ] Visit `/apps/pipelinq/` — a11y tree shows exactly one "Dashboard" h2 (the manifest's)
- [ ] All four KPI tiles render with their counts and link to filtered list routes
- [ ] Requests-by-Status bar chart, Complaints widget, My Work list, and Client Overview list all render and remain clickable
- [ ] Grid collapses 4→2→1 columns at the documented breakpoints
- [ ] Refresh / New Lead / New Request / New Client buttons in the actions row still work
- [ ] Loading state shows the spinner; empty state shows the welcome message; error state shows the retry button

Closes #536
Related: #523, #535