### PR TITLE
feat(notifications): lead/contact creation notifications

### DIFF
--- a/lib/Settings/pipelinq_register.json
+++ b/lib/Settings/pipelinq_register.json
@@ -122,6 +122,20 @@
       },
       "contact": {
         "slug": "contact",
+        "x-openregister-notifications": {
+          "newContact": {
+            "trigger": { "type": "created" },
+            "enabled": true,
+            "channels": ["nc-notification"],
+            "recipients": [
+              { "kind": "groups", "groups": ["sales"] }
+            ],
+            "subject": {
+              "nl": "Nieuw contact: {{name}}",
+              "en": "New contact: {{name}}"
+            }
+          }
+        },
         "title": "Contact",
         "icon": "CardAccountDetails",
         "version": "1.0.0",
@@ -167,6 +181,21 @@
       },
       "lead": {
         "slug": "lead",
+        "x-openregister-notifications": {
+          "newLead": {
+            "trigger": { "type": "created" },
+            "enabled": true,
+            "channels": ["nc-notification"],
+            "recipients": [
+              { "kind": "groups", "groups": ["sales"] },
+              { "kind": "field", "field": "assignee" }
+            ],
+            "subject": {
+              "nl": "Nieuwe lead: {{title}}",
+              "en": "New lead: {{title}}"
+            }
+          }
+        },
         "title": "Lead",
         "icon": "TrendingUp",
         "version": "1.0.0",


### PR DESCRIPTION
Declares `x-openregister-notifications` on the **lead** and **contact** schemas so the OpenRegister notification engine raises an in-app notification when one is created:

- **lead** `object.created` → `sales` group + the lead's `assignee` field
- **contact** `object.created` → `sales` group

Schema-object-level annotation (folded into the schema `configuration` on register import). Uses the verified engine dialect (`trigger.type`/`channels`/`recipients`/per-locale `subject`). Push is delivered automatically via notify_push. Users can opt out per-notification via OpenRegister's override-only notification preferences.

Part of the fleet notification rollout (hydra/openspec/fleet-notification-plan.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)