### PR TITLE
chore(openspec): normalize REQ headings to canonical Form A (ADR-037)

### DIFF
--- a/openspec/specs/admin-settings/spec.md
+++ b/openspec/specs/admin-settings/spec.md
@@ -14,7 +14,7 @@ The admin settings page provides a Nextcloud admin panel for configuring Pipelin
 
 ## Requirements
 
-### REQ-AS-010: Nextcloud Admin Panel Registration [MVP]
+### Requirement: Nextcloud Admin Panel Registration [MVP]
 
 The system MUST register a settings page in the Nextcloud admin panel under "Administration". Only users with Nextcloud admin privileges MUST be able to access this page.
 
@@ -43,7 +43,7 @@ The system MUST register a settings page in the Nextcloud admin panel under "Adm
 
 ---
 
-### REQ-AS-012: Register Status Display [MVP]
+### Requirement: Register Status Display [MVP]
 
 The admin settings page MUST display the current register configuration status so administrators can verify the OpenRegister integration is working.
 
@@ -67,7 +67,7 @@ The admin settings page MUST display the current register configuration status s
 
 ---
 
-### REQ-AS-015: Re-import Configuration Action [MVP]
+### Requirement: Re-import Configuration Action [MVP]
 
 The admin settings page MUST provide a button to re-run the register configuration import, allowing administrators to recover from failed imports or apply updated schemas.
 
@@ -88,7 +88,7 @@ The admin settings page MUST provide a button to re-run the register configurati
 
 ---
 
-### REQ-AS-020: Pipeline Management [MVP]
+### Requirement: Pipeline Management [MVP]
 
 The admin settings MUST provide full CRUD operations for pipelines. Pipelines are stored as OpenRegister objects with schema `pipeline`.
 
@@ -139,7 +139,7 @@ The admin settings MUST provide full CRUD operations for pipelines. Pipelines ar
 
 ---
 
-### REQ-AS-030: Stage Management [MVP]
+### Requirement: Stage Management [MVP]
 
 The admin settings MUST provide CRUD operations for stages within each pipeline. Stages are stored as OpenRegister objects with schema `stage`.
 
@@ -207,7 +207,7 @@ The admin settings MUST provide CRUD operations for stages within each pipeline.
 
 ---
 
-### REQ-AS-040: Default Pipeline Selection [MVP]
+### Requirement: Default Pipeline Selection [MVP]
 
 The admin settings MUST allow selecting one pipeline as the default. The default pipeline is used when creating new leads or requests that are not explicitly assigned to a pipeline.
 
@@ -242,7 +242,7 @@ The admin settings MUST allow selecting one pipeline as the default. The default
 
 ---
 
-### REQ-AS-050: Lead Source Configuration [V1]
+### Requirement: Lead Source Configuration [V1]
 
 The admin settings SHOULD allow customizing the list of available lead source values. Lead sources are displayed as a dropdown when creating or editing leads.
 
@@ -289,7 +289,7 @@ The admin settings SHOULD allow customizing the list of available lead source va
 
 ---
 
-### REQ-AS-060: Request Channel Configuration [V1]
+### Requirement: Request Channel Configuration [V1]
 
 The admin settings SHOULD allow customizing the list of available request channel values. Channels are displayed as a dropdown when creating or editing requests.
 
@@ -329,7 +329,7 @@ The admin settings SHOULD allow customizing the list of available request channe
 
 ---
 
-### REQ-AS-070: Default Pipelines on Installation [MVP]
+### Requirement: Default Pipelines on Installation [MVP]
 
 When Pipelinq is installed for the first time, the system MUST create default pipelines and stages via the repair step / configuration import.
 
@@ -370,7 +370,7 @@ When Pipelinq is installed for the first time, the system MUST create default pi
 
 ---
 
-### REQ-AS-080: Settings Persistence [MVP]
+### Requirement: Settings Persistence [MVP]
 
 All admin settings MUST be persisted and survive app updates and server restarts.
 
@@ -392,7 +392,7 @@ All admin settings MUST be persisted and survive app updates and server restarts
 
 ---
 
-### REQ-AS-090: Queue Management Section [Enterprise]
+### Requirement: Queue Management Section [Enterprise]
 
 The admin settings page SHALL include a "Queues" section for managing queues. Admins can create, edit, and delete queues, configure categories, set capacity limits, and assign agents to queues.
 
@@ -423,7 +423,7 @@ The admin settings page SHALL include a "Queues" section for managing queues. Ad
 
 ---
 
-### REQ-AS-100: Skill Management Section [Enterprise]
+### Requirement: Skill Management Section [Enterprise]
 
 The admin settings page SHALL include a "Skills" section for managing skill definitions and agent skill profiles.
 
@@ -550,7 +550,7 @@ The admin settings page provides a Nextcloud admin panel for configuring Pipelin
 
 ## Requirements
 
-### REQ-AS-010: Nextcloud Admin Panel Registration [MVP]
+### Requirement: Nextcloud Admin Panel Registration [MVP]
 
 The system MUST register a settings page in the Nextcloud admin panel under "Administration". Only users with Nextcloud admin privileges MUST be able to access this page. The implementation uses `OCP\Settings\ISettings` (`AdminSettings.php`) and `OCP\Settings\IIconSection` (`SettingsSection.php`) to register the "Pipelinq" section with priority 10.
 

--- a/openspec/specs/klachtenregistratie/spec.md
+++ b/openspec/specs/klachtenregistratie/spec.md
@@ -12,7 +12,7 @@ Add complaint registration and tracking to Pipelinq, enabling KCC agents and CRM
 
 ## Requirements
 
-### REQ-KL-001: Complaint Schema in Register
+### Requirement: Complaint Schema in Register
 
 The system MUST define a `complaint` schema in the Pipelinq register configuration with all required fields for complaint registration.
 
@@ -43,7 +43,7 @@ The system MUST define a `complaint` schema in the Pipelinq register configurati
 
 ---
 
-### REQ-KL-002: Complaint Registration Form
+### Requirement: Complaint Registration Form
 
 The system MUST provide a complaint form for creating and editing complaints with validation.
 
@@ -77,7 +77,7 @@ The system MUST provide a complaint form for creating and editing complaints wit
 
 ---
 
-### REQ-KL-003: Complaint List View
+### Requirement: Complaint List View
 
 The complaint list MUST support search, filtering by status/category/priority, sorting, and pagination.
 
@@ -129,7 +129,7 @@ The complaint list MUST support search, filtering by status/category/priority, s
 
 ---
 
-### REQ-KL-004: Complaint Detail View
+### Requirement: Complaint Detail View
 
 The complaint detail view MUST show all complaint information, linked entities, status timeline, and resolution fields.
 
@@ -171,7 +171,7 @@ The complaint detail view MUST show all complaint information, linked entities, 
 
 ---
 
-### REQ-KL-005: Complaint Audit Trail
+### Requirement: Complaint Audit Trail
 
 The system MUST maintain a full audit trail of all complaint status changes visible on the complaint detail.
 
@@ -194,7 +194,7 @@ The system MUST maintain a full audit trail of all complaint status changes visi
 
 ---
 
-### REQ-KL-006: Complaint Dashboard Widget
+### Requirement: Complaint Dashboard Widget
 
 The dashboard MUST include a complaints widget showing key metrics.
 
@@ -210,7 +210,7 @@ The dashboard MUST include a complaints widget showing key metrics.
 
 ---
 
-### REQ-KL-007: Complaints on Client Detail
+### Requirement: Complaints on Client Detail
 
 Complaints linked to a client MUST be visible on the client detail view.
 
@@ -225,7 +225,7 @@ Complaints linked to a client MUST be visible on the client detail view.
 
 ---
 
-### REQ-KL-008: SLA Configuration
+### Requirement: SLA Configuration
 
 The admin settings MUST allow configuring SLA response times per complaint category.
 
@@ -243,7 +243,7 @@ The admin settings MUST allow configuring SLA response times per complaint categ
 
 ---
 
-### REQ-KL-009: Backend SLA Deadline Service
+### Requirement: Backend SLA Deadline Service
 
 A PHP service MUST calculate SLA deadlines and provide SLA configuration helpers for backend use.
 
@@ -268,7 +268,7 @@ A PHP service MUST calculate SLA deadlines and provide SLA configuration helpers
 
 ---
 
-### REQ-KL-010: Background Job for SLA Monitoring
+### Requirement: Background Job for SLA Monitoring
 
 A timed background job MUST periodically check for overdue complaints and log warnings.
 

--- a/openspec/specs/lead-management/spec.md
+++ b/openspec/specs/lead-management/spec.md
@@ -41,7 +41,7 @@ See [ARCHITECTURE.md](../../../docs/ARCHITECTURE.md) for the full Lead entity de
 
 ## Requirements
 
-### REQ-LEAD-001: Lead CRUD [MVP]
+### Requirement: Lead CRUD [MVP]
 
 The system MUST support creating, reading, updating, and deleting lead records. Each lead MUST have a `title`. All leads are stored as OpenRegister objects in the `pipelinq` register using the `lead` schema.
 
@@ -103,7 +103,7 @@ The system MUST support creating, reading, updating, and deleting lead records. 
 
 ---
 
-### REQ-LEAD-002: Lead Validation [MVP]
+### Requirement: Lead Validation [MVP]
 
 The system MUST enforce validation rules on lead properties to maintain data integrity.
 
@@ -144,7 +144,7 @@ The system MUST enforce validation rules on lead properties to maintain data int
 
 ---
 
-### REQ-LEAD-003: Lead List View [MVP]
+### Requirement: Lead List View [MVP]
 
 The system MUST provide a list view of all leads with search, sort, and filter capabilities. The list view is the primary navigation for leads and MUST support efficient browsing of large datasets.
 
@@ -213,7 +213,7 @@ The system MUST provide a list view of all leads with search, sort, and filter c
 
 ---
 
-### REQ-LEAD-004: Lead Detail View [MVP]
+### Requirement: Lead Detail View [MVP]
 
 The system MUST provide a detail view for each lead that displays all properties, pipeline progress, linked entities, and activity timeline. The layout MUST follow the wireframe in DESIGN-REFERENCES.md Section 3.4.
 
@@ -269,7 +269,7 @@ The system MUST provide a detail view for each lead that displays all properties
 
 ---
 
-### REQ-LEAD-005: Lead Source Tracking [MVP]
+### Requirement: Lead Source Tracking [MVP]
 
 The system MUST support tracking where leads originate from. Source values are managed via the lead sources admin settings (TagManager-based CRUD at `/api/settings/lead-sources`).
 
@@ -299,7 +299,7 @@ The system MUST support tracking where leads originate from. Source values are m
 
 ---
 
-### REQ-LEAD-006: Lead Assignment [MVP]
+### Requirement: Lead Assignment [MVP]
 
 The system MUST support assigning leads to Nextcloud users. Assignment determines which user is responsible for the lead and controls visibility in the My Work view.
 
@@ -338,7 +338,7 @@ The system MUST support assigning leads to Nextcloud users. Assignment determine
 
 ---
 
-### REQ-LEAD-007: Lead Lifecycle via Pipeline Stages [MVP]
+### Requirement: Lead Lifecycle via Pipeline Stages [MVP]
 
 A lead's lifecycle from creation to won/lost MUST be driven by pipeline stages. Moving a lead to a closed stage (isClosed: true) represents the end of the sales process for that lead.
 
@@ -379,7 +379,7 @@ A lead's lifecycle from creation to won/lost MUST be driven by pipeline stages. 
 
 ---
 
-### REQ-LEAD-008: Lead Value and Probability [MVP]
+### Requirement: Lead Value and Probability [MVP]
 
 The system MUST support tracking the monetary value and win probability of leads for pipeline valuation and sales forecasting.
 
@@ -406,7 +406,7 @@ The system MUST support tracking the monetary value and win probability of leads
 
 ---
 
-### REQ-LEAD-009: Lead Expected Close Date [MVP]
+### Requirement: Lead Expected Close Date [MVP]
 
 The system MUST support an expected close date to track when a lead is anticipated to close.
 
@@ -428,7 +428,7 @@ The system MUST support an expected close date to track when a lead is anticipat
 
 ---
 
-### REQ-LEAD-010: Lead Priority [MVP]
+### Requirement: Lead Priority [MVP]
 
 The system MUST support four priority levels to enable triage and sorting of leads.
 
@@ -455,7 +455,7 @@ The system MUST support four priority levels to enable triage and sorting of lea
 
 ---
 
-### REQ-LEAD-011: Quick Actions on Lead Cards [MVP]
+### Requirement: Quick Actions on Lead Cards [MVP]
 
 The system MUST support quick actions on lead cards (in kanban and list views) to enable common operations without opening the detail view. This follows the pattern described in DESIGN-REFERENCES.md Section 3.2 and is a standard CRM pattern (HubSpot, Salesforce).
 
@@ -485,7 +485,7 @@ The system MUST support quick actions on lead cards (in kanban and list views) t
 
 ---
 
-### REQ-LEAD-012: Stale Lead Detection [V1]
+### Requirement: Stale Lead Detection [V1]
 
 The system MUST detect leads with no activity for a configurable number of days and highlight them to prevent forgotten opportunities.
 
@@ -507,7 +507,7 @@ The system MUST detect leads with no activity for a configurable number of days 
 
 ---
 
-### REQ-LEAD-013: Aging Indicator [V1]
+### Requirement: Aging Indicator [V1]
 
 The system MUST display how long a lead has been in its current stage to help identify bottlenecks.
 
@@ -527,7 +527,7 @@ The system MUST display how long a lead has been in its current stage to help id
 
 ---
 
-### REQ-LEAD-014: Lead Import/Export CSV [V1]
+### Requirement: Lead Import/Export CSV [V1]
 
 The system MUST support importing leads from CSV and exporting leads to CSV for migration and reporting.
 
@@ -557,7 +557,7 @@ The system MUST support importing leads from CSV and exporting leads to CSV for 
 
 ---
 
-### REQ-LEAD-015: Error Scenarios [MVP]
+### Requirement: Error Scenarios [MVP]
 
 The system MUST handle error conditions gracefully and provide meaningful feedback to users.
 

--- a/openspec/specs/my-work/spec.md
+++ b/openspec/specs/my-work/spec.md
@@ -16,7 +16,7 @@ The design follows the wireframe in DESIGN-REFERENCES.md section 3.5.
 
 ## Requirements
 
-### REQ-MW-010: Personal Workload View [MVP]
+### Requirement: Personal Workload View [MVP]
 
 The system MUST provide a "My Work" view showing all leads and requests assigned to the current user. Only open items are shown by default, with a toggle to include completed items.
 
@@ -46,7 +46,7 @@ The system MUST provide a "My Work" view showing all leads and requests assigned
 
 ---
 
-### REQ-MW-020: Sorting [MVP]
+### Requirement: Sorting [MVP]
 
 Within each temporal group, items MUST be sorted by priority first, then by due date ascending.
 
@@ -60,7 +60,7 @@ Within each temporal group, items MUST be sorted by priority first, then by due 
 
 ---
 
-### REQ-MW-030: Temporal Grouping [MVP]
+### Requirement: Temporal Grouping [MVP]
 
 Items MUST be organized into four temporal groups displayed top to bottom: Overdue, Due This Week, Upcoming, No Due Date. Empty groups MUST be hidden.
 
@@ -90,7 +90,7 @@ Items MUST be organized into four temporal groups displayed top to bottom: Overd
 
 ---
 
-### REQ-MW-040: Filtering [MVP]
+### Requirement: Filtering [MVP]
 
 The system MUST allow filtering by entity type: All (default), Leads, Requests.
 
@@ -106,7 +106,7 @@ The system MUST allow filtering by entity type: All (default), Leads, Requests.
 
 ---
 
-### REQ-MW-050: Overdue Item Highlighting [MVP]
+### Requirement: Overdue Item Highlighting [MVP]
 
 Overdue items MUST be visually distinct with red indicators and "N days overdue" text.
 
@@ -121,7 +121,7 @@ Overdue items MUST be visually distinct with red indicators and "N days overdue"
 
 ---
 
-### REQ-MW-060: Item Navigation [MVP]
+### Requirement: Item Navigation [MVP]
 
 Each item MUST be clickable, navigating to the full detail view.
 
@@ -131,7 +131,7 @@ Each item MUST be clickable, navigating to the full detail view.
 
 ---
 
-### REQ-MW-070: Cross-App Workload [V1]
+### Requirement: Cross-App Workload [V1]
 
 The system SHOULD include items from Procest (cases and tasks assigned to the current user) in the My Work view.
 
@@ -157,7 +157,7 @@ The system SHOULD include items from Procest (cases and tasks assigned to the cu
 
 ---
 
-### REQ-MW-080: Item Card Layout [MVP]
+### Requirement: Item Card Layout [MVP]
 
 Each item MUST follow a consistent card layout showing entity badge, title, stage/status, pipeline, value (leads), due date, and priority.
 
@@ -171,7 +171,7 @@ Each item MUST follow a consistent card layout showing entity badge, title, stag
 
 ---
 
-### REQ-MW-090: Queue-Based Work Section [Enterprise]
+### Requirement: Queue-Based Work Section [Enterprise]
 
 The My Work view SHALL include a "My Queues" tab showing items from queues the current user is assigned to, providing a queue-centric view of incoming work alongside the existing time-based grouping.
 
@@ -284,7 +284,7 @@ The design follows the wireframe in DESIGN-REFERENCES.md section 3.5.
 
 ## Requirements
 
-### REQ-MW-010: Personal Workload View [MVP]
+### Requirement: Personal Workload View [MVP]
 
 The system MUST provide a "My Work" view showing all leads, requests, and tasks assigned to the current user. Only open items are shown by default, with a toggle to include completed items. Tasks assigned to Nextcloud groups the user belongs to MUST also appear.
 
@@ -316,7 +316,7 @@ The system MUST provide a "My Work" view showing all leads, requests, and tasks 
 
 ---
 
-### REQ-MW-020: Sorting [MVP]
+### Requirement: Sorting [MVP]
 
 Within each temporal group, items MUST be sorted by priority first, then by due date ascending.
 
@@ -330,7 +330,7 @@ Within each temporal group, items MUST be sorted by priority first, then by due 
 
 ---
 
-### REQ-MW-030: Temporal Grouping [MVP]
+### Requirement: Temporal Grouping [MVP]
 
 Items MUST be organized into four temporal groups displayed top to bottom: Overdue, Due This Week, Upcoming, No Due Date. Empty groups MUST be hidden.
 
@@ -360,7 +360,7 @@ Items MUST be organized into four temporal groups displayed top to bottom: Overd
 
 ---
 
-### REQ-MW-040: Filtering [MVP]
+### Requirement: Filtering [MVP]
 
 The system MUST allow filtering by entity type: All (default), Leads, Requests, Tasks.
 
@@ -376,7 +376,7 @@ The system MUST allow filtering by entity type: All (default), Leads, Requests, 
 
 ---
 
-### REQ-MW-050: Overdue Item Highlighting [MVP]
+### Requirement: Overdue Item Highlighting [MVP]
 
 Overdue items MUST be visually distinct with red indicators and "N days overdue" text.
 
@@ -391,7 +391,7 @@ Overdue items MUST be visually distinct with red indicators and "N days overdue"
 
 ---
 
-### REQ-MW-060: Item Navigation [MVP]
+### Requirement: Item Navigation [MVP]
 
 Each item MUST be clickable, navigating to the full detail view.
 
@@ -401,7 +401,7 @@ Each item MUST be clickable, navigating to the full detail view.
 
 ---
 
-### REQ-MW-070: Cross-App Workload [V1]
+### Requirement: Cross-App Workload [V1]
 
 The system MUST include items from Procest (cases and tasks assigned to the current user) in the My Work view.
 
@@ -427,7 +427,7 @@ The system MUST include items from Procest (cases and tasks assigned to the curr
 
 ---
 
-### REQ-MW-080: Item Card Layout [MVP]
+### Requirement: Item Card Layout [MVP]
 
 Each item MUST follow a consistent card layout showing entity badge, title, stage/status, pipeline, value (leads), due date, and priority.
 
@@ -449,7 +449,7 @@ Each item MUST follow a consistent card layout showing entity badge, title, stag
 
 ## Requirements
 
-### REQ-MW-090: KPI Summary Widgets [V1]
+### Requirement: KPI Summary Widgets [V1]
 
 The My Work view MUST display a row of key performance indicator (KPI) summary tiles at the top, giving the user an at-a-glance overview of their personal workload metrics. These tiles are scoped to the current user's assigned items only (not the team or organization totals shown on the Dashboard).
 
@@ -476,7 +476,7 @@ The My Work view MUST display a row of key performance indicator (KPI) summary t
 
 ---
 
-### REQ-MW-100: Quick Actions [V1]
+### Requirement: Quick Actions [V1]
 
 The My Work view MUST provide quick action buttons that allow the user to create new items directly from the workspace without navigating away.
 
@@ -507,7 +507,7 @@ The My Work view MUST provide quick action buttons that allow the user to create
 
 ---
 
-### REQ-MW-110: Recent Activity Feed [V1]
+### Requirement: Recent Activity Feed [V1]
 
 The My Work view MUST include a collapsible recent activity feed showing the latest changes to items assigned to the current user, providing context on what has happened since their last visit.
 
@@ -535,7 +535,7 @@ The My Work view MUST include a collapsible recent activity feed showing the lat
 
 ---
 
-### REQ-MW-120: Upcoming Follow-Ups [V1]
+### Requirement: Upcoming Follow-Ups [V1]
 
 The My Work view MUST display upcoming follow-up actions scheduled for the current user, drawn from lead follow-up dates and request scheduled callback dates.
 
@@ -563,7 +563,7 @@ The My Work view MUST display upcoming follow-up actions scheduled for the curre
 
 ---
 
-### REQ-MW-130: Calendar Integration [V1]
+### Requirement: Calendar Integration [V1]
 
 The My Work view SHOULD display upcoming meetings and calendar events from the user's Nextcloud Calendar that are linked to CRM entities (clients, contacts, leads).
 
@@ -592,7 +592,7 @@ The My Work view SHOULD display upcoming meetings and calendar events from the u
 
 ---
 
-### REQ-MW-140: Notification Inbox Summary [V1]
+### Requirement: Notification Inbox Summary [V1]
 
 The My Work view MUST display a summary of unread Pipelinq notifications, providing quick access to assignment changes, stage/status updates, and note additions.
 
@@ -620,7 +620,7 @@ The My Work view MUST display a summary of unread Pipelinq notifications, provid
 
 ---
 
-### REQ-MW-150: Saved Filters [Enterprise]
+### Requirement: Saved Filters [Enterprise]
 
 The system MUST allow users to save and recall filter combinations for the My Work view, enabling quick access to frequently used workload slices.
 
@@ -650,7 +650,7 @@ The system MUST allow users to save and recall filter combinations for the My Wo
 
 ---
 
-### REQ-MW-160: Customizable Layout [Enterprise]
+### Requirement: Customizable Layout [Enterprise]
 
 The My Work view MUST allow users to customize which sections are visible and their display order, enabling personalization of the workspace.
 
@@ -674,7 +674,7 @@ The My Work view MUST allow users to customize which sections are visible and th
 
 ---
 
-### REQ-MW-170: Responsive Mobile View [MVP]
+### Requirement: Responsive Mobile View [MVP]
 
 The My Work view MUST be fully usable on mobile devices with screen widths down to 320px, following progressive disclosure patterns to optimize for small screens.
 
@@ -705,7 +705,7 @@ The My Work view MUST be fully usable on mobile devices with screen widths down 
 
 ---
 
-### REQ-MW-180: Role-Based Content [V1]
+### Requirement: Role-Based Content [V1]
 
 The My Work view MUST adapt its content and available actions based on the user's role, distinguishing between KCC agents, team managers, and administrators.
 
@@ -739,7 +739,7 @@ The My Work view MUST adapt its content and available actions based on the user'
 
 ---
 
-### REQ-MW-190: Auto-Refresh and Real-Time Updates [V1]
+### Requirement: Auto-Refresh and Real-Time Updates [V1]
 
 The My Work view MUST keep data current through periodic auto-refresh, ensuring the user always sees their latest workload state.
 
@@ -764,7 +764,7 @@ The My Work view MUST keep data current through periodic auto-refresh, ensuring 
 
 ---
 
-### REQ-MW-200: Priority and Pipeline Filter Extensions [V1]
+### Requirement: Priority and Pipeline Filter Extensions [V1]
 
 The My Work view MUST extend the basic entity type filter with additional filter dimensions for priority level and pipeline, enabling more precise workload slicing.
 

--- a/openspec/specs/pipeline/spec.md
+++ b/openspec/specs/pipeline/spec.md
@@ -631,7 +631,7 @@ Pipeline cards MUST support quick actions for moving between stages and assignin
 
 ## Requirements
 
-### Requirement: REQ-PIPE-019: Multiple Pipelines per Organization [V1]
+### Requirement: Multiple Pipelines per Organization [V1] (REQ-PIPE-019)
 
 Organizations MUST be able to maintain multiple active pipelines simultaneously, each targeting different workflows or teams. This enables separate sales processes (e.g., government deals vs. commercial, inbound vs. outbound) and prevents forcing all leads through a single funnel. Inspired by EspoCRM's multi-pipeline opportunities and Krayin's pipeline-per-team model.
 
@@ -663,7 +663,7 @@ Organizations MUST be able to maintain multiple active pipelines simultaneously,
 
 ---
 
-### Requirement: REQ-PIPE-020: Pipeline Template Creation [Enterprise]
+### Requirement: Pipeline Template Creation [Enterprise] (REQ-PIPE-020)
 
 The system SHOULD allow admins to save an existing pipeline configuration as a reusable template. Templates accelerate onboarding by providing pre-built pipeline configurations that match common workflows (sales, service, hiring, procurement). Krayin ships with a default pipeline template; EspoCRM uses installable extension packs.
 
@@ -696,7 +696,7 @@ The system SHOULD allow admins to save an existing pipeline configuration as a r
 
 ---
 
-### Requirement: REQ-PIPE-021: Stage Automation on Transition [Enterprise]
+### Requirement: Stage Automation on Transition [Enterprise] (REQ-PIPE-021)
 
 The system SHOULD support configurable automation actions triggered when a lead or request moves to a specific stage. This reduces manual work and ensures consistency in follow-up actions. EspoCRM implements this via its BPM engine; Krayin uses a workflow automation system with event-based triggers on lead stage changes.
 
@@ -738,7 +738,7 @@ The system SHOULD support configurable automation actions triggered when a lead 
 
 ---
 
-### Requirement: REQ-PIPE-022: Pipeline Filtering and Search [MVP]
+### Requirement: Pipeline Filtering and Search [MVP] (REQ-PIPE-022)
 
 The pipeline kanban and list views MUST support filtering and searching items to help users focus on specific subsets of leads or requests. This is a fundamental CRM capability present in all competitors (EspoCRM, Krayin, Twenty, BottleCRM).
 
@@ -782,7 +782,7 @@ The pipeline kanban and list views MUST support filtering and searching items to
 
 ---
 
-### Requirement: REQ-PIPE-023: Pipeline Access Control [V1]
+### Requirement: Pipeline Access Control [V1] (REQ-PIPE-023)
 
 The system SHOULD enforce access control on pipelines to ensure users only see and interact with pipelines relevant to their role. Access control is managed via OpenRegister's RBAC system. EspoCRM uses team-based access with role-level restrictions; Krayin has a "bouncer" system with all/group/individual permission levels.
 
@@ -814,7 +814,7 @@ The system SHOULD enforce access control on pipelines to ensure users only see a
 
 ---
 
-### Requirement: REQ-PIPE-024: Pipeline Dashboard Widgets [V1]
+### Requirement: Pipeline Dashboard Widgets [V1] (REQ-PIPE-024)
 
 The Pipelinq dashboard MUST include pipeline-specific widgets that provide at-a-glance visibility into pipeline health and performance. These widgets complement the full kanban view by surfacing key metrics on the landing page.
 
@@ -853,7 +853,7 @@ The Pipelinq dashboard MUST include pipeline-specific widgets that provide at-a-
 
 ---
 
-### Requirement: REQ-PIPE-025: Stage SLA and Deadline Tracking [Enterprise]
+### Requirement: Stage SLA and Deadline Tracking [Enterprise] (REQ-PIPE-025)
 
 The system SHOULD support configuring maximum time limits (SLAs) per stage so that leads and requests that exceed the expected duration are flagged for attention. SLA tracking is a common feature in government CRM contexts where response time commitments are contractual. EspoCRM offers SLA tracking in its Cases module; Krayin does not have built-in SLA.
 
@@ -892,7 +892,7 @@ The system SHOULD support configuring maximum time limits (SLAs) per stage so th
 
 ---
 
-### Requirement: REQ-PIPE-026: Pipeline Reporting [V1]
+### Requirement: Pipeline Reporting [V1] (REQ-PIPE-026)
 
 The system SHOULD provide exportable pipeline reports that summarize pipeline performance over a configurable time period. Reports complement real-time analytics by providing historical snapshots for management review and tender compliance.
 
@@ -929,7 +929,7 @@ The system SHOULD provide exportable pipeline reports that summarize pipeline pe
 
 ---
 
-### Requirement: REQ-PIPE-027: Win/Loss Tracking [Enterprise]
+### Requirement: Win/Loss Tracking [Enterprise] (REQ-PIPE-027)
 
 The system SHOULD track the outcome of closed leads with structured reason data to enable analysis of why deals are won or lost. This is a standard CRM feature in EspoCRM (close reason field on opportunities), Krayin (lost reason on leads), and all enterprise CRMs.
 
@@ -966,7 +966,7 @@ The system SHOULD track the outcome of closed leads with structured reason data 
 
 ---
 
-### Requirement: REQ-PIPE-028: Pipeline Sidebar Details [MVP]
+### Requirement: Pipeline Sidebar Details [MVP] (REQ-PIPE-028)
 
 The pipeline view MUST include a sidebar panel that displays detailed information about the currently selected pipeline and its stages without navigating away from the board. The sidebar provides quick access to pipeline metadata and stage configuration.
 
@@ -1007,7 +1007,7 @@ The pipeline view MUST include a sidebar panel that displays detailed informatio
 
 ---
 
-### Requirement: REQ-PIPE-029: View Persistence and User Preferences [V1]
+### Requirement: View Persistence and User Preferences [V1] (REQ-PIPE-029)
 
 The system MUST remember per-user pipeline view preferences so that returning to the pipeline view restores the user's last configuration. This reduces friction when users have consistent workflow patterns.
 
@@ -1042,7 +1042,7 @@ The system MUST remember per-user pipeline view preferences so that returning to
 
 ---
 
-### Requirement: REQ-PIPE-030: Weighted Pipeline Value and Sales Forecast [V1]
+### Requirement: Weighted Pipeline Value and Sales Forecast [V1] (REQ-PIPE-030)
 
 The system MUST calculate and display weighted pipeline values to provide a realistic forecast of expected revenue. The weighted value multiplies each lead's value by its stage probability, giving a more accurate picture than raw totals. This is a standard feature in EspoCRM (opportunity reports), Krayin (pipeline dashboard), and all enterprise CRMs.
 

--- a/openspec/specs/pipeline/spec.md
+++ b/openspec/specs/pipeline/spec.md
@@ -42,7 +42,7 @@ See [ARCHITECTURE.md](../../../docs/ARCHITECTURE.md) for the full Pipeline and S
 
 ## Requirements
 
-### REQ-PIPE-001: Pipeline CRUD [MVP]
+### Requirement: Pipeline CRUD [MVP]
 
 The system MUST support creating, reading, updating, and deleting pipelines. Pipelines are managed by admins via the Nextcloud admin settings page (see DESIGN-REFERENCES.md Section 3.7).
 
@@ -100,7 +100,7 @@ The system MUST support creating, reading, updating, and deleting pipelines. Pip
 
 ---
 
-### REQ-PIPE-002: Pipeline Entity Types [MVP]
+### Requirement: Pipeline Entity Types [MVP]
 
 Each pipeline MUST declare which entity types it supports. This controls which entities can be placed on the pipeline and which entities appear on the kanban board.
 
@@ -127,7 +127,7 @@ Each pipeline MUST declare which entity types it supports. This controls which e
 
 ---
 
-### REQ-PIPE-003: Default Pipelines [MVP]
+### Requirement: Default Pipelines [MVP]
 
 The system MUST create default pipelines during app initialization (repair step) so the app is usable out-of-the-box without configuration.
 
@@ -178,7 +178,7 @@ The system MUST create default pipelines during app initialization (repair step)
 
 ---
 
-### REQ-PIPE-004: Stage CRUD [MVP]
+### Requirement: Stage CRUD [MVP]
 
 The system MUST support creating, reading, updating, reordering, and deleting stages within a pipeline. Stages are managed via the admin settings page as sub-items of their parent pipeline.
 
@@ -238,7 +238,7 @@ The system MUST support creating, reading, updating, reordering, and deleting st
 
 ---
 
-### REQ-PIPE-005: Stage Validation [MVP]
+### Requirement: Stage Validation [MVP]
 
 The system MUST enforce validation rules on stage configuration to maintain pipeline integrity.
 
@@ -276,7 +276,7 @@ The system MUST enforce validation rules on stage configuration to maintain pipe
 
 ---
 
-### REQ-PIPE-006: Kanban Board View [MVP]
+### Requirement: Kanban Board View [MVP]
 
 The system MUST provide a kanban board view for each pipeline showing stages as columns and leads/requests as cards. Request cards MUST be visually distinct from lead cards.
 
@@ -300,7 +300,7 @@ The system MUST provide a kanban board view for each pipeline showing stages as 
 
 ---
 
-### REQ-PIPE-007: Pipeline View Toggle [MVP]
+### Requirement: Pipeline View Toggle [MVP]
 
 The system MUST support toggling between kanban board view and list table view for each pipeline. Both views show the same data, just in different formats.
 
@@ -350,7 +350,7 @@ The system MUST support toggling between kanban board view and list table view f
 
 ---
 
-### REQ-PIPE-008: Stage Column Headers [MVP]
+### Requirement: Stage Column Headers [MVP]
 
 Each stage column on the kanban board MUST display aggregate information in its header.
 
@@ -372,7 +372,7 @@ Each stage column on the kanban board MUST display aggregate information in its 
 
 ---
 
-### REQ-PIPE-009: Add Entity from Stage Column [MVP]
+### Requirement: Add Entity from Stage Column [MVP]
 
 The system MUST allow creating new entities directly from within a stage column on the kanban board. On mixed pipelines, the quick-create form MUST include an entity type selector.
 
@@ -383,7 +383,7 @@ The system MUST allow creating new entities directly from within a stage column 
 
 ---
 
-### REQ-PIPE-010: Pipeline Selection on Entity [MVP]
+### Requirement: Pipeline Selection on Entity [MVP]
 
 Leads and requests MUST be assignable to a pipeline and stage, either during creation or via editing.
 
@@ -421,7 +421,7 @@ Leads and requests MUST be assignable to a pipeline and stage, either during cre
 
 ---
 
-### REQ-PIPE-011: Stage Probability Mapping [V1]
+### Requirement: Stage Probability Mapping [V1]
 
 When a lead is moved to a stage that has a probability value set, the system MUST automatically update the lead's probability to match the stage probability.
 
@@ -448,7 +448,7 @@ When a lead is moved to a stage that has a probability value set, the system MUS
 
 ---
 
-### REQ-PIPE-012: Pipeline Analytics [V1]
+### Requirement: Pipeline Analytics [V1]
 
 The system MUST provide analytics for each pipeline to help managers understand conversion rates and bottlenecks.
 
@@ -477,7 +477,7 @@ The system MUST provide analytics for each pipeline to help managers understand 
 
 ---
 
-### REQ-PIPE-013: Pipeline Funnel Visualization [V1]
+### Requirement: Pipeline Funnel Visualization [V1]
 
 The system MUST display a funnel chart showing the distribution of leads/requests across pipeline stages.
 
@@ -493,7 +493,7 @@ The system MUST display a funnel chart showing the distribution of leads/request
 
 ---
 
-### REQ-PIPE-014: Stage Revenue Summary [V1]
+### Requirement: Stage Revenue Summary [V1]
 
 The system MUST display the total monetary value of leads in each stage to provide at-a-glance pipeline valuation.
 
@@ -515,7 +515,7 @@ The system MUST display the total monetary value of leads in each stage to provi
 
 ---
 
-### REQ-PIPE-015: Error Scenarios [MVP]
+### Requirement: Error Scenarios [MVP]
 
 The system MUST handle error conditions gracefully with meaningful feedback.
 
@@ -558,7 +558,7 @@ The system MUST handle error conditions gracefully with meaningful feedback.
 
 ---
 
-### REQ-PIPE-016: Pipeline List on Admin Settings [MVP]
+### Requirement: Pipeline List on Admin Settings [MVP]
 
 The admin settings page MUST display all pipelines with their configuration summary. See DESIGN-REFERENCES.md Section 3.7 for the wireframe.
 
@@ -584,7 +584,7 @@ The admin settings page MUST display all pipelines with their configuration summ
 
 ---
 
-### REQ-PIPE-017: Pipeline Selector Dropdown [MVP]
+### Requirement: Pipeline Selector Dropdown [MVP]
 
 The pipeline view MUST include a dropdown to switch between pipelines.
 
@@ -604,7 +604,7 @@ The pipeline view MUST include a dropdown to switch between pipelines.
 
 ---
 
-### REQ-PIPE-018: Pipeline Card Quick Actions [MVP]
+### Requirement: Pipeline Card Quick Actions [MVP]
 
 Pipeline cards MUST support quick actions for moving between stages and assigning users without opening the detail view.
 

--- a/openspec/specs/request-management/spec.md
+++ b/openspec/specs/request-management/spec.md
@@ -55,7 +55,7 @@ Request management handles the intake and tracking of requests (verzoeken) — s
 
 ## Requirements
 
-### REQ-RM-010: Request CRUD [MVP]
+### Requirement: Request CRUD [MVP]
 
 The system MUST support creating, reading, updating, and deleting request records. Each request MUST have a `title`. The `status` MUST default to `new` when not explicitly provided. The `channel` field MUST be added to the OpenRegister schema to support persistence.
 
@@ -97,7 +97,7 @@ The system MUST support creating, reading, updating, and deleting request record
 
 ---
 
-### REQ-RM-020: Request Status Lifecycle [MVP]
+### Requirement: Request Status Lifecycle [MVP]
 
 The system MUST enforce allowed status transitions as defined in the transition table. The frontend MUST present only valid transitions for the current status.
 
@@ -128,7 +128,7 @@ The system MUST enforce allowed status transitions as defined in the transition 
 
 ---
 
-### REQ-RM-030: Request List View [MVP]
+### Requirement: Request List View [MVP]
 
 The system MUST provide a full list view with search, sort, filter, and pagination. The current basic table MUST be enhanced with filtering controls and sortable columns.
 
@@ -173,7 +173,7 @@ The system MUST provide a full list view with search, sort, filter, and paginati
 
 ---
 
-### REQ-RM-040: Request Detail View [MVP]
+### Requirement: Request Detail View [MVP]
 
 The system MUST provide a detail view with proper layout including core info, client link, pipeline position, assignment, and activity timeline. The current basic form MUST be replaced with a structured detail layout.
 
@@ -199,7 +199,7 @@ The system MUST provide a detail view with proper layout including core info, cl
 
 ---
 
-### REQ-RM-050: Request Assignment [MVP]
+### Requirement: Request Assignment [MVP]
 
 The system MUST allow assigning a request to a Nextcloud user via a user picker dropdown.
 
@@ -217,7 +217,7 @@ The system MUST allow assigning a request to a Nextcloud user via a user picker 
 
 ---
 
-### REQ-RM-060: Request Priority [MVP]
+### Requirement: Request Priority [MVP]
 
 The system MUST support four priority levels with visual indicators in all views.
 
@@ -238,7 +238,7 @@ The system MUST support four priority levels with visual indicators in all views
 
 ---
 
-### REQ-RM-070: Request Channel Tracking [V1]
+### Requirement: Request Channel Tracking [V1]
 
 The system MUST support tracking the intake channel. Channel values come from SystemTag-based admin settings (already implemented). The `channel` field MUST be added to the OpenRegister schema.
 
@@ -252,7 +252,7 @@ The system MUST support tracking the intake channel. Channel values come from Sy
 
 ---
 
-### REQ-RM-080: Request Category/Product Classification [V1]
+### Requirement: Request Category/Product Classification [V1]
 
 The system SHOULD support categorizing requests by product or service type. Categories are free-text strings that MAY be pre-populated from admin configuration.
 
@@ -268,7 +268,7 @@ The system SHOULD support categorizing requests by product or service type. Cate
 
 ---
 
-### REQ-RM-090: Request-to-Case Conversion [V1]
+### Requirement: Request-to-Case Conversion [V1]
 
 The system MUST support converting a request to a case in Procest.
 
@@ -295,7 +295,7 @@ The system MUST support converting a request to a case in Procest.
 
 ---
 
-### REQ-RM-100: Request on Pipeline [MVP]
+### Requirement: Request on Pipeline [MVP]
 
 A request MAY optionally be placed on a pipeline. When on a pipeline, the request has a `stage`, `stageOrder`, and appears on the kanban board.
 
@@ -316,7 +316,7 @@ A request MAY optionally be placed on a pipeline. When on a pipeline, the reques
 
 ---
 
-### REQ-RM-110: Request Validation Rules [MVP]
+### Requirement: Request Validation Rules [MVP]
 
 The system MUST enforce validation rules for request data integrity.
 
@@ -338,7 +338,7 @@ The system MUST enforce validation rules for request data integrity.
 
 ---
 
-### REQ-RM-120: Request Queue Assignment [Enterprise]
+### Requirement: Request Queue Assignment [Enterprise]
 
 The request entity SHALL support an optional `queue` reference field linking the request to a queue for workload management.
 
@@ -501,7 +501,7 @@ Request management handles the intake and tracking of requests (verzoeken) — s
 
 ## Requirements
 
-### REQ-RM-010: Request CRUD [MVP]
+### Requirement: Request CRUD [MVP]
 
 The system MUST support creating, reading, updating, and deleting request records. Each request MUST have a `title`. The `status` MUST default to `new` when not explicitly provided. All properties defined in the data model MUST be persisted via OpenRegister.
 
@@ -543,7 +543,7 @@ The system MUST support creating, reading, updating, and deleting request record
 
 ---
 
-### REQ-RM-020: Request Status Lifecycle [MVP]
+### Requirement: Request Status Lifecycle [MVP]
 
 The system MUST enforce allowed status transitions as defined in the transition table. The frontend MUST present only valid transitions for the current status.
 
@@ -574,7 +574,7 @@ The system MUST enforce allowed status transitions as defined in the transition 
 
 ---
 
-### REQ-RM-030: Request List View [MVP]
+### Requirement: Request List View [MVP]
 
 The system MUST provide a full list view with search, sort, filter, and pagination. The current basic table MUST be enhanced with filtering controls and sortable columns.
 
@@ -619,7 +619,7 @@ The system MUST provide a full list view with search, sort, filter, and paginati
 
 ---
 
-### REQ-RM-040: Request Detail View [MVP]
+### Requirement: Request Detail View [MVP]
 
 The system MUST provide a detail view with proper layout including core info, client link, pipeline position, assignment, and activity timeline. The current basic form MUST be replaced with a structured detail layout.
 
@@ -645,7 +645,7 @@ The system MUST provide a detail view with proper layout including core info, cl
 
 ---
 
-### REQ-RM-050: Request Assignment [MVP]
+### Requirement: Request Assignment [MVP]
 
 The system MUST allow assigning a request to a Nextcloud user via a user picker dropdown.
 
@@ -663,7 +663,7 @@ The system MUST allow assigning a request to a Nextcloud user via a user picker 
 
 ---
 
-### REQ-RM-060: Request Priority [MVP]
+### Requirement: Request Priority [MVP]
 
 The system MUST support four priority levels with visual indicators in all views.
 
@@ -684,7 +684,7 @@ The system MUST support four priority levels with visual indicators in all views
 
 ---
 
-### REQ-RM-070: Request Channel Tracking [V1]
+### Requirement: Request Channel Tracking [V1]
 
 The system MUST support tracking the intake channel. Channel values come from SystemTag-based admin settings (already implemented). The `channel` field is present in the OpenRegister schema.
 
@@ -698,7 +698,7 @@ The system MUST support tracking the intake channel. Channel values come from Sy
 
 ---
 
-### REQ-RM-080: Request Category/Product Classification [V1]
+### Requirement: Request Category/Product Classification [V1]
 
 The system MUST support categorizing requests by product or service type. Categories are free-text strings that MAY be pre-populated from admin configuration.
 
@@ -714,7 +714,7 @@ The system MUST support categorizing requests by product or service type. Catego
 
 ---
 
-### REQ-RM-090: Request-to-Case Conversion [V1]
+### Requirement: Request-to-Case Conversion [V1]
 
 The system MUST support converting a request to a case in Procest.
 
@@ -741,7 +741,7 @@ The system MUST support converting a request to a case in Procest.
 
 ---
 
-### REQ-RM-100: Request on Pipeline [MVP]
+### Requirement: Request on Pipeline [MVP]
 
 A request MUST be optionally placeable on a pipeline. When on a pipeline, the request has a `stage`, `stageOrder`, and appears on the kanban board.
 
@@ -762,7 +762,7 @@ A request MUST be optionally placeable on a pipeline. When on a pipeline, the re
 
 ---
 
-### REQ-RM-110: Request Validation Rules [MVP]
+### Requirement: Request Validation Rules [MVP]
 
 The system MUST enforce validation rules for request data integrity.
 
@@ -786,7 +786,7 @@ The system MUST enforce validation rules for request data integrity.
 
 ## Requirements
 
-### REQ-RM-120: Request-Contact Linking [MVP]
+### Requirement: Request-Contact Linking [MVP]
 
 The system MUST support linking a request to a specific contact person at the client organization. The `contact` field in the request schema stores a UUID reference to a contact object. When a request is linked to both a client and a contact, the contact MUST belong to that client.
 
@@ -816,7 +816,7 @@ The system MUST support linking a request to a specific contact person at the cl
 
 ---
 
-### REQ-RM-130: Request Notes and Activity Timeline [MVP]
+### Requirement: Request Notes and Activity Timeline [MVP]
 
 The system MUST support adding notes to requests via the Nextcloud ICommentsManager and displaying an activity timeline showing status changes, assignment changes, and user notes. This leverages the existing `EntityNotes` component and `ActivityService`.
 
@@ -847,7 +847,7 @@ The system MUST support adding notes to requests via the Nextcloud ICommentsMana
 
 ---
 
-### REQ-RM-140: Request SLA Tracking [Enterprise]
+### Requirement: Request SLA Tracking [Enterprise]
 
 The system SHOULD support tracking service level agreement (SLA) response and resolution times for requests. SLA targets are defined per category or globally and enable monitoring of service quality.
 
@@ -879,7 +879,7 @@ The system SHOULD support tracking service level agreement (SLA) response and re
 
 ---
 
-### REQ-RM-150: Bulk Request Operations [V1]
+### Requirement: Bulk Request Operations [V1]
 
 The system MUST support performing actions on multiple requests at once from the list view. Bulk actions reduce repetitive work for request handlers processing a high volume of incoming requests.
 
@@ -912,7 +912,7 @@ The system MUST support performing actions on multiple requests at once from the
 
 ---
 
-### REQ-RM-160: Request Templates [V1]
+### Requirement: Request Templates [V1]
 
 The system SHOULD support pre-defined request templates to standardize common request types. Templates pre-fill the title, description, category, priority, and optionally the pipeline/stage, reducing data entry time and ensuring consistency.
 
@@ -937,7 +937,7 @@ The system SHOULD support pre-defined request templates to standardize common re
 
 ---
 
-### REQ-RM-170: Request Reporting and KPIs [V1]
+### Requirement: Request Reporting and KPIs [V1]
 
 The system MUST provide reporting capabilities for request management performance. KPIs include request volume, average handling time, status distribution, and assignment workload. Reports leverage the existing `MetricsRepository` and `MetricsFormatter` services.
 
@@ -973,7 +973,7 @@ The system MUST provide reporting capabilities for request management performanc
 
 ---
 
-### REQ-RM-180: Request Search and Faceted Filtering [MVP]
+### Requirement: Request Search and Faceted Filtering [MVP]
 
 The system MUST support full-text search across request fields and faceted filtering using OpenRegister's `facetable` schema properties. The request schema marks `status`, `priority`, `assignee`, `category`, `channel`, and `stage` as facetable.
 
@@ -1004,7 +1004,7 @@ The system MUST support full-text search across request fields and faceted filte
 
 ---
 
-### REQ-RM-190: Request-to-Case Conversion with Data Mapping [V1]
+### Requirement: Request-to-Case Conversion with Data Mapping [V1]
 
 When converting a request to a Procest case, the system MUST map request fields to case fields following the VNG Verzoek-to-Zaak relationship pattern. This extends REQ-RM-090 with detailed field mapping and error handling.
 
@@ -1040,7 +1040,7 @@ When converting a request to a Procest case, the system MUST map request fields 
 
 ---
 
-### REQ-RM-200: Request Pipeline Kanban View [MVP]
+### Requirement: Request Pipeline Kanban View [MVP]
 
 Requests placed on a pipeline MUST appear on the kanban board alongside leads. Request-specific kanban interactions include drag-and-drop stage changes, quick status updates, and visual differentiation from leads.
 
@@ -1071,7 +1071,7 @@ Requests placed on a pipeline MUST appear on the kanban board alongside leads. R
 
 ---
 
-### REQ-RM-210: Request Notification and Assignment Alerts [V1]
+### Requirement: Request Notification and Assignment Alerts [V1]
 
 The system MUST send Nextcloud notifications when requests are created, assigned, reassigned, or have their status changed. This leverages the existing `ObjectEventHandlerService`, `ObjectEventDispatcher`, and `NotificationService`.
 
@@ -1103,7 +1103,7 @@ The system MUST send Nextcloud notifications when requests are created, assigned
 
 ---
 
-### REQ-RM-220: Request Quick Create from Client Detail [MVP]
+### Requirement: Request Quick Create from Client Detail [MVP]
 
 The system MUST support creating a request directly from a client's detail view, pre-linking the request to that client. This provides a natural workflow where a service agent receiving a call can create a request without leaving the client context.
 


### PR DESCRIPTION
2026/05/24 15:21:27.661736 cmd_run.go:1605: WARNING: cannot start document portal: dial unix /run/user/1000/bus: connect: no such file or directory
## Summary

Phase 1c per [hydra ADR-037](https://github.com/ConductionNL/hydra/pull/326): convert legacy Form B headings `### REQ-XX-NNN: <title>` to canonical Form A `### Requirement: <title>` across the pipelinq spec set.

## Changes

| Spec | REQs migrated | Notes |
|---|---|---|
| `admin-settings` | 13 (REQ-AS) | mixed; 16 already Form A |
| `klachtenregistratie` | 10 (REQ-KL) | now passes `openspec validate --strict` |
| `lead-management` | 15 (REQ-LEAD) | now passes `openspec validate --strict` |
| `my-work` | 29 (REQ-MW) | duplicate REQ blocks from prior merge residue retained as-is |
| `pipeline` | 18 (REQ-PIPE) | now passes `openspec validate --strict` |
| `request-management` | 34 (REQ-RM) | duplicate REQ blocks from prior merge residue retained as-is |

**Diff stats:** 6 files changed, 119 insertions(+), 119 deletions(-) — pure heading rename, no body or scenario changes.

The other 31 specs in `openspec/specs/` already used Form A and were left untouched.

## Not touched

- `terugbel-taakbeheer/spec.md` — left intact per #546 (open PR archiving this spec; avoiding conflict).
- `callback-management/spec.md` — already Form A; left intact in case #546 merges and modifies it.

## Validation

`openspec validate --specs --strict` — 19 passed, 18 failed. **Same totals as before this PR**; the 18 failures are pre-existing `SHALL/MUST keyword` warnings and unresolved merge residue in `admin-settings`, `my-work`, `request-management`. Those are out of scope for this normalization pass and will be addressed separately.

## Test plan

- [x] No Form B headings remain anywhere in `openspec/specs/`
- [x] `terugbel-taakbeheer` untouched (PR #546 not blocked)
- [x] Body / scenarios / section ordering preserved (diff is +/- symmetric)
- [x] Validator results no worse than baseline

Refs #545
Refs ConductionNL/hydra#326

---

## Amended 2026-05-24

Aligned with the **revised** [ADR-037 canonical form](https://github.com/ConductionNL/hydra/pull/326): IDs now live as a **heading-suffix** `(REQ-XX-NNN)` rather than as `### Requirement: REQ-XX-NNN: <title>`.

The original form was rejected by `openspec validate --strict` because the validator parsed `REQ-XX-NNN: <title>` as the requirement text and failed the SHALL/MUST-keyword check. The corrected canonical (just landed on hydra#326) is heading-suffix:

```markdown
### Requirement: <title> (REQ-XX-NNN)

<SHALL body>
```

### Fixup commit

`d912927` — rewrote 12 headings in `openspec/specs/pipeline/spec.md` (REQ-PIPE-019..030) from `### Requirement: REQ-PIPE-NNN: <title>` to `### Requirement: <title> (REQ-PIPE-NNN)`.

### Why only pipeline

- `klachtenregistratie`, `lead-management` — no `REQ-prefix-in-title` headings present; Phase 1c already left them in canonical form.
- `admin-settings`, `my-work`, `request-management` — pre-existing `=======` merge-conflict markers and duplicate `## Requirements` blocks (called out in the original report). **Left intact** for a separate cleanup PR; the REQ-prefix headings inside their merge-residue blocks are not safe to touch in isolation.
- `pipeline` — has a duplicate `## Requirements` block but no `=======` markers; the 12 REQ-prefix headings were safely converted.

### Validation

`openspec validate --specs --strict` totals unchanged: **19 passed / 18 failed** (same as the original commit). The 18 failures are pre-existing SHALL/MUST issues in unrelated specs and the 3 merge-residue specs noted above. `pipeline` still validates cleanly post-amend.
