### PR TITLE
chore(composer): bump lock platform to PHP 8.3

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -7674,11 +7674,11 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "^8.1"
+        "php": "^8.3"
     },
     "platform-dev": [],
     "platform-overrides": {
-        "php": "8.1"
+        "php": "8.3"
     },
     "plugin-api-version": "2.6.0"
 }


### PR DESCRIPTION
Regenerates the stale composer.lock platform pin (8.1 -> 8.3) to match composer.json require ^8.3 / config.platform 8.3, fixing the 'lock file does not contain a compatible set of packages' composer install failure. Version-neutral: composer install --dry-run reports 0 updates / 0 removals.