### PR TITLE
feat(features-roadmap): wire Features tab via IInitialState from docs/features.json

### DIFF
--- a/docs/features.json
+++ b/docs/features.json
@@ -1,0 +1,110 @@
+[
+  {
+    "slug": "activity-timeline",
+    "title": "activity-timeline",
+    "summary": "Provide a chronological activity feed per contact, organization, and pipeline item in Pipelinq. All interactions -- status changes, notes, emails, calls, document uploads, field changes, and linked case events -- appear in one unified timeline. This gives the complete \"klantbeeld\" (customer view) that relationship managers need to understand the full history of any entity at a glance.",
+    "docsUrl": "openspec/specs/activity-timeline/spec.md"
+  },
+  {
+    "slug": "admin-settings",
+    "title": "Admin Settings",
+    "summary": "The admin settings page provides a Nextcloud admin panel for configuring Pipelinq. Administrators can manage pipelines and their stages, set a default pipeline, and configure lead source and request channel values. Only Nextcloud admin users can access this page. The design follows the wireframe in DESIGN-REFERENCES.md section 3.7.",
+    "docsUrl": "openspec/specs/admin-settings/spec.md"
+  },
+  {
+    "slug": "client-management",
+    "title": "Client Management",
+    "summary": "Client management is the core capability of Pipelinq. A client represents a person or organization that the team has a relationship with. Contact persons are individuals linked to organization clients, qualified by role. This specification covers client and contact person CRUD, list views with search/sort/filter, the client detail view (info panel, summary stats, contact persons, leads, requests, activity timeline), validation rules, Nextcloud Contacts sync, and future capabilities such as duplicate detection and import/export.",
+    "docsUrl": "openspec/specs/client-management/spec.md"
+  },
+  {
+    "slug": "contacts-sync",
+    "title": "Contacts Sync",
+    "summary": "Sync Pipelinq clients and contacts with Nextcloud Contacts via IManager to eliminate duplicate data entry and keep address books current.",
+    "docsUrl": "openspec/specs/contacts-sync/spec.md"
+  },
+  {
+    "slug": "dashboard",
+    "title": "Dashboard",
+    "summary": "The Pipelinq CRM dashboard provides an at-a-glance overview of key performance indicators, pipeline health, assigned work, and client activity. It uses the `CnDashboardPage` component from `@conduction/nextcloud-vue` for a configurable grid layout and integrates with the Nextcloud Dashboard Widget API (`OCP\\Dashboard\\IWidget`) for platform-level widget exposure.",
+    "docsUrl": "openspec/specs/dashboard/spec.md"
+  },
+  {
+    "slug": "entity-notes",
+    "title": "Entity Notes",
+    "summary": "Add internal notes/comments to all Pipelinq entities (clients, contacts, leads, requests) using Nextcloud's ICommentsManager, enabling team collaboration and context tracking. Notes serve as the primary collaboration mechanism for CRM users, supporting categorized note types, rich text, @mentions, attachments, and privacy controls to match the workflows of government KCC and commercial sales teams.",
+    "docsUrl": "openspec/specs/entity-notes/spec.md"
+  },
+  {
+    "slug": "lead-management",
+    "title": "Lead Management",
+    "summary": "Lead management handles sales opportunities -- from first contact through to won or lost. A lead is a unified entity (no separate Opportunity split) that flows through configurable pipeline stages. Pipeline stages encode qualification level, making a separate conversion step unnecessary.",
+    "docsUrl": "openspec/specs/lead-management/spec.md"
+  },
+  {
+    "slug": "lead-product-link",
+    "title": "Lead-Product Link",
+    "summary": "The lead-product link enables sales reps to attach specific products (with quantities and pricing) to leads, replacing or supplementing manual value entry. This creates an accurate, auditable breakdown of what a lead is worth based on actual product line items. It follows the standard CRM pattern where Products are the master catalog and Line Items are deal-specific instances.",
+    "docsUrl": "openspec/specs/lead-product-link/spec.md"
+  },
+  {
+    "slug": "my-work",
+    "title": "My Work (Werkvoorraad)",
+    "summary": "My Work provides a personal workload view aggregating all items assigned to the current user -- leads, requests, and optionally tasks from Procest. This is the user's daily productivity hub, showing what needs immediate attention, what is due soon, and what is upcoming. Items are organized into temporal groups (Overdue, Due This Week, Upcoming, No Due Date) and sorted by priority within each group.",
+    "docsUrl": "openspec/specs/my-work/spec.md"
+  },
+  {
+    "slug": "notifications-activity",
+    "title": "Notifications & Activity Stream",
+    "summary": "Deliver real-time notifications and a team-visible activity timeline for CRM events so users stay informed about leads, requests, and collaboration actions. This spec covers the notification dispatch logic, activity stream integration, per-category user preferences, notification rendering, and CRM-specific event types including SLA breach warnings, deal won celebrations, and quote lifecycle events.",
+    "docsUrl": "openspec/specs/notifications-activity/spec.md"
+  },
+  {
+    "slug": "openregister-integration",
+    "title": "OpenRegister Integration",
+    "summary": "Pipelinq stores all data as OpenRegister objects -- it owns no database tables. This specification defines how the register and schemas are initialized, how the frontend and backend interact with the OpenRegister API for CRUD operations, how Pinia stores manage state, how schema validation works, how errors are handled, and how cross-entity references, audit trails, RBAC, pagination, and performance concerns are addressed. OpenRegister is the foundational layer for every Pipelinq feature.",
+    "docsUrl": "openspec/specs/openregister-integration/spec.md"
+  },
+  {
+    "slug": "pipeline",
+    "title": "Pipeline & Kanban",
+    "summary": "Pipelines provide configurable kanban-style boards where leads and requests flow through ordered stages. A pipeline is comparable to Trello boards or Nextcloud Deck -- each pipeline has columns (stages) and cards (leads/requests). Both entity types can appear on the same pipeline, distinguished by visual badges. Pipelines are the primary visual workflow tool in Pipelinq.",
+    "docsUrl": "openspec/specs/pipeline/spec.md"
+  },
+  {
+    "slug": "product-catalog",
+    "title": "Product Catalog",
+    "summary": "The product catalog allows Pipelinq users to manage the products and services their organization sells. Products are central to accurate pipeline valuation — instead of manually estimating lead values, sales reps attach specific products (with quantities and prices) to leads. Product categories provide hierarchical grouping for organization and reporting.",
+    "docsUrl": "openspec/specs/product-catalog/spec.md"
+  },
+  {
+    "slug": "product-service-catalog",
+    "title": "Product & Service Catalog (PDC)",
+    "summary": "Implement a government product and service catalog (PDC - Producten- en Dienstencatalogus) as a core Pipelinq capability for CRM-driven citizen service delivery, conforming to the Uniforme Productnamenlijst (UPL) and Single Digital Gateway (SDG) standards. The PDC integrates with Pipelinq's existing product entities and CRM workflows, enabling KCC (Klant Contact Centrum) agents to look up products during citizen interactions, link products to contact moments, and initiate service requests. Products MUST support structured content blocks, publication lifecycle, target audience classification, pricing, multilingual content for cross-border EU access, zaaktype linking, versioning, bundling, and analytics. The catalog MUST expose a public read-only API for integration with municipal websites, citizen portals, and the SDG Your Europe portal.",
+    "docsUrl": "openspec/specs/product-service-catalog/spec.md"
+  },
+  {
+    "slug": "prometheus-metrics",
+    "title": "Prometheus Metrics Endpoint",
+    "summary": "Expose application metrics in Prometheus text exposition format at `GET /api/metrics` for monitoring, alerting, and operational dashboards. Provide a complementary health check endpoint for container orchestration. Enable CRM-specific observability covering pipeline value, client counts, conversion rates, and OpenRegister integration health.",
+    "docsUrl": "openspec/specs/prometheus-metrics/spec.md"
+  },
+  {
+    "slug": "prospect-discovery",
+    "title": "Prospect Discovery",
+    "summary": "The prospect discovery capability enables sales teams to find new potential clients by searching public company registries (KVK Handelsregister, OpenCorporates) against a configurable Ideal Customer Profile (ICP). Results are displayed in a dashboard widget, scored by fit, with existing clients excluded. This transforms prospecting from a manual external research task into an integrated, data-driven workflow within the CRM.",
+    "docsUrl": "openspec/specs/prospect-discovery/spec.md"
+  },
+  {
+    "slug": "register-i18n",
+    "title": "Register Content Internationalization",
+    "summary": "Enable multi-language support for Pipelinq's register objects, allowing users to view and manage CRM and pipeline content in their preferred language. Built on OpenRegister's register-i18n foundation (see `openregister/openspec/specs/register-i18n/spec.md`). This spec covers both data-level i18n for translatable register content (pipeline names, product descriptions) and app UI string translations via Nextcloud's `IL10N` / `t()` system per ADR-005.",
+    "docsUrl": "openspec/specs/register-i18n/spec.md"
+  },
+  {
+    "slug": "request-management",
+    "title": "Request Management",
+    "summary": "Request management handles the intake and tracking of requests (verzoeken) — service inquiries that come in before they become formal cases. Requests are the bridge between Pipelinq (CRM) and Procest (case management). A request flows through a status lifecycle from intake to resolution or conversion, can optionally be placed on a pipeline alongside leads, and can be converted into a Procest case.",
+    "docsUrl": "openspec/specs/request-management/spec.md"
+  }
+]

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -37,6 +37,7 @@ use OCP\AppFramework\App;
 use OCP\AppFramework\Bootstrap\IBootContext;
 use OCP\AppFramework\Bootstrap\IBootstrap;
 use OCP\AppFramework\Bootstrap\IRegistrationContext;
+use OCP\AppFramework\Services\IInitialState;
 use OCP\Comments\ICommentsManager;
 
 /**
@@ -109,6 +110,27 @@ class Application extends App implements IBootstrap
     public function boot(IBootContext $context): void
     {
         $server = $context->getServerContainer();
+
+        // Hand the Features & Roadmap surface its build-time feature list.
+        // docs/features.json is regenerated from openspec/specs/ by the
+        // org-wide Features Extract workflow stage (.github/workflows/quality.yml).
+        // Pull IInitialState from the per-app container so the serialized key
+        // is correctly namespaced as `initial-state-pipelinq-<key>`.
+        try {
+            $initialState  = $this->getContainer()->get(IInitialState::class);
+            $featuresPath  = __DIR__.'/../../docs/features.json';
+            $features      = [];
+            if (is_file($featuresPath) === true) {
+                $decoded = json_decode((string) file_get_contents($featuresPath), associative: true);
+                if (is_array($decoded) === true) {
+                    $features = $decoded;
+                }
+            }
+
+            $initialState->provideInitialState('features_roadmap_features', $features);
+        } catch (\Exception $e) {
+            // Initial state unavailable — Features tab will fall back to []
+        }
 
         try {
             $commentsManager = $server->get(ICommentsManager::class);


### PR DESCRIPTION
## Summary
- Wire the in-product Features & Roadmap surface to render real capabilities — closes the long-standing "No features documented yet" empty state.
- Add `lib/AppInfo/Application.php` boot wiring that reads `docs/features.json` and calls `IInitialState::provideInitialState('features_roadmap_features', …)` from the per-app container (correct appId namespacing).
- Commit the initial `docs/features.json` (18 capabilities). It will be auto-regenerated from `openspec/specs/` going forward by the Features Extract stage added in [ConductionNL/.github#94](https://github.com/ConductionNL/.github/commit/b7681b1).

## Why the IInitialState bit was non-obvious
`IInitialState` resolved from the server container produces an instance without an appId binding, so the emitted HTML key is generic, not `initial-state-pipelinq-…`. Resolving via `$this->getContainer()->get(IInitialState::class)` gives the per-app variant. Same shape as softwarecatalog's working pattern.

## Test plan
- [x] Hard-refresh http://localhost:8080/apps/pipelinq/features-roadmap → Features tab renders 18 cards
- [x] Curl: `grep -oE 'initial-state-pipelinq-features_roadmap_features"' on the page returns 1 match
- [x] Decoded value contains the 18 capabilities from openspec/specs/