### PR TITLE
chore(openspec): re-point pending changes to consume OR integration leaves (ADR-022)

### DIFF
--- a/openspec/changes/appointment-booking/proposal.md
+++ b/openspec/changes/appointment-booking/proposal.md
@@ -19,7 +19,9 @@ MKB service businesses urgently need better scheduling. Current tools fail becau
 
 ## Solution
 
-Implement appointment booking as a new Pipelinq module using existing OpenRegister and email-calendar-sync infrastructure:
+**Leaf-first boundary (ADR-022).** Calendar read/write and email/SMS dispatch are NOT built in pipelinq. They are delegated to `email-calendar-sync`, which consumes the OpenRegister `calendar` (`integration-calendar`) and `email` (`integration-email`) integration leaves; SMS/payment dispatch goes through openconnector. Pipelinq builds only the genuinely app-specific booking domain (Service/Resource/Booking/WalkInTicket entities, slot computation, skill-based routing, deposits, no-show, walk-in queue, public portal). Booking events are written to staff calendars through the calendar leaf's VEVENT create API — pipelinq adds no CalDAV client of its own.
+
+Implement appointment booking as a new Pipelinq module using existing OpenRegister abstractions and the calendar/email leaves (via email-calendar-sync):
 
 1. **Service** — a bookable offering with duration, skills required, pricing, deposit policy, cancellation policy, multi-step sub-steps.
 2. **Resource** — staff member, room, or equipment with working hours, vacation dates, skills, and optional calendar sync link so their Outlook/Google Calendar blocks are fetched automatically.
@@ -27,7 +29,7 @@ Implement appointment booking as a new Pipelinq module using existing OpenRegist
 4. **WalkInTicket** — a queue entry for unscheduled arrivals, separately tracked so barbershops can mix both model.
 5. **AvailabilityCache** — per-resource per-day free blocks (regenerated on Resource or Booking change) for fast slot queries.
 6. **Customer-facing portal** — a public website at `/book/{service-slug}` where customers pick date + time and self-book without logging in. Integrates skill-routing to never show unqualified resources.
-7. **Bi-directional calendar sync** — via email-calendar-sync: staff's Google/Outlook calendar blocks are ingested every 5 minutes, bookings push back to staff calendars so they see booked appointments.
+7. **Bi-directional calendar sync** — via email-calendar-sync, which consumes the OR `calendar` leaf: staff calendar blocks are ingested every 5 minutes, and booking VEVENTs are pushed back to staff calendars through the leaf's create API (no pipelinq-local CalDAV client).
 8. **Confirmation + reminder flows** — email-calendar-sync dispatches confirmation on booking creation, reminder 24 hours before, SMS optional. Signed deep-links allow reschedule/cancel without logging in.
 9. **No-show tracking and fees** — staff marks booking as no-show; system increments customer lifetime no-show count; optional deposit or fee is charged via openconnector (Mollie/Stripe).
 10. **Reschedule audit trail** — original booking transitions to `rescheduled`, new booking created with `previousBookingId` reference, audit trail preserved.

--- a/openspec/changes/appointment-booking/specs/appointment-booking/spec.md
+++ b/openspec/changes/appointment-booking/specs/appointment-booking/spec.md
@@ -4,6 +4,8 @@
 
 Implement appointment scheduling in Pipelinq by adding Service, Resource, Booking, and WalkInTicket entities with availability computation, a public self-booking portal, and email/calendar workflows for confirmations, reminders, reschedules, and no-show tracking.
 
+**Leaf-first boundary (ADR-022).** Calendar read/write and email dispatch are NOT built in pipelinq. They are delegated to `email-calendar-sync`, which consumes the OpenRegister `calendar` (`integration-calendar`) and `email` (`integration-email`) integration leaves. Pipelinq builds only the genuinely app-specific booking domain — Service/Resource/Booking/WalkInTicket entities, 15-minute slot computation, skill-based routing, deposit holds, no-show tracking, the walk-in queue, and the public portal. Calendar VEVENT linkage and `.ics`/confirmation email mechanics belong to the leaves.
+
 **Standards**: Schema.org (`schema:Event`, `schema:Service`, `schema:LocalBusiness`), iCalendar (RFC 5545 for `.ics` attachments), vCard email matching, Dutch locale formatting (WCAG 2.1 AA for accessibility)
 **Feature tier**: V1 (core booking, portal, email flows), V2 (automation triggers, advanced rules), V3 (mobile app, waitlist)
 **Entities used**: Service, Resource, Booking, WalkInTicket (new to Pipelinq); Customer (from client-management)
@@ -11,11 +13,11 @@ Implement appointment scheduling in Pipelinq by adding Service, Resource, Bookin
 
 ---
 
-## Requirements
+## ADDED Requirements
 
 ---
 
-### REQ-APT-001: Service Entity Schema
+### Requirement: REQ-APT-001 Service Entity Schema (renumbered for delta validation)
 
 The system MUST support Service entities with configurable duration, pricing, skills, multi-step composition, and booking policies.
 
@@ -35,7 +37,7 @@ The system MUST support Service entities with configurable duration, pricing, sk
 
 ---
 
-### REQ-APT-002: Resource Entity Schema
+### Requirement: REQ-APT-002 Resource Entity Schema
 
 The system MUST support Resource entities (staff, room, equipment) with working hours, vacations, skills, and optional calendar sync.
 
@@ -61,7 +63,7 @@ The system MUST support Resource entities (staff, room, equipment) with working 
 
 ---
 
-### REQ-APT-003: Availability Computation
+### Requirement: REQ-APT-003 Availability Computation
 
 The system MUST compute available 15-minute-aligned slots per resource per date by intersecting working hours, vacations, booked times, and calendar-synced blocks.
 
@@ -87,7 +89,7 @@ The system MUST compute available 15-minute-aligned slots per resource per date 
 
 ---
 
-### REQ-APT-004: Skill-Based Routing
+### Requirement: REQ-APT-004 Skill-Based Routing
 
 The system MUST query skill-routing to determine which Resources are eligible for a Service, then intersect with availability.
 
@@ -107,7 +109,7 @@ The system MUST query skill-routing to determine which Resources are eligible fo
 
 ---
 
-### REQ-APT-005: Public Booking Portal
+### Requirement: REQ-APT-005 Public Booking Portal
 
 The system MUST provide a public, unauthenticated web portal at `/book/{serviceSlug}` where customers self-book appointments.
 
@@ -134,7 +136,7 @@ The system MUST provide a public, unauthenticated web portal at `/book/{serviceS
 
 ---
 
-### REQ-APT-006: Booking Confirmation Email
+### Requirement: REQ-APT-006 Booking Confirmation Email
 
 The system MUST send a confirmation email immediately after a Booking is created or deposit is paid, including an `.ics` calendar attachment and signed reschedule/cancel links.
 
@@ -156,7 +158,7 @@ The system MUST send a confirmation email immediately after a Booking is created
 
 ---
 
-### REQ-APT-007: Reminder Email and SMS
+### Requirement: REQ-APT-007 Reminder Email and SMS
 
 The system MUST send a 24-hour reminder email and optional SMS before each appointment.
 
@@ -178,7 +180,7 @@ The system MUST send a 24-hour reminder email and optional SMS before each appoi
 
 ---
 
-### REQ-APT-008: Reschedule via Signed Link
+### Requirement: REQ-APT-008 Reschedule via Signed Link
 
 The system MUST allow customers to reschedule appointments via a signed email link without logging in, preserving the audit trail by marking the original Booking as rescheduled and creating a new Booking.
 
@@ -198,7 +200,7 @@ The system MUST allow customers to reschedule appointments via a signed email li
 
 ---
 
-### REQ-APT-009: Cancellation with Policy Enforcement
+### Requirement: REQ-APT-009 Cancellation with Policy Enforcement
 
 The system MUST enforce configurable cancellation policies: free-until-N-hours-before, always-charge, or no-charge. Late cancellations trigger optional payment charges.
 
@@ -224,7 +226,7 @@ The system MUST enforce configurable cancellation policies: free-until-N-hours-b
 
 ---
 
-### REQ-APT-010: Deposit-Required Bookings
+### Requirement: REQ-APT-010 Deposit-Required Bookings
 
 The system MUST support optional deposits: bookings requiring deposits are created with `status: "pending-deposit"`, the slot is held for 15 minutes, and on successful payment `status` transitions to `confirmed`.
 
@@ -250,7 +252,7 @@ The system MUST support optional deposits: bookings requiring deposits are creat
 
 ---
 
-### REQ-APT-011: No-Show Tracking and Fees
+### Requirement: REQ-APT-011 No-Show Tracking and Fees
 
 The system MUST track no-shows, increment customer lifetime no-show count, and optionally charge fees.
 
@@ -276,7 +278,7 @@ The system MUST track no-shows, increment customer lifetime no-show count, and o
 
 ---
 
-### REQ-APT-012: Walk-In Queue
+### Requirement: REQ-APT-012 Walk-In Queue
 
 The system MUST support walk-in arrivals (WalkInTicket) for businesses that mix scheduled and unscheduled service.
 
@@ -302,7 +304,7 @@ The system MUST support walk-in arrivals (WalkInTicket) for businesses that mix 
 
 ---
 
-### REQ-APT-013: Booking Status Lifecycle
+### Requirement: REQ-APT-013 Booking Status Lifecycle
 
 The system MUST enforce a valid status transition flow: pending-deposit → confirmed → completed/no-show/cancelled, with rescheduled as a parallel branch.
 
@@ -328,7 +330,7 @@ The system MUST enforce a valid status transition flow: pending-deposit → conf
 
 ---
 
-### REQ-APT-014: Customer Timeline Integration
+### Requirement: REQ-APT-014 Customer Timeline Integration
 
 The system MUST display all Bookings on the Customer detail page in the CRM, showing past and future appointments with status, service, resource, and time.
 
@@ -348,7 +350,7 @@ The system MUST display all Bookings on the Customer detail page in the CRM, sho
 
 ---
 
-### REQ-APT-015: Admin Booking Management
+### Requirement: REQ-APT-015 Admin Booking Management
 
 The system MUST provide admin views for staff to manage Services, Resources, and Bookings: list, create, edit, and delete.
 
@@ -375,7 +377,7 @@ The system MUST provide admin views for staff to manage Services, Resources, and
 
 ---
 
-### REQ-APT-016: AvailabilityCache
+### Requirement: REQ-APT-016 AvailabilityCache
 
 The system MUST maintain a read-only cache of free slots per resource per date for sub-second queries. Cache is regenerated on Resource/Booking/vacation changes and expires after 24 hours.
 
@@ -401,7 +403,7 @@ The system MUST maintain a read-only cache of free slots per resource per date f
 
 ---
 
-### REQ-APT-017: Compliance and Audit Trails
+### Requirement: REQ-APT-017 Compliance and Audit Trails
 
 The system MUST provide full audit trails for regulatory compliance: AVG right-to-be-forgotten (pseudonymize, not delete), NL Boekhoudplicht 7-year retention, and WCAG 2.1 AA accessibility on the public portal.
 
@@ -429,27 +431,29 @@ The system MUST provide full audit trails for regulatory compliance: AVG right-t
 
 ---
 
-### REQ-APT-018: Bi-Directional Calendar Sync
+### Requirement: REQ-APT-018 Bi-Directional Calendar Sync
 
-The system MUST sync staff calendar blocks (vacation, lunch, meetings) from Google/Outlook/iCloud via email-calendar-sync every 5 minutes, and push created Bookings back to staff calendars.
+**Leaf-first (ADR-022).** Calendar read/write is NOT implemented in pipelinq. Staff calendar blocks are read, and Booking events are written, through the OpenRegister **`calendar` leaf** (`integration-calendar`) — mediated by `email-calendar-sync`, which itself consumes the calendar leaf's `CalendarProvider`/VEVENT link+create API. Pipelinq MUST NOT add its own CalDAV client or `X-PIPELINQ-*` VEVENT properties (that would reproduce the ADR-022 "parallel link table" / "duplicate CalDAV sync" anti-pattern observed on decidesk). Pipelinq owns only the availability-cache invalidation that reacts to the leaf's synced blocks.
+
+The system MUST react to staff calendar blocks (vacation, lunch, meetings) synced by the `calendar` leaf every 5 minutes, and MUST push created Bookings back to staff calendars by creating VEVENTs through the leaf.
 
 **Feature tier**: V1
 
 #### Scenario: Calendar-synced block is respected in availability
 
-- **GIVEN** a staff member has a "lunch" event 12:00-13:00 in their Outlook calendar
-- **WHEN** the email-calendar-sync syncs the calendar
+- **GIVEN** a staff member has a "lunch" event 12:00-13:00 in their calendar
+- **WHEN** the `calendar` leaf (via email-calendar-sync) syncs the calendar
 - **THEN** within 5 minutes the AvailabilityCache MUST be invalidated, and no customer can book that staff member 12:00-13:00
 
-#### Scenario: Booking is pushed to staff calendar
+#### Scenario: Booking is pushed to staff calendar via the leaf
 
 - **GIVEN** a Booking is created for staff member X on 2026-05-25 14:00
 - **WHEN** the Booking is confirmed
-- **THEN** an event MUST be created in X's calendar (via email-calendar-sync push) with customer name, service, and a deep-link back to the Booking in Pipelinq
+- **THEN** a VEVENT MUST be created in X's calendar **through the `calendar` leaf's create API** (not a pipelinq-local CalDAV write) with customer name, service, and a deep-link back to the Booking in Pipelinq
 
 ---
 
-### REQ-APT-019: Unit Tests and Code Quality
+### Requirement: REQ-APT-019 Unit Tests and Code Quality
 
 Every new PHP service, controller, and background job MUST have PHPUnit tests with at least 3 test methods. Code MUST pass phpcs, phpstan, and phpmd linters.
 
@@ -475,7 +479,7 @@ Every new PHP service, controller, and background job MUST have PHPUnit tests wi
 
 ---
 
-### REQ-APT-020: Internationalization (i18n)
+### Requirement: REQ-APT-020 Internationalization (i18n)
 
 All user-visible strings in the portal, admin UI, and email templates MUST have translations in English and Dutch. No hardcoded strings.
 

--- a/openspec/changes/appointment-booking/tasks.md
+++ b/openspec/changes/appointment-booking/tasks.md
@@ -1,5 +1,13 @@
 # Tasks: Appointment Booking
 
+> **Leaf-first (ADR-022).** Calendar read/write and email/SMS dispatch are delegated to
+> `email-calendar-sync`, which consumes the OR `calendar` (`integration-calendar`) and `email`
+> (`integration-email`) leaves; payments/SMS go through openconnector. Where these tasks
+> reference `email-calendar-sync` for block-fetching or booking push, that path resolves to the
+> `calendar` leaf's VEVENT link/create API — pipelinq adds NO CalDAV client and NO local
+> calendar/email link schema. Build only the booking domain (Service/Resource/Booking/
+> WalkInTicket, slots, skill routing, deposits, no-show, walk-in queue, portal).
+
 ## Section 0: Deduplication Check
 
 ### Task 0.1: Verify no overlap with existing services [MVP]

--- a/openspec/changes/email-calendar-sync/proposal.md
+++ b/openspec/changes/email-calendar-sync/proposal.md
@@ -33,58 +33,61 @@ This gap directly blocks the marketing automation features that the market deman
 
 ## Solution
 
-Implement email and calendar synchronisation using the existing `emailLink` and `calendarLink` OpenRegister schemas defined in ADR-000:
+**Leaf-first (ADR-022).** The link-table, sidebar timeline, and follow-up-event-creation concepts in this change map directly onto two OpenRegister integration leaves that already own this functionality fleet-wide:
 
-1. **EmailSyncJob** — ITimedJob background job running every 5 minutes, fetching new messages from Nextcloud Mail via `OCP\Mail\IMailManager` and creating `emailLink` objects for matched CRM entities.
-2. **EmailSyncService** — matching logic: look up sender/recipient addresses against `contact.email` and `client.email`; fall back to domain-to-organization matching for unknown senders.
-3. **CalendarSyncService** — bidirectional calendar link management: create `calendarLink` objects from Nextcloud Calendar events that include attendees matching CRM contacts, and allow creating calendar follow-up events directly from entity context.
-4. **EmailSyncController** — REST API for per-user sync settings (which mail account to index, sync toggle, public-domain exclusion list).
-5. **Email Timeline UI** — `EmailTimelineCard.vue` component displayed on client, contact, lead, and request detail views showing linked emails with subject, date, direction, and a link to open the full message in Nextcloud Mail.
-6. **Calendar Events UI** — `CalendarEventCard.vue` component displayed on entity detail views showing upcoming and past linked calendar events, with a button to schedule a new follow-up event.
-7. **Automation trigger types** — register `email.received` and `calendar.event.start` as valid automation trigger values so that the existing automation engine can react to communication events.
+- **`email` leaf** (`openregister/.../integration-email`) — `EmailProvider` + `CnEmailTab` + `CnEmailCard`. Backed by OR's shipped `EmailService`/`EmailsController` (links Nextcloud Mail messages to OR objects via `openregister_email_links`, caches subject/sender/date, reverse-lookup by sender). Note: the email leaf is **link-only** — compose/send stays out of scope.
+- **`calendar` leaf** (`openregister/.../integration-calendar`) — `CalendarProvider` + `CnCalendarTab` + `CnCalendarCard`. Backed by OR's shipped `CalendarEventService`/`CalendarEventsController` (link/create/unlink VEVENT, attendee handling, `X-OPENREGISTER-*` reverse discovery, the "Add meeting" inline create flow).
+
+Building pipelinq-local `emailLink`/`calendarLink` schemas, an `EmailSyncService`/`CalendarSyncService`, and `EmailTimelineCard`/`CalendarEventCard` Vue components would reproduce three ADR-022 review-blocking anti-patterns at once — **parallel link tables**, **duplicate sidebar tab systems**, and **app-local "linked emails/events" that mirror an OR integration**. This change therefore **consumes the leaves** instead:
+
+1. **Enable the leaves on CRM detail pages via the app manifest (ADR-024).** Add `email` and `calendar` to the `linkedTypes` of the `client`, `contact`, `lead`, and `request` schemas so the `CnEmailTab`/`CnEmailCard` and `CnCalendarTab`/`CnCalendarCard` widgets render on those detail pages — no per-app timeline component, no per-app link schema, no per-app sync service.
+2. **CRM email-to-entity matching (genuinely app-specific, stays in pipelinq).** A thin `EmailMatchJob` (`ITimedJob`, every 5 minutes) resolves a Mail message's sender/recipient against `contact.email` / `client.email` (falling back to domain-to-organization matching, skipping public domains) and then calls the **email leaf's link API** to attach the message to the matched OR object. Pipelinq owns the CRM matching rule; OR owns the link record.
+3. **Follow-up events use the calendar leaf's create flow.** "Schedule follow-up" from a lead/request opens the `CnCalendarTab` inline create form (attendees pre-filled from the linked contact via the contacts integration) — pipelinq does not implement its own `createFollowUpEvent`.
+4. **Per-user sync configuration** for the matching job (which mail account to index, sync toggle, public-domain exclusion list) stays a thin pipelinq setting; the leaf owns display/storage of the links themselves.
+5. **Automation trigger types (genuinely app-specific, stays in pipelinq).** Register `email.received` and `calendar.event.start` as valid `automation` trigger values; the matching job and the calendar leaf's link events drive the existing pipelinq automation engine.
 
 ## Scope
 
 ### In scope
 
-- `emailLink` objects created by background job from Nextcloud Mail (poll-based, every 5 minutes)
-- `calendarLink` objects created from Nextcloud Calendar events (poll-based)
-- Email-to-contact matching by exact email address (`contact.email`, `client.email`)
-- Domain-to-organization matching for corporate email domains (skips public domains: gmail, outlook, yahoo, etc.)
-- Per-user sync configuration: select mail account, enable/disable sync, exclude email addresses
-- Email timeline display on client, contact, lead, and request detail views
-- Calendar event timeline display on lead, request, and client detail views
-- Create follow-up calendar event from entity context (pre-fills attendees from linked contacts)
-- Automation trigger types: `email.received`, `calendar.event.start`
-- Sync status display: last sync timestamp, error count, sync toggle
+- Enable the `email` + `calendar` leaves on `client`, `contact`, `lead`, `request` detail pages via the app manifest (add to each schema's `linkedTypes`)
+- `EmailMatchJob` (poll-based, every 5 minutes): resolve a Mail message's sender/recipient and link it to the matched OR object **through the email leaf's link API**
+- Email-to-contact matching by exact email address (`contact.email`, `client.email`) — pipelinq CRM rule
+- Domain-to-organization matching for corporate email domains (skips public domains: gmail, outlook, yahoo, etc.) — pipelinq CRM rule
+- Per-user sync configuration for the matching job: select mail account, enable/disable sync, exclude email addresses
+- Automation trigger types: `email.received`, `calendar.event.start` — pipelinq automation engine
+- Sync status display for the matching job: last run timestamp, count linked, error count
 
 ### Out of scope
 
-- Email compose and send from within Pipelinq (requires Mail app plugin API — V2)
-- Email template library and marketing campaign sequences (V2)
+- **Email link-table, email timeline UI, calendar link-table, calendar timeline UI, and follow-up-event create flow** — all owned by the `email` and `calendar` OR integration leaves (ADR-022); pipelinq consumes them, does not rebuild them
+- Pipelinq-local `emailLink` / `calendarLink` schemas — superseded by `openregister_email_links` / the calendar leaf's link table
+- Email compose and send from within Pipelinq (the email leaf is link-only; sending handled by n8n / openconnector workflows)
+- Email template library and marketing campaign sequences (V2; see `marketing-segmentation-and-blast`)
 - Bulk email / mass marketing sends (V3)
 - Real-time push (WebSocket/webhook from Mail) — poll only in this change
 - Email attachment management inside CRM (OpenRegister FileService handles this separately)
-- "Link to Pipelinq" action in Nextcloud Mail sidebar (requires Nextcloud Mail plugin — V2)
 - Sync monitoring admin dashboard (V2)
 
 ## Acceptance Criteria
 
 1. **GIVEN** a Nextcloud Mail account is configured for sync, **WHEN** an email is exchanged with a known contact's email address, **THEN** an `emailLink` object is created within 5 minutes linking the email to the contact and its parent client.
 
-2. **GIVEN** an `emailLink` exists for a client, **WHEN** an agent views the client detail page, **THEN** a chronological email timeline is visible with subject, date, direction, and a link to open the message in Nextcloud Mail.
+2. **GIVEN** the matching job has linked an email to a client, **WHEN** an agent views the client detail page, **THEN** the email leaf's `CnEmailTab`/`CnEmailCard` renders a chronological email timeline (subject, date, direction, open-in-Mail link) — no pipelinq-local timeline component is involved.
 
-3. **GIVEN** a lead exists with a linked contact, **WHEN** the agent clicks "Schedule follow-up" on the lead detail page, **THEN** a calendar event creation dialog opens pre-filled with the contact's email as attendee, and on save a `calendarLink` object is created linking the event to the lead.
+3. **GIVEN** a lead exists with a linked contact, **WHEN** the agent uses the calendar leaf's inline create flow on the lead detail page, **THEN** a follow-up VEVENT is created (attendees pre-filled from the linked contact) and linked to the lead via the calendar leaf — no pipelinq-local `calendarLink` object is created.
 
-4. **GIVEN** a calendar event exists for a meeting with a known contact, **WHEN** an agent views the contact detail page, **THEN** linked calendar events are displayed with title, date/time, and status.
+4. **GIVEN** a calendar event exists for a meeting with a known contact, **WHEN** an agent views the contact detail page, **THEN** the calendar leaf's `CnCalendarCard` displays the linked event with title, date/time, and status.
 
-5. **GIVEN** an agent configures sync settings, **WHEN** they disable sync for a specific mail account, **THEN** no new `emailLink` objects are created from that account's emails.
+5. **GIVEN** an agent configures sync settings, **WHEN** they disable sync for a specific mail account, **THEN** the `EmailMatchJob` creates no new email links from that account.
 
-6. **GIVEN** an automation with trigger type `email.received`, **WHEN** a new inbound `emailLink` is created for an entity, **THEN** the automation engine evaluates and executes matching automations for that entity.
+6. **GIVEN** an automation with trigger type `email.received`, **WHEN** the matching job links a new inbound email to an entity, **THEN** the automation engine evaluates and executes matching automations for that entity.
 
 ## Dependencies
 
 - **client-management** (completed) — Clients and contacts must exist for email address matching
-- **OpenRegister** — `emailLink` and `calendarLink` schemas must be registered
+- **OpenRegister `email` leaf** (`integration-email`) — provides `EmailProvider`, `CnEmailTab`, `CnEmailCard`, `openregister_email_links`; pipelinq links via its API
+- **OpenRegister `calendar` leaf** (`integration-calendar`) — provides `CalendarProvider`, `CnCalendarTab`, `CnCalendarCard`, VEVENT link/create; pipelinq enables it on detail pages
+- **OpenRegister pluggable integration registry** (ADR-019) + **app manifest** (ADR-024) — the mechanism that places the leaf widgets on detail pages
 - **crm-workflow-automation** — Automation engine must accept `email.received` and `calendar.event.start` trigger types
-- **Nextcloud OCP interfaces**: `OCP\Mail\IMailManager`, `OCP\Calendar\ICalendarQuery`, `OCP\IUserSession`
+- **Nextcloud OCP interfaces**: `OCP\Mail\IMailManager` (matching job only); calendar/link surfaces are mediated by the OR leaves

--- a/openspec/changes/email-calendar-sync/specs/email-calendar-sync/spec.md
+++ b/openspec/changes/email-calendar-sync/specs/email-calendar-sync/spec.md
@@ -2,321 +2,206 @@
 
 ## Purpose
 
-Add email and calendar synchronisation to Pipelinq by indexing `emailLink` and `calendarLink` objects from Nextcloud Mail and Calendar, matching communications to CRM entities, and exposing linked communications on entity detail views. Enables the automation engine to react to email and calendar events.
+Surface email and calendar communications on Pipelinq CRM detail pages by **consuming the OpenRegister `email` and `calendar` integration leaves** (ADR-022), and add CRM-specific email-to-entity matching plus automation triggers on top. No pipelinq-local link schemas, timeline components, or sync services are introduced — the link tables, sidebar tabs, and follow-up-event create flow are owned by the leaves.
 
 **Standards**: Schema.org (`schema:CommunicateAction`, `schema:Event`), iCalendar (RFC 5545), vCard (RFC 6350 email field)
-**Feature tier**: V1 (email sync, calendar sync, timeline UI), V2 (automation triggers)
-**Entities used**: `emailLink`, `calendarLink` (both defined in ADR-000 — no new schemas)
-**OCP interfaces**: `OCP\Mail\IMailManager`, `OCP\Calendar\ICalendarQuery`, `OCP\Calendar\IManager`
+**Feature tier**: V1 (leaf enablement, email matching), V2 (automation triggers)
+**OR leaves consumed**: `email` (`integration-email`), `calendar` (`integration-calendar`) via the pluggable integration registry (ADR-019) and app manifest (ADR-024)
+**OCP interfaces**: `OCP\Mail\IMailManager` (matching job only)
 
 ---
 
-## Requirements
+## ADDED Requirements
+
+### Requirement: Enable email + calendar leaves on CRM detail pages
+
+The app manifest MUST add `email` and `calendar` to the `linkedTypes` of the `client`, `contact`, `lead`, and `request` schemas so that the leaves' tabs and cards render on those detail pages. The system MUST NOT define pipelinq-local `emailLink` or `calendarLink` schemas.
+
+#### Scenario: Email tab appears on client detail
+
+- **GIVEN** the Nextcloud Mail app is installed and the `client` schema lists `email` in `linkedTypes`
+- **WHEN** an agent opens a client detail page
+- **THEN** the `email` leaf's `CnEmailTab` MUST render the client's linked emails
+- **AND** no pipelinq-local email-timeline component is loaded
+
+#### Scenario: Calendar card appears on lead detail
+
+- **GIVEN** the Nextcloud Calendar app is installed and the `lead` schema lists `calendar` in `linkedTypes`
+- **WHEN** an agent opens a lead detail page
+- **THEN** the `calendar` leaf's `CnCalendarCard` MUST render the lead's linked events
+
+#### Scenario: No pipelinq-local link schema is registered
+
+- **GIVEN** the pipelinq register file `lib/Settings/pipelinq_register.json`
+- **WHEN** the register is imported
+- **THEN** it MUST NOT contain an `emailLink` or `calendarLink` schema definition
 
 ---
 
-### REQ-ECS-001: EmailLink Seed Data
+### Requirement: CRM email-to-entity matching job
 
-The system MUST include realistic seed `emailLink` objects in `lib/Settings/pipelinq_register.json` so that the feature can be tested and demonstrated on a fresh install.
+The system MUST run an `ITimedJob` (`EmailMatchJob`) every 5 minutes that resolves a Nextcloud Mail message's sender/recipient to a CRM entity and links the message to that entity **through the `email` leaf's link API** (`openregister_email_links`), not through a pipelinq-local table.
 
-**Feature tier**: V1
-
-#### Scenario: Seed data loaded on install
-
-- **GIVEN** a fresh Pipelinq installation
-- **WHEN** the repair step imports `pipelinq_register.json`
-- **THEN** at least 3 `emailLink` objects MUST be available in the register
-- AND re-importing MUST NOT create duplicates (matched by slug)
-
----
-
-### REQ-ECS-002: CalendarLink Seed Data
-
-The system MUST include realistic seed `calendarLink` objects in `lib/Settings/pipelinq_register.json`.
-
-**Feature tier**: V1
-
-#### Scenario: Calendar seed data loaded on install
-
-- **GIVEN** a fresh Pipelinq installation
-- **WHEN** the repair step imports `pipelinq_register.json`
-- **THEN** at least 3 `calendarLink` objects MUST be available in the register
-- AND re-importing MUST NOT create duplicates (matched by slug)
-
----
-
-### REQ-ECS-003: Email Sync Background Job
-
-The system MUST run an `ITimedJob` background job every 5 minutes that fetches new emails from Nextcloud Mail and creates `emailLink` objects for matched CRM entities.
-
-**Feature tier**: V1
-
-#### Scenario: New inbound email from known contact
+#### Scenario: New inbound email from known contact is linked via the leaf
 
 - **GIVEN** a contact exists with email address `contact@example.nl`
 - **AND** sync is enabled for the Pipelinq mail account
 - **WHEN** a new email arrives from `contact@example.nl`
-- **THEN** an `emailLink` object MUST be created within 5 minutes
-- AND `linkedEntityType` MUST be `contact`
-- AND `linkedEntityId` MUST be the UUID of the matching contact
-- AND `direction` MUST be `inbound`
+- **THEN** within 5 minutes the message MUST be linked to that contact via the email leaf
+- **AND** the link MUST be visible in the leaf's `CnEmailTab` on the contact detail page
 
-#### Scenario: Duplicate email is not re-indexed
+#### Scenario: Duplicate email is not re-linked
 
-- **GIVEN** an `emailLink` with `messageId` X already exists
-- **WHEN** the sync job runs again
-- **THEN** no new `emailLink` is created for message X
-- AND the existing record is not modified
+- **GIVEN** the email leaf already holds a link for message X on the matched entity
+- **WHEN** the matching job runs again
+- **THEN** no duplicate link is created
 
 #### Scenario: Sync disabled for account
 
 - **GIVEN** the user has disabled sync for a mail account
-- **WHEN** the EmailSyncJob runs
-- **THEN** no `emailLink` objects are created from that account's emails
+- **WHEN** the `EmailMatchJob` runs
+- **THEN** no email links are created from that account's messages
 
 ---
 
-### REQ-ECS-004: Email-to-Contact Matching
+### Requirement: Email-to-contact matching rule
 
-The `EmailSyncService` MUST match email sender/recipient addresses to `contact.email` and `client.email` fields in OpenRegister.
-
-**Feature tier**: V1
+The `EmailMatchJob` MUST match sender/recipient addresses to `contact.email` and `client.email` fields in OpenRegister. This CRM matching rule is pipelinq-specific and stays in pipelinq.
 
 #### Scenario: Match by exact email address
 
 - **GIVEN** a contact exists with `email: "j.devries@gemeente-utrecht.nl"`
 - **WHEN** an email is processed with sender `j.devries@gemeente-utrecht.nl`
-- **THEN** `matchEmailToEntities("j.devries@gemeente-utrecht.nl")` MUST return that contact's entity reference
+- **THEN** the matcher MUST return that contact's entity reference
 
 #### Scenario: No match returns empty
 
 - **GIVEN** no contact or client has email `unknown@example.nl`
-- **WHEN** `matchEmailToEntities("unknown@example.nl")` is called
-- **THEN** it MUST return an empty array
+- **WHEN** the matcher is called for `unknown@example.nl`
+- **THEN** it MUST return an empty result and create no link
 
 ---
 
-### REQ-ECS-005: Domain-to-Organization Matching
+### Requirement: Domain-to-organization matching rule
 
-When no exact email match is found, the service MUST attempt to match the sender's domain against client organizations — unless the domain is a public email provider.
-
-**Feature tier**: V1
+When no exact email match is found, the matcher MUST attempt to match the sender's domain against client organizations — unless the domain is a public email provider.
 
 #### Scenario: Corporate domain matched to organization
 
 - **GIVEN** a client of type `organization` with email `info@bakker-installaties.nl` exists
 - **AND** no individual contact has the address `p.bakker@bakker-installaties.nl`
 - **WHEN** an email from `p.bakker@bakker-installaties.nl` is processed
-- **THEN** `matchDomainToOrganization("bakker-installaties.nl")` MUST return the organization's entity reference
+- **THEN** the matcher MUST return the organization's entity reference
 
 #### Scenario: Public domain is not matched
 
-- **GIVEN** no contact has address `iemand@gmail.com`
-- **WHEN** `isPublicDomain("gmail.com")` is called
-- **THEN** it MUST return `true`
-- AND domain matching MUST NOT be attempted for `gmail.com`
+- **GIVEN** an email from `iemand@gmail.com`
+- **WHEN** the matcher evaluates `gmail.com`
+- **THEN** it MUST treat the domain as public and skip domain matching
 
 ---
 
-### REQ-ECS-006: Email Timeline on Entity Detail Views
+### Requirement: Follow-up events use the calendar leaf create flow
 
-The system MUST display a chronological list of linked `emailLink` objects on client, contact, lead, and request detail views.
+Creating a follow-up event from a lead, request, or client detail page MUST use the `calendar` leaf's inline create flow (`CnCalendarTab`). The system MUST NOT implement a pipelinq-local `createFollowUpEvent` or `calendarLink` write.
 
-**Feature tier**: V1
-
-#### Scenario: Emails visible on client detail
-
-- **GIVEN** one or more `emailLink` objects are linked to a client
-- **WHEN** an agent opens the client detail page
-- **THEN** an email timeline MUST be displayed showing: direction icon, subject, sender or recipient, and date
-- AND each entry MUST include a link that opens the email in Nextcloud Mail
-
-#### Scenario: Empty state when no emails linked
-
-- **GIVEN** no `emailLink` objects are linked to an entity
-- **WHEN** the agent views that entity's detail page
-- **THEN** the `EmailTimelineCard` MUST display an empty state message
-- AND the empty state MUST NOT show an error
-
----
-
-### REQ-ECS-007: Email Exclude Action
-
-An agent MUST be able to exclude a specific email from future sync visibility by marking it `excluded: true` on the `emailLink` object.
-
-**Feature tier**: V1
-
-#### Scenario: Excluded email is hidden
-
-- **GIVEN** an `emailLink` with `excluded: true`
-- **WHEN** the email timeline is rendered for the linked entity
-- **THEN** the excluded email MUST NOT appear in the visible timeline
-
-#### Scenario: Exclude action saves to register
-
-- **GIVEN** an email is visible in the timeline
-- **WHEN** the agent clicks "Exclude"
-- **THEN** the `emailLink.excluded` field MUST be set to `true` via `ObjectService.saveObject()`
-- AND the email MUST disappear from the timeline without a page reload
-
----
-
-### REQ-ECS-008: Calendar Sync Background Job
-
-The `EmailSyncJob` MUST also invoke `CalendarSyncService::syncUserCalendar()` to index new calendar events and create `calendarLink` objects.
-
-**Feature tier**: V1
-
-#### Scenario: Calendar event matched to CRM entity
-
-- **GIVEN** a calendar event exists with attendee `m.vanderberg@stichtingwelzijn.nl`
-- **AND** a contact exists with that email address
-- **WHEN** the sync job processes that event
-- **THEN** a `calendarLink` object MUST be created with `linkedEntityType: contact` and `createdFrom: calendar`
-
-#### Scenario: Duplicate calendar event not re-indexed
-
-- **GIVEN** a `calendarLink` with `eventUid` Y already exists
-- **WHEN** the sync job runs again
-- **THEN** no new `calendarLink` is created for event Y
-
----
-
-### REQ-ECS-009: Calendar Events on Entity Detail Views
-
-The system MUST display linked `calendarLink` objects on lead, request, and client detail views.
-
-**Feature tier**: V1
-
-#### Scenario: Calendar events visible on lead detail
-
-- **GIVEN** one or more `calendarLink` objects are linked to a lead
-- **WHEN** an agent opens the lead detail page
-- **THEN** a calendar events section MUST display each event with: title, start/end datetime, attendees, and status badge
-
-#### Scenario: Status badge uses correct colour
-
-- **GIVEN** a `calendarLink` with `status: scheduled`
-- **WHEN** rendered in `CalendarEventCard`
-- **THEN** the `CnStatusBadge` MUST use the colour associated with `scheduled`
-
----
-
-### REQ-ECS-010: Follow-up Calendar Event Creation
-
-An agent MUST be able to create a follow-up calendar event from entity context. The event is created in the user's primary Nextcloud Calendar and a `calendarLink` object is saved in OpenRegister.
-
-**Feature tier**: V1
-
-#### Scenario: Follow-up event created from lead
+#### Scenario: Follow-up event created via the leaf
 
 - **GIVEN** a lead detail page is open with a linked contact
-- **WHEN** the agent clicks "Schedule follow-up" and fills the event form
-- **THEN** `CalendarSyncService::createFollowUpEvent()` MUST create the event via `ICalendarManager`
-- AND a `calendarLink` object MUST be saved with `createdFrom: pipelinq` and `linkedEntityType: lead`
-- AND the new event MUST appear in the calendar events section without a page reload
+- **WHEN** the agent uses the calendar leaf's "Add meeting" create flow
+- **THEN** the VEVENT MUST be created and linked to the lead by the calendar leaf
+- **AND** the new event MUST appear in the leaf's `CnCalendarCard` without a page reload
 
-#### Scenario: Follow-up dialog pre-fills attendees
+#### Scenario: Follow-up form pre-fills attendees from contact
 
 - **GIVEN** a lead is linked to a contact with email `j.devries@gemeente-utrecht.nl`
-- **WHEN** the "Schedule follow-up" dialog opens
+- **WHEN** the calendar leaf's create form opens from that lead
 - **THEN** the attendees field MUST be pre-filled with `j.devries@gemeente-utrecht.nl`
 
 ---
 
-### REQ-ECS-011: Per-User Sync Settings
+### Requirement: Per-user matching-job settings
 
-Each Nextcloud user MUST be able to configure their own sync preferences independently via the in-app settings modal.
-
-**Feature tier**: V1
+Each Nextcloud user MUST be able to configure their own matching-job preferences (mail account to index, sync enabled toggle, excluded addresses) independently via the in-app settings modal. These settings govern the matching job only; link display/storage is owned by the email leaf.
 
 #### Scenario: Settings saved per user
 
 - **GIVEN** two users have different mail account configurations
-- **WHEN** each saves their sync settings via `POST /api/sync/email/settings`
+- **WHEN** each saves their sync settings
 - **THEN** each user's settings MUST be stored independently in `IAppConfig`
-- AND changing one user's settings MUST NOT affect the other
+- **AND** changing one user's settings MUST NOT affect the other
 
 #### Scenario: Settings surfaced in user settings modal
 
 - **GIVEN** a user opens the in-app settings modal (gear menu)
-- **WHEN** the SyncSettingsSection is rendered
-- **THEN** it MUST show: mail account selector, sync enabled toggle, excluded addresses field, last sync status, and a "Sync now" button
+- **WHEN** the sync settings section is rendered
+- **THEN** it MUST show: mail account selector, sync enabled toggle, excluded addresses field, last run status, and a "Sync now" button
 
 ---
 
-### REQ-ECS-012: Sync Status Display
+### Requirement: Matching-job status display
 
-The sync settings UI MUST display the last sync timestamp, count of indexed items, and any error messages from the last run.
+The sync settings UI MUST display the last matching-job run timestamp, count of links created, and any error messages from the last run.
 
-**Feature tier**: V1
+#### Scenario: Status shows last run time
 
-#### Scenario: Status shows last sync time
-
-- **GIVEN** a sync run completed successfully at 14:30
+- **GIVEN** a matching-job run completed successfully at 14:30
 - **WHEN** the user views sync settings
 - **THEN** the status MUST show "Last synced: [date] at 14:30" (formatted per user locale)
 
-#### Scenario: Status shows error when sync failed
+#### Scenario: Status shows error when run failed
 
-- **GIVEN** the last sync run produced an error (e.g., mail account unreachable)
+- **GIVEN** the last run produced an error (e.g., mail account unreachable)
 - **WHEN** the user views sync settings
 - **THEN** the status MUST show an error indicator with the error message
-- AND the error message MUST NOT expose internal paths, SQL, or stack traces (per ADR-005)
+- **AND** the error message MUST NOT expose internal paths, SQL, or stack traces (per ADR-005)
 
 ---
 
-### REQ-ECS-013: Automation Trigger Types
+### Requirement: Automation trigger types
 
-The `automation` entity MUST accept `email.received` and `calendar.event.start` as valid `trigger` values.
+The `automation` entity MUST accept `email.received` and `calendar.event.start` as valid `trigger` values. This is pipelinq-specific automation wiring and stays in pipelinq.
 
-**Feature tier**: V2
-
-#### Scenario: email.received automation triggers on new emailLink
+#### Scenario: email.received automation triggers on new linked email
 
 - **GIVEN** an `automation` with `trigger: email.received` and `isActive: true` exists
-- **AND** a new inbound `emailLink` is created for a client
-- **WHEN** the EmailSyncService creates the emailLink
+- **WHEN** the `EmailMatchJob` links a new inbound email to a client
 - **THEN** the automation engine MUST evaluate trigger conditions against the linked entity
-- AND execute configured actions if conditions match
+- **AND** execute configured actions if conditions match
 
 #### Scenario: calendar.event.start automation triggers on event start
 
 - **GIVEN** an `automation` with `trigger: calendar.event.start` exists
-- **AND** a `calendarLink` with `status: scheduled` has a `startDate` in the next sync window
-- **WHEN** the CalendarSyncService processes the event
-- **THEN** the automation engine MUST be notified and evaluate the trigger
+- **AND** a calendar-leaf-linked event has a `startDate` in the next evaluation window
+- **WHEN** the automation engine processes the window
+- **THEN** it MUST evaluate the trigger against the linked entity
 
 ---
 
-### REQ-ECS-014: Unit Tests
+### Requirement: Unit tests
 
 Every new PHP service and controller MUST have PHPUnit tests with at least 3 test methods per class.
 
-**Feature tier**: V1
+#### Scenario: Matcher tests cover matching logic
 
-#### Scenario: Service tests cover matching logic
-
-- **GIVEN** `EmailSyncServiceTest.php` exists
+- **GIVEN** `EmailMatchJobTest.php` (or the matcher service test) exists
 - **WHEN** `composer test` runs
-- **THEN** tests for `matchEmailToEntities`, `isPublicDomain`, and `isDuplicate` MUST pass
+- **THEN** tests for exact-address match, domain match, and public-domain skip MUST pass
 
-#### Scenario: Integration error paths tested
+#### Scenario: Settings controller error paths tested
 
-- **GIVEN** `EmailSyncControllerTest.php` exists
+- **GIVEN** the sync-settings controller test exists
 - **THEN** tests MUST cover: 200 success, 401 unauthenticated, and 400 invalid input for each endpoint
 
 ---
 
-### REQ-ECS-015: Translation Coverage
+### Requirement: Translation coverage
 
-All user-visible strings in sync components MUST have `en.json` and `nl.json` entries.
+All user-visible strings in the sync-settings UI MUST have `en.json` and `nl.json` entries.
 
-**Feature tier**: V1
+#### Scenario: No hardcoded strings in sync settings
 
-#### Scenario: No hardcoded strings in sync components
-
-- **GIVEN** `EmailTimelineCard.vue`, `CalendarEventCard.vue`, `SyncSettingsSection.vue`, and `FollowUpEventDialog.vue` are rendered
+- **GIVEN** the sync settings section is rendered
 - **WHEN** the app language is set to Dutch (nl)
 - **THEN** all labels, buttons, empty states, and error messages MUST display in Dutch
-- AND no raw English string MUST appear in Dutch locale
+- **AND** no raw English string MUST appear in Dutch locale

--- a/openspec/changes/email-calendar-sync/tasks.md
+++ b/openspec/changes/email-calendar-sync/tasks.md
@@ -1,275 +1,139 @@
 # Tasks: email-calendar-sync
 
+> **Leaf-first (ADR-022).** The link tables, sidebar timeline tabs/cards, and follow-up-event
+> create flow are owned by the OpenRegister `email` (`integration-email`) and `calendar`
+> (`integration-calendar`) leaves. This change consumes the leaves via the app manifest
+> (ADR-024 / ADR-019) and adds only the pipelinq-specific CRM email-matching job, per-user
+> settings, and automation triggers. Do NOT build pipelinq-local `emailLink`/`calendarLink`
+> schemas, `EmailSyncService`/`CalendarSyncService`, or `EmailTimelineCard`/`CalendarEventCard`.
+
 ## Section 0: Deduplication Check
 
-### Task 0.1: Verify no overlap with existing services [MVP]
-- **Spec ref**: ADR-012
-- **Files**: Search `openspec/specs/`, `openregister/lib/Service/`, existing Pipelinq services
+### Task 0.1: Verify no overlap with OR leaves [MVP]
+- **Spec ref**: ADR-012, ADR-022
+- **Files**: Search `openregister/openspec/changes/integration-email`, `integration-calendar`, existing Pipelinq services
 - **Findings**:
-  - `ObjectService` — reused for all emailLink/calendarLink CRUD (no custom CRUD built)
-  - `createObjectStore` — reused for Pinia stores (no hand-rolled stores)
-  - No prior email or calendar sync service exists in Pipelinq
-  - No overlap found with OpenRegister's `ObjectService`, `RegisterService`, `SchemaService`, or `ConfigurationService`
-  - `CnStatusBadge` from `@conduction/nextcloud-vue` reused for calendar event status badges
-- [ ] Document deduplication check findings in PR description before merging
+  - `email` leaf owns the email link table (`openregister_email_links`), `EmailProvider`, `CnEmailTab`, `CnEmailCard` — REUSE, do not rebuild
+  - `calendar` leaf owns VEVENT link/create, `CalendarProvider`, `CnCalendarTab`, `CnCalendarCard` — REUSE, do not rebuild
+  - Pipelinq retains ONLY: CRM email→entity matching rule, the matching job that calls the email leaf's link API, per-user matching settings, and automation trigger wiring
+  - No pipelinq-local link schema, sync service, or timeline component is created (ADR-022 anti-patterns: parallel link tables, duplicate sidebar tab systems)
+- [ ] Document leaf-consumption decision + ADR-022 citation in PR description before merging
 
 ---
 
-## Section 1: Seed Data [V1]
+## Section 1: Enable leaves on CRM detail pages [V1]
 
-### Task 1.1: Add emailLink seed objects to pipelinq_register.json [V1]
-- **Spec ref**: REQ-ECS-001
-- **Files**: `lib/Settings/pipelinq_register.json`
-- **Acceptance**: 5 emailLink seed objects with realistic Dutch values, varied entityTypes (lead, client, contact, request), both directions, unique slugs
-- [ ] Add 5 emailLink objects under `components.objects[]` with `@self` envelope (`register: pipelinq`, `schema: email-link`, unique slug)
-- [ ] Each object has `messageId`, `subject`, `sender`, `recipients`, `date`, `linkedEntityType`, `linkedEntityId`, `direction`, `syncSource`
-- [ ] Verify slugs are unique and match `email-link-001` through `email-link-005` pattern
-
-### Task 1.2: Add calendarLink seed objects to pipelinq_register.json [V1]
-- **Spec ref**: REQ-ECS-002
-- **Files**: `lib/Settings/pipelinq_register.json`
-- **Acceptance**: 4 calendarLink seed objects with realistic Dutch event names, varied statuses and entity types, unique slugs
-- [ ] Add 4 calendarLink objects under `components.objects[]` with `@self` envelope (`register: pipelinq`, `schema: calendar-link`, unique slug)
-- [ ] Each object has `eventUid`, `title`, `startDate`, `endDate`, `attendees`, `linkedEntityType`, `linkedEntityId`, `status`, `createdFrom`
-- [ ] Include both `status: completed` and `status: scheduled` entries for realistic test scenarios
+### Task 1.1: Add `email` + `calendar` to schema linkedTypes [V1]
+- **Spec ref**: Requirement "Enable email + calendar leaves on CRM detail pages"
+- **Files**: `lib/Settings/pipelinq_register.json`, app manifest (ADR-024)
+- **Acceptance**: The leaf tabs/cards render on client, contact, lead, request detail pages
+- [ ] Add `email` and `calendar` to the `linkedTypes` of the `client`, `contact`, `lead`, `request` schemas
+- [ ] Confirm the app manifest declares the `email` + `calendar` leaf widget placements on those detail pages
+- [ ] Verify the register file contains NO `emailLink` or `calendarLink` schema definition (remove if present)
 
 ---
 
-## Section 2: Backend Services [V1]
+## Section 2: CRM email-matching job [V1]
 
-### Task 2.1: Create EmailSyncService [V1]
-- **Spec ref**: REQ-ECS-003, REQ-ECS-004, REQ-ECS-005
-- **Files**: `lib/Service/EmailSyncService.php`
-- **Acceptance**: Service matches emails to CRM entities, avoids duplicates, skips public domains
-- [ ] Implement `syncUserEmails(string $userId): int` — fetch messages via `OCP\Mail\IMailManager`, call matching, create emailLink objects, return count
-- [ ] Implement `matchEmailToEntities(string $address): array` — query `ObjectService::findObjects` on `contact` and `client` schemas filtering by email field
-- [ ] Implement `matchDomainToOrganization(string $domain): ?array` — extract domain, check against client organization emails
-- [ ] Implement `isPublicDomain(string $domain): bool` — return true for gmail.com, outlook.com, hotmail.com, yahoo.com, live.com, icloud.com
-- [ ] Implement `isDuplicate(string $messageId): bool` — query emailLink objects with `messageId` filter, return true if found
-- [ ] Use `ObjectService::saveObject($register, $schema, $data)` (3 positional args per ADR-015)
-- [ ] Add `@spec openspec/changes/email-calendar-sync/tasks.md#task-2.1` PHPDoc to class and all public methods
-
-### Task 2.2: Create CalendarSyncService [V1]
-- **Spec ref**: REQ-ECS-008, REQ-ECS-009, REQ-ECS-010
-- **Files**: `lib/Service/CalendarSyncService.php`
-- **Acceptance**: Service syncs calendar events, matches attendees to CRM entities, creates follow-up events
-- [ ] Implement `syncUserCalendar(string $userId): int` — query calendar events via `OCP\Calendar\ICalendarQuery`, match attendees, create calendarLink objects
-- [ ] Implement `matchAttendeesToEntities(array $attendeeEmails): array` — for each email, call `EmailSyncService::matchEmailToEntities()`
-- [ ] Implement `createFollowUpEvent(string $entityType, string $entityId, array $eventData, string $userId): array` — create event via `ICalendarManager`, save calendarLink with `createdFrom: pipelinq`
-- [ ] Implement `isDuplicate(string $eventUid): bool` — query calendarLink objects with `eventUid` filter
+### Task 2.1: Create EmailMatchJob + matcher [V1]
+- **Spec ref**: Requirements "CRM email-to-entity matching job", "Email-to-contact matching rule", "Domain-to-organization matching rule"
+- **Files**: `lib/BackgroundJob/EmailMatchJob.php`, `lib/Service/EmailMatchService.php`
+- **Acceptance**: Job matches Mail messages to CRM entities and links them THROUGH the email leaf's link API
+- [ ] Extend `OCP\BackgroundJob\TimedJob` with `setInterval(300)` (5 minutes)
+- [ ] Inject `IUserManager`, `IAppConfig`, `LoggerInterface`, `OCP\Mail\IMailManager`, and the OR email-leaf link client/service
+- [ ] Implement `matchEmailToEntities(string $address): array` — query `contact`/`client` schemas by email field
+- [ ] Implement `matchDomainToOrganization(string $domain): ?array` — corporate-domain fallback
+- [ ] Implement `isPublicDomain(string $domain): bool` — gmail/outlook/hotmail/yahoo/live/icloud
+- [ ] On match, call the email leaf's link API to attach the message to the matched OR object (do NOT write a pipelinq link table)
+- [ ] Skip messages the leaf has already linked (no duplicate links)
+- [ ] Per-user errors caught + logged; job continues for remaining users
+- [ ] Register in `appinfo/info.xml` under `<background-jobs>`
 - [ ] Add `@spec` PHPDoc to class and all public methods
 
-### Task 2.3: Create EmailSyncJob [V1]
-- **Spec ref**: REQ-ECS-003, REQ-ECS-008
-- **Files**: `lib/BackgroundJob/EmailSyncJob.php`
-- **Acceptance**: Job runs every 5 minutes via ITimedJob, calls both sync services for all users with sync enabled
-- [ ] Extend `OCP\BackgroundJob\TimedJob` with `setInterval(300)` (5 minutes)
-- [ ] Inject `EmailSyncService`, `CalendarSyncService`, `IUserManager`, `IAppConfig`, `LoggerInterface`
-- [ ] In `run()`: iterate users, check sync enabled in app config, call `syncUserEmails()` and `syncUserCalendar()`, log counts and any errors
-- [ ] Per-user errors MUST be caught and logged — job continues for remaining users (does not abort)
-- [ ] Register in `appinfo/info.xml` under `<background-jobs>`
-- [ ] Add `@spec` PHPDoc
+---
 
-### Task 2.4: Create EmailSyncController [V1]
-- **Spec ref**: REQ-ECS-011, REQ-ECS-012
+## Section 3: Per-user matching settings [V1]
+
+### Task 3.1: Create matching-settings controller [V1]
+- **Spec ref**: Requirements "Per-user matching-job settings", "Matching-job status display"
 - **Files**: `lib/Controller/EmailSyncController.php`, `appinfo/routes.php`
-- **Acceptance**: Settings endpoints save/load per-user config; trigger endpoint starts manual sync; status returns last run info
-- [ ] Implement `GET /api/sync/email/settings` → return current user's sync config from `IAppConfig`
-- [ ] Implement `POST /api/sync/email/settings` → validate and save sync config (account, enabled, excludedAddresses) to `IAppConfig`
-- [ ] Implement `POST /api/sync/email/trigger` → call `EmailSyncService::syncUserEmails()` + `CalendarSyncService::syncUserCalendar()` for current user, return count
-- [ ] Implement `GET /api/sync/email/status` → return last sync timestamp, email count, calendar count, last error (if any)
-- [ ] All endpoints derive user identity from `IUserSession` — NEVER trust frontend-sent user ID (ADR-005)
-- [ ] Error responses use static messages, never `$e->getMessage()` in JSONResponse (ADR-015)
-- [ ] Controller methods MUST be thin (<10 lines) — delegate logic to services (ADR-003)
-- [ ] Add routes to `appinfo/routes.php` (specific routes before any wildcard routes)
+- [ ] `GET /api/sync/email/settings` → current user's matching config from `IAppConfig`
+- [ ] `POST /api/sync/email/settings` → validate + save (account, enabled, excludedAddresses)
+- [ ] `POST /api/sync/email/trigger` → run the matching job for the current user, return count linked
+- [ ] `GET /api/sync/email/status` → last run timestamp, links-created count, last error
+- [ ] Derive user identity from `IUserSession` — never trust frontend-sent user ID (ADR-005)
+- [ ] Error responses use static messages, never `$e->getMessage()` (ADR-015)
+- [ ] Controller methods thin (<10 lines) — delegate to service (ADR-003)
 - [ ] Add `@spec` PHPDoc
 
----
-
-## Section 3: Unit Tests [V1]
-
-### Task 3.1: Unit tests for EmailSyncService [V1]
-- **Spec ref**: REQ-ECS-014
-- **Files**: `tests/Unit/Service/EmailSyncServiceTest.php`
-- **Acceptance**: ≥3 test methods; covers matching, public domain detection, and deduplication
-- [ ] Test `matchEmailToEntities()` returns correct entity when contact email matches
-- [ ] Test `matchEmailToEntities()` returns empty array for unknown address
-- [ ] Test `isPublicDomain()` returns true for gmail.com, false for corporate domain
-- [ ] Test `isDuplicate()` returns true when messageId already exists
-- [ ] Test `isDuplicate()` returns false when messageId is new
-- [ ] Mock `ObjectService` — do NOT use real DB in unit tests
-
-### Task 3.2: Unit tests for CalendarSyncService [V1]
-- **Spec ref**: REQ-ECS-014
-- **Files**: `tests/Unit/Service/CalendarSyncServiceTest.php`
-- **Acceptance**: ≥3 test methods covering attendee matching and duplicate detection
-- [ ] Test `matchAttendeesToEntities()` returns entities for known attendee emails
-- [ ] Test `isDuplicate()` correctly identifies existing calendarLink by eventUid
-- [ ] Test `createFollowUpEvent()` saves calendarLink with `createdFrom: pipelinq`
-
-### Task 3.3: Unit tests for EmailSyncJob [V1]
-- **Spec ref**: REQ-ECS-003
-- **Files**: `tests/Unit/BackgroundJob/EmailSyncJobTest.php`
-- **Acceptance**: ≥2 test methods covering normal run and per-user error handling
-- [ ] Test job calls `syncUserEmails()` for each user with sync enabled
-- [ ] Test job continues processing remaining users when one user's sync throws an exception
-
-### Task 3.4: Unit tests for EmailSyncController [V1]
-- **Spec ref**: REQ-ECS-011, REQ-ECS-014
-- **Files**: `tests/Unit/Controller/EmailSyncControllerTest.php`
-- **Acceptance**: ≥3 test methods per endpoint covering success, unauthorized, and validation errors
-- [ ] Test `GET /api/sync/email/settings` returns 200 with settings for authenticated user
-- [ ] Test `POST /api/sync/email/settings` returns 200 and saves config
-- [ ] Test `POST /api/sync/email/trigger` returns 200 with counts
-- [ ] Test unauthenticated request returns 401
+### Task 3.2: Create SyncSettingsSection.vue [V1]
+- **Spec ref**: Requirement "Per-user matching-job settings"
+- **Files**: `src/components/sync/SyncSettingsSection.vue`, `src/views/UserSettings.vue`
+- **Note**: Rendered inside `NcAppSettingsDialog`, NOT a routed page (ADR-004)
+- [ ] SPDX header first line
+- [ ] On `created()`: `GET /api/sync/email/settings`
+- [ ] Fields: mail account selector (`NcSelect` with `inputLabel`), enabled toggle (`NcCheckboxRadioSwitch`), excluded addresses
+- [ ] Status display: last run time, links-created count, error indicator
+- [ ] "Sync now" → `POST /api/sync/email/trigger`; Save → `POST /api/sync/email/settings`
+- [ ] All strings via `t('pipelinq', ...)`; import only from `@conduction/nextcloud-vue`
+- [ ] Register `<SyncSettingsSection />` in the UserSettings dialog content
 
 ---
 
-## Section 4: Frontend Components [V1]
+## Section 4: Automation trigger types [V2]
 
-### Task 4.1: Create EmailTimelineCard.vue [V1]
-- **Spec ref**: REQ-ECS-006, REQ-ECS-007
-- **Files**: `src/components/sync/EmailTimelineCard.vue`
-- **Acceptance**: Component shows linked emails per entity, supports exclude action, shows empty state
-- [ ] Add `<!-- SPDX-License-Identifier: EUPL-1.2 -->` as first line
-- [ ] Props: `entityType` (String, required), `entityId` (String, required)
-- [ ] On `created()`, fetch emailLink objects filtered by `linkedEntityType` and `linkedEntityId` using `emailLink` object store
-- [ ] Display list: direction icon (inbound=arrow-down, outbound=arrow-up), subject, sender/recipient, date formatted via Nextcloud locale
-- [ ] "Open in Mail" button: link to Nextcloud Mail (`generateUrl('/apps/mail')`)
-- [ ] "Exclude" button: calls `ObjectService.saveObject` to set `excluded: true`, removes from list on success
-- [ ] Empty state: `CnEmptyState` with translated message "No emails linked yet"
-- [ ] EVERY `await` on store actions MUST be wrapped in `try/catch` with `this.showError()` (ADR-015)
-- [ ] ALL strings via `this.t('pipelinq', 'key')` — no hardcoded strings (ADR-007)
-- [ ] Import only from `@conduction/nextcloud-vue` — NEVER from `@nextcloud/vue` (ADR-004)
-- [ ] All template components MUST be imported AND registered in `components: {}` (ADR-015)
-- [ ] `<style scoped>` using only `var(--color-*)` CSS variables (ADR-010)
-
-### Task 4.2: Create CalendarEventCard.vue [V1]
-- **Spec ref**: REQ-ECS-009, REQ-ECS-010
-- **Files**: `src/components/sync/CalendarEventCard.vue`
-- **Acceptance**: Component shows linked calendar events, supports opening follow-up dialog
-- [ ] Add SPDX header
-- [ ] Props: `entityType` (String, required), `entityId` (String, required)
-- [ ] Fetch calendarLink objects for entity on `created()`
-- [ ] Display events: title, formatted start/end datetime, attendees (comma-separated), `CnStatusBadge` for status
-- [ ] "Schedule follow-up" button opens `FollowUpEventDialog`
-- [ ] On dialog confirm, call `POST /api/sync/calendar/events` and refresh list
-- [ ] EVERY await wrapped in try/catch with user-facing error (ADR-004)
-- [ ] All strings translated (ADR-007)
-- [ ] `<style scoped>` with CSS variables only
-
-### Task 4.3: Create FollowUpEventDialog.vue [V1]
-- **Spec ref**: REQ-ECS-010
-- **Files**: `src/components/sync/FollowUpEventDialog.vue`
-- **Acceptance**: Dialog pre-fills attendees from linked contacts, creates calendar event and calendarLink on submit
-- [ ] Add SPDX header
-- [ ] Use `CnFormDialog` pattern (not `window.confirm()` or custom dialog — ADR-004)
-- [ ] Props: `entityType`, `entityId`, `prefillAttendees` (Array)
-- [ ] Fields: title, startDate (datetime-local), endDate (datetime-local), notes, attendees (pre-filled from `prefillAttendees`)
-- [ ] On submit: `POST /api/sync/email/trigger` with event data and entity reference (update route in controller per design)
-- [ ] Emit `event-created` on success so parent refreshes calendarLink list
-- [ ] All strings translated
-
-### Task 4.4: Create SyncSettingsSection.vue [V1]
-- **Spec ref**: REQ-ECS-011, REQ-ECS-012
-- **Files**: `src/components/sync/SyncSettingsSection.vue`
-- **Acceptance**: Settings section in UserSettings modal, loads/saves sync config, shows status
-- [ ] Add SPDX header
-- [ ] Use `CnSettingsCard` or `CnSettingsSection` wrapper
-- [ ] On `created()`: call `GET /api/sync/email/settings` to load current config
-- [ ] Fields: mail account selector (`NcSelect`, options from settings store), sync enabled toggle (`NcCheckboxRadioSwitch`), excluded addresses (text input)
-- [ ] Status display: last sync time, email count, calendar count, error indicator
-- [ ] "Sync now" button: calls `POST /api/sync/email/trigger`, shows spinner, displays result count
-- [ ] Save button: calls `POST /api/sync/email/settings`, shows success toast
-- [ ] All strings translated (en + nl)
-
----
-
-## Section 5: Wire Components into Detail Views [V1]
-
-### Task 5.1: Add email and calendar cards to ClientDetail.vue [V1]
-- **Spec ref**: REQ-ECS-006, REQ-ECS-009
-- **Files**: `src/views/clients/ClientDetail.vue`
-- **Acceptance**: Client detail shows EmailTimelineCard and CalendarEventCard sections
-- [ ] Import `EmailTimelineCard` and `CalendarEventCard`, register in `components: {}`
-- [ ] Add `<EmailTimelineCard :entity-type="'client'" :entity-id="clientId" />` in a `CnDetailCard` section below existing sections
-- [ ] Add `<CalendarEventCard :entity-type="'client'" :entity-id="clientId" />` below email timeline
-
-### Task 5.2: Add EmailTimelineCard to ContactDetail.vue [V1]
-- **Spec ref**: REQ-ECS-006
-- **Files**: `src/views/contacts/ContactDetail.vue`
-- [ ] Import and register `EmailTimelineCard`
-- [ ] Add `<EmailTimelineCard :entity-type="'contact'" :entity-id="contactId" />` section
-
-### Task 5.3: Add email and calendar cards to LeadDetail.vue [V1]
-- **Spec ref**: REQ-ECS-006, REQ-ECS-009, REQ-ECS-010
-- **Files**: `src/views/leads/LeadDetail.vue`
-- [ ] Import and register `EmailTimelineCard` and `CalendarEventCard`
-- [ ] Add `<EmailTimelineCard :entity-type="'lead'" :entity-id="leadId" />` section
-- [ ] Add `<CalendarEventCard :entity-type="'lead'" :entity-id="leadId" />` section
-
-### Task 5.4: Add email and calendar cards to RequestDetail.vue [V1]
-- **Spec ref**: REQ-ECS-006, REQ-ECS-009
-- **Files**: `src/views/requests/RequestDetail.vue`
-- [ ] Import and register `EmailTimelineCard` and `CalendarEventCard`
-- [ ] Add `<EmailTimelineCard :entity-type="'request'" :entity-id="requestId" />` section
-- [ ] Add `<CalendarEventCard :entity-type="'request'" :entity-id="requestId" />` section
-
-### Task 5.5: Add SyncSettingsSection to UserSettings.vue [V1]
-- **Spec ref**: REQ-ECS-011
-- **Files**: `src/views/UserSettings.vue`
-- **Note**: User settings is rendered inside `NcAppSettingsDialog` — NOT a routed page (ADR-004)
-- [ ] Import and register `SyncSettingsSection`
-- [ ] Add `<SyncSettingsSection />` inside the settings dialog content
-
----
-
-## Section 6: Automation Trigger Types [V2]
-
-### Task 6.1: Register email.received and calendar.event.start trigger types [V2]
-- **Spec ref**: REQ-ECS-013
+### Task 4.1: Register email.received and calendar.event.start [V2]
+- **Spec ref**: Requirement "Automation trigger types"
 - **Files**: `lib/Service/AutomationService.php` (or wherever trigger types are enumerated)
-- **Acceptance**: Automation form shows new trigger options; automation engine dispatches on emailLink/calendarLink creation
-- [ ] Add `email.received` and `calendar.event.start` to the list of valid automation trigger values
-- [ ] In `EmailSyncService::syncUserEmails()`: after creating an emailLink, call automation evaluation for the linked entity
-- [ ] In `CalendarSyncService::syncUserCalendar()`: after creating a calendarLink, evaluate `calendar.event.start` automations for the linked entity
-- [ ] Tag as V2 — do NOT enable in info.xml or register until implemented
+- [ ] Add `email.received` and `calendar.event.start` to valid automation trigger values
+- [ ] After the matching job links an inbound email, evaluate `email.received` automations for the linked entity
+- [ ] Subscribe to the calendar leaf's link/event signal to evaluate `calendar.event.start` automations
+- [ ] Tag as V2 — do NOT enable until implemented
 
 ---
 
-## Section 7: Translations [V1]
+## Section 5: Unit Tests [V1]
 
-### Task 7.1: Add sync UI strings to translation files [V1]
-- **Spec ref**: REQ-ECS-015
+### Task 5.1: Tests for the matcher + job [V1]
+- **Spec ref**: Requirement "Unit tests"
+- **Files**: `tests/Unit/Service/EmailMatchServiceTest.php`, `tests/Unit/BackgroundJob/EmailMatchJobTest.php`
+- [ ] Test exact-address match returns the correct entity
+- [ ] Test unknown address returns empty and creates no link
+- [ ] Test `isPublicDomain()` true for gmail.com, false for corporate domain
+- [ ] Test the job calls the email leaf link API on match (mock the leaf client)
+- [ ] Test the job continues when one user's run throws
+- [ ] Mock OR services — no real DB in unit tests
+
+### Task 5.2: Tests for the settings controller [V1]
+- **Spec ref**: Requirement "Unit tests"
+- **Files**: `tests/Unit/Controller/EmailSyncControllerTest.php`
+- [ ] 200 success, 401 unauthenticated, 400 invalid input for each endpoint
+
+---
+
+## Section 6: Translations [V1]
+
+### Task 6.1: Add sync-settings UI strings [V1]
+- **Spec ref**: Requirement "Translation coverage"
 - **Files**: `l10n/en.json`, `l10n/nl.json`
-- **Acceptance**: Both files have identical key sets; no hardcoded strings in sync components
-- [ ] Add all string keys from `EmailTimelineCard`, `CalendarEventCard`, `FollowUpEventDialog`, `SyncSettingsSection` to `l10n/en.json` (key == English value)
-- [ ] Add Dutch translations for every key in `l10n/nl.json`
-- [ ] Verify key parity: both files MUST contain exactly the same keys (zero gaps)
-- [ ] Run pre-commit translation check: `grep -rn "'" src/components/sync/ --include='*.vue' | grep -v "this\.t\|import\|//\|console"` — must return zero matches
+- [ ] Add every `SyncSettingsSection` key to `en.json` (key == English value) and `nl.json` (Dutch)
+- [ ] Verify key parity (zero gaps)
 
 ---
 
-## Section 8: Pre-commit Verification [V1]
+## Section 7: Pre-commit Verification [V1]
 
-### Task 8.1: Run pre-commit checklist [V1]
-- **Spec ref**: ADR-015
-- [ ] SPDX headers: `grep -rL 'SPDX-License-Identifier' lib/Service/EmailSync* lib/Service/CalendarSync* lib/BackgroundJob/EmailSync* lib/Controller/EmailSync* --include='*.php'` → zero results
-- [ ] SPDX headers: `grep -rL 'SPDX-License-Identifier' src/components/sync/ --include='*.vue'` → zero results
-- [ ] ObjectService calls: verify all `saveObject`/`findObjects`/`findObject` calls use 3 positional args
+### Task 7.1: Run pre-commit checklist [V1]
+- **Spec ref**: ADR-015, ADR-022
+- [ ] SPDX headers on all new PHP + Vue files → zero missing
+- [ ] Register file contains NO `emailLink`/`calendarLink` schema and NO pipelinq timeline component (ADR-022 gate)
 - [ ] Error responses: `grep -rn 'getMessage()' lib/Controller/EmailSyncController.php` → zero results
-- [ ] Auth checks: verify `IUserSession::getUser()` is called in all controller methods
-- [ ] Store registration: verify `email-link` and `calendar-link` are registered in `src/store/store.js` (kebab-case, once each)
-- [ ] Translations: `npm run lint` — no missing i18n keys
-- [ ] No raw fetch: `grep -rn 'fetch(' src/components/sync/ --include='*.vue'` → zero results
-- [ ] No direct @nextcloud/vue imports: `grep -rn "from '@nextcloud/vue'" src/` → zero results
-- [ ] Component imports: for every `<NcFoo>` / `<CnFoo>` in sync templates, verify import AND `components: {}` entry
+- [ ] Auth: `IUserSession::getUser()` in all controller methods
+- [ ] No raw `fetch(` in `src/components/sync/`; no `from '@nextcloud/vue'` imports
 
-### Task 8.2: Build and smoke test [V1]
+### Task 7.2: Build and smoke test [V1]
 - [ ] `npm run build` — zero errors
 - [ ] `php -l` on all new PHP files — zero syntax errors
-- [ ] `curl GET /api/sync/email/settings` with valid session — verify 200 response shape
-- [ ] `curl GET /api/sync/email/settings` unauthenticated — verify 401
-- [ ] `curl POST /api/sync/email/settings` with invalid payload — verify 400
-- [ ] Open client detail page — verify EmailTimelineCard renders (or shows empty state, not error)
-- [ ] Open lead detail page — verify CalendarEventCard renders with "Schedule follow-up" button
+- [ ] `GET /api/sync/email/settings` authenticated → 200; unauthenticated → 401; invalid POST → 400
+- [ ] Open a client detail page — verify the `email` leaf's `CnEmailTab` renders (empty state, not error)
+- [ ] Open a lead detail page — verify the `calendar` leaf's `CnCalendarCard` renders with its "Add meeting" create flow


### PR DESCRIPTION
## What

Intercepts **not-yet-implemented** OpenSpec changes in pipelinq so they **consume OpenRegister integration leaves** instead of building parallel calendar/email machinery in-app, per hydra **ADR-022** (apps consume OR abstractions). No code is written — only change artifacts (proposal / spec / tasks) are edited.

## Per-change decisions

| Change | Decision | Reason |
|---|---|---|
| `email-calendar-sync` | **Re-pointed** | Was building pipelinq-local `emailLink`/`calendarLink` schemas, `EmailSyncService`/`CalendarSyncService`, and `EmailTimelineCard`/`CalendarEventCard` — three ADR-022 anti-patterns (parallel link tables, duplicate sidebar tabs, app-local linked-emails mirroring an OR integration). Now consumes the **email** (`integration-email`) + **calendar** (`integration-calendar`) leaves via the app manifest (ADR-024). Keeps only the CRM email→entity matching job (calls the leaf link API), per-user matching settings, and the `email.received`/`calendar.event.start` automation triggers. |
| `appointment-booking` | **Re-pointed (boundary made explicit)** | Booking domain (Service/Resource/Booking/WalkInTicket, slot computation, skill routing, deposits, no-show, walk-in queue, portal) stays in-app — genuinely app-specific. Calendar block reads + booking-event writes now explicitly go through the **calendar** leaf (via `email-calendar-sync`); no pipelinq-local CalDAV client. |
| `marketing-segmentation-and-blast` | **Left — already leaf-aligned** | The hypothesis "blast/send → email leaf" does not hold: the **email leaf is link-only; sending is explicitly out of scope** (handled by openconnector/n8n), which is exactly what the proposal already does. Segmentation is app-specific CRM logic; the live send-monitor/A-B/attribution dashboard is campaign-domain, not a generic embedded NC Analytics report. No re-point needed. |
| `time-entry-core` | **Left — ambiguous (human decision)** | See note below. |
| `time-entry-mobile` | **Left — ambiguous (human decision)** | See note below. |
| `time-approval-workflow` | **Left — ambiguous (human decision)** | See note below. |

## Ambiguity flagged for human decision (time tracking)

The three time changes are **not** re-pointed because the destination is genuinely undecided:

1. The OR **`time-tracker` leaf** (`integration-time-tracker`) exists, but it **explicitly puts approval workflows and invoicing out of scope** ("those belong in a separate billing app"). It covers quick-log + list + totals only — so `time-approval-workflow` cannot be delivered by the leaf as written.
2. **`pipelinq-time-to-shillinq-wip` already exists**, signalling time tracking may be migrating to **shillinq**, not (just) to a leaf.

So the open question is: do pipelinq time entries (a) consume the time-tracker leaf for capture and keep approval in-app, (b) move wholesale to shillinq, or (c) a hybrid? This needs a human/architect call before any re-point. Left untouched per the intercept brief's option (c).

## Validation

`openspec validate <change> --type change --strict` passes for both touched changes (`email-calendar-sync`, `appointment-booking`). Both were converted from the legacy `## Requirements` style to valid `## ADDED Requirements` / `### Requirement:` delta format as part of the edit (they failed strict validation at baseline).

🤖 Generated with [Claude Code](https://claude.com/claude-code)