### PR TITLE
chore(nav): restructure manifest sections + bump to 0.2.12

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -52,7 +52,7 @@ Vrij en open source onder de AGPL-licentie.
 
 **Ondersteuning:** Voor ondersteuning, neem contact op via support@conduction.nl. Voor een Service Level Agreement (SLA), neem contact op via sales@conduction.nl.
     ]]></description>
-    <version>0.2.0</version>
+    <version>0.2.12</version>
     <licence>agpl</licence>
     <author mail="info@conduction.nl" homepage="https://www.conduction.nl/">Conduction</author>
     <namespace>Pipelinq</namespace>

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -122,7 +122,6 @@
 			"label": "Pipelines",
 			"icon": "icon-category-organization",
 			"route": "Pipelines",
-			"section": "settings",
 			"order": 200
 		},
 		{
@@ -130,7 +129,6 @@
 			"label": "Forms",
 			"icon": "icon-file",
 			"route": "Forms",
-			"section": "settings",
 			"order": 210
 		},
 		{
@@ -138,7 +136,6 @@
 			"label": "Automations",
 			"icon": "icon-play",
 			"route": "Automations",
-			"section": "settings",
 			"order": 220
 		},
 		{
@@ -930,7 +927,10 @@
 			"id": "FeaturesRoadmap",
 			"route": "/features-roadmap",
 			"type": "roadmap",
-			"title": "Features & roadmap"
+			"title": "Features & roadmap",
+			"config": {
+				"documentationUrl": "https://pipelinq.conduction.nl"
+			}
 		}
 	]
 }


### PR DESCRIPTION
## Summary

- **Manifest restructure**: Pipelines/Forms/Automations move from `section: "settings"` to the default `main` section — they're primary nav pages, not user settings. Footer no longer stacks four items
- **Docs URL config**: `FeaturesRoadmap` page declares `config.documentationUrl: "https://pipelinq.conduction.nl"` so the docs-info card resolves the right host
- **Version bump 0.2.0 → 0.2.12** to flip the cache-buster (each in-product change since 0.2.0 was already applied locally via `occ upgrade`)

## Test plan

- [x] `json.load(manifest.json)` valid
- [x] `occ upgrade` already run locally — sidebar copy + section restructure visible at /apps/pipelinq/features-roadmap
- [ ] After merge: container deploy will pick up the new version on next pull