### PR TITLE
chore: bump to 0.2.13 for nc-vue widget-action-defaults pickup

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -52,7 +52,7 @@ Vrij en open source onder de AGPL-licentie.
 
 **Ondersteuning:** Voor ondersteuning, neem contact op via support@conduction.nl. Voor een Service Level Agreement (SLA), neem contact op via sales@conduction.nl.
     ]]></description>
-    <version>0.2.12</version>
+    <version>0.2.13</version>
     <licence>agpl</licence>
     <author mail="info@conduction.nl" homepage="https://www.conduction.nl/">Conduction</author>
     <namespace>Pipelinq</namespace>


### PR DESCRIPTION
Cache-buster bump to surface nc-vue PR #380 (CnPageRenderer $listeners + $attrs forwarding) and PR #381 (CnWidgetWrapper built-in default action handlers + refresh contract) in pipelinq.

After this lands the Refresh and Request-a-feature actions on every dashboard widget actually do something out of the box.