### PR TITLE
fix: resolve hydra mechanical gates (initial-state, nc-input-labels, modal-isolation)

### DIFF
--- a/lib/Settings/AdminSettings.php
+++ b/lib/Settings/AdminSettings.php
@@ -27,6 +27,7 @@ use OCA\Pipelinq\AppInfo\Application;
 use OCA\Pipelinq\Service\SettingsService;
 use OCP\App\IAppManager;
 use OCP\AppFramework\Http\TemplateResponse;
+use OCP\AppFramework\Services\IInitialState;
 use OCP\Settings\ISettings;
 
 /**
@@ -39,10 +40,12 @@ class AdminSettings implements ISettings
      *
      * @param SettingsService $settingsService The settings service.
      * @param IAppManager     $appManager      The app manager.
+     * @param IInitialState   $initialState    The initial state service.
      */
     public function __construct(
         private SettingsService $settingsService,
         private IAppManager $appManager,
+        private IInitialState $initialState,
     ) {
     }//end __construct()
 
@@ -58,12 +61,13 @@ class AdminSettings implements ISettings
         $config  = $this->settingsService->getSettings();
         $version = $this->appManager->getAppVersion(appId: Application::APP_ID);
 
+        $this->initialState->provideInitialState('version', $version);
+
         return new TemplateResponse(
                 Application::APP_ID,
                 'settings/admin',
                 [
-                    'config'  => json_encode($config),
-                    'version' => $version,
+                    'config' => json_encode($config),
                 ]
                 );
     }//end getForm()

--- a/src/components/ContactRelationships.vue
+++ b/src/components/ContactRelationships.vue
@@ -73,6 +73,7 @@
 						<NcSelect
 							v-model="addForm.toContact"
 							:options="entityOptions"
+							:aria-label-combobox="t('pipelinq', 'Related entity')"
 							:placeholder="t('pipelinq', 'Search contacts and clients...')"
 							label="name"
 							:reduce="opt => opt.id"
@@ -83,6 +84,7 @@
 						<NcSelect
 							v-model="addForm.type"
 							:options="typeOptions"
+							:aria-label-combobox="t('pipelinq', 'Relationship type')"
 							:placeholder="t('pipelinq', 'Select type...')"
 							label="label"
 							:reduce="opt => opt.value"
@@ -107,6 +109,7 @@
 						<NcSelect
 							v-model="addForm.strength"
 							:options="strengthOptions"
+							:aria-label-combobox="t('pipelinq', 'Strength')"
 							:placeholder="t('pipelinq', 'Select strength...')"
 							label="label"
 							:reduce="opt => opt.value" />

--- a/src/components/ContactmomentQuickLog.vue
+++ b/src/components/ContactmomentQuickLog.vue
@@ -21,6 +21,7 @@
 				<NcSelect
 					v-model="form.channel"
 					:options="channelOptions"
+					:aria-label-combobox="t('pipelinq', 'Channel')"
 					:clearable="false"
 					:placeholder="t('pipelinq', 'Select channel')" />
 			</div>
@@ -29,6 +30,7 @@
 				<NcSelect
 					v-model="form.outcome"
 					:options="outcomeOptions"
+					:aria-label-combobox="t('pipelinq', 'Outcome')"
 					:clearable="true"
 					:placeholder="t('pipelinq', 'Select outcome')" />
 			</div>
@@ -40,6 +42,7 @@
 			<NcSelect
 				v-model="form.client"
 				:options="clientSelectOptions"
+				:aria-label-combobox="t('pipelinq', 'Client')"
 				:clearable="true"
 				label="label"
 				:reduce="o => o.value"
@@ -52,6 +55,7 @@
 			<NcSelect
 				v-model="form.request"
 				:options="requestSelectOptions"
+				:aria-label-combobox="t('pipelinq', 'Request')"
 				:clearable="true"
 				label="label"
 				:reduce="o => o.value"

--- a/src/components/LeadContactRoles.vue
+++ b/src/components/LeadContactRoles.vue
@@ -62,6 +62,7 @@
 						<NcSelect
 							v-model="addForm.toContact"
 							:options="contactOptions"
+							:aria-label-combobox="t('pipelinq', 'Contact')"
 							:placeholder="t('pipelinq', 'Search contacts...')"
 							label="name"
 							:reduce="opt => opt.id"
@@ -72,6 +73,7 @@
 						<NcSelect
 							v-model="addForm.type"
 							:options="roleOptions"
+							:aria-label-combobox="t('pipelinq', 'Role')"
 							:placeholder="t('pipelinq', 'Select role...')"
 							label="label"
 							:reduce="opt => opt.value" />

--- a/src/components/LeadProducts.vue
+++ b/src/components/LeadProducts.vue
@@ -106,6 +106,7 @@
 						<NcSelect
 							v-model="addForm.product"
 							:options="productOptions"
+							:aria-label-combobox="t('pipelinq', 'Product')"
 							:placeholder="t('pipelinq', 'Search products...')"
 							label="name"
 							:reduce="opt => opt.id"

--- a/src/dialogs/DeletePipelineDialog.vue
+++ b/src/dialogs/DeletePipelineDialog.vue
@@ -1,0 +1,49 @@
+<template>
+	<NcDialog :name="t('pipelinq', 'Delete pipeline')"
+		@closing="$emit('cancel')">
+		<p>{{ t('pipelinq', 'Are you sure you want to delete "{title}"?', { title: pipeline.title }) }}</p>
+		<p v-if="affectedCount > 0" class="delete-warning">
+			{{ t('pipelinq', '{count} leads/requests are on this pipeline. They will be removed from the pipeline but not deleted.', { count: affectedCount }) }}
+		</p>
+		<p v-if="pipeline.stages && pipeline.stages.length > 0" class="delete-warning">
+			{{ t('pipelinq', 'This pipeline has {count} stages. All stage configuration will be lost.', { count: pipeline.stages.length }) }}
+		</p>
+		<template #actions>
+			<NcButton type="tertiary" @click="$emit('cancel')">
+				{{ t('pipelinq', 'Cancel') }}
+			</NcButton>
+			<NcButton type="error" @click="$emit('confirm')">
+				{{ t('pipelinq', 'Delete') }}
+			</NcButton>
+		</template>
+	</NcDialog>
+</template>
+
+<script>
+import { NcButton, NcDialog } from '@nextcloud/vue'
+
+export default {
+	name: 'DeletePipelineDialog',
+	components: {
+		NcButton,
+		NcDialog,
+	},
+	props: {
+		/**
+		 * The pipeline pending deletion.
+		 */
+		pipeline: {
+			type: Object,
+			required: true,
+		},
+		/**
+		 * Number of leads/requests currently on the pipeline.
+		 */
+		affectedCount: {
+			type: Number,
+			default: 0,
+		},
+	},
+	emits: ['cancel', 'confirm'],
+}
+</script>

--- a/src/views/automations/AutomationBuilder.vue
+++ b/src/views/automations/AutomationBuilder.vue
@@ -19,6 +19,7 @@
 				<label>{{ t('pipelinq', 'Trigger') }}</label>
 				<NcSelect v-model="form.trigger"
 					:options="triggerOptions"
+					:aria-label-combobox="t('pipelinq', 'Trigger')"
 					:placeholder="t('pipelinq', 'Select trigger event')"
 					label="label"
 					:reduce="opt => opt.value" />
@@ -30,6 +31,7 @@
 					<input v-model="condition.field" type="text" :placeholder="t('pipelinq', 'Field name')">
 					<NcSelect v-model="condition.operator"
 						:options="operatorOptions"
+						:input-label="t('pipelinq', 'Condition operator')"
 						label="label"
 						:reduce="opt => opt.value" />
 					<input v-model="condition.value" type="text" :placeholder="t('pipelinq', 'Value')">
@@ -54,6 +56,7 @@
 						<span class="action-number">{{ index + 1 }}</span>
 						<NcSelect v-model="action.type"
 							:options="actionOptions"
+							:input-label="t('pipelinq', 'Action type')"
 							label="label"
 							:reduce="opt => opt.value"
 							class="action-type-select" />

--- a/src/views/clients/ClientForm.vue
+++ b/src/views/clients/ClientForm.vue
@@ -18,6 +18,7 @@
 				<NcSelect
 					v-model="form.type"
 					input-id="client-type"
+					:aria-label-combobox="t('pipelinq', 'Type')"
 					:options="typeOptions"
 					:placeholder="t('pipelinq', 'Select type')"
 					data-testid="client-type-select"

--- a/src/views/complaints/ComplaintDetail.vue
+++ b/src/views/complaints/ComplaintDetail.vue
@@ -157,6 +157,7 @@
 				<NcSelect
 					:value="assigneeOption"
 					:options="userOptions"
+					:input-label="t('pipelinq', 'Assign to user')"
 					:clearable="true"
 					label="label"
 					:reduce="o => o.value"

--- a/src/views/complaints/ComplaintForm.vue
+++ b/src/views/complaints/ComplaintForm.vue
@@ -29,6 +29,7 @@
 				<NcSelect
 					v-model="form.category"
 					:options="categoryOptions"
+					:aria-label-combobox="t('pipelinq', 'Category')"
 					:clearable="false"
 					:placeholder="t('pipelinq', 'Select category')" />
 				<span v-if="errors.category" class="field-error">{{ errors.category }}</span>
@@ -38,6 +39,7 @@
 				<NcSelect
 					v-model="form.priority"
 					:options="priorityOptions"
+					:aria-label-combobox="t('pipelinq', 'Priority')"
 					:clearable="false"
 					:placeholder="t('pipelinq', 'Priority')" />
 			</div>
@@ -50,6 +52,7 @@
 				<NcSelect
 					v-model="form.channel"
 					:options="channelOptions"
+					:aria-label-combobox="t('pipelinq', 'Channel')"
 					:clearable="true"
 					:placeholder="t('pipelinq', 'Select channel')" />
 			</div>
@@ -58,6 +61,7 @@
 				<NcSelect
 					v-model="form.status"
 					:options="availableStatuses"
+					:aria-label-combobox="t('pipelinq', 'Status')"
 					:clearable="false"
 					:placeholder="t('pipelinq', 'Status')" />
 			</div>
@@ -69,6 +73,7 @@
 			<NcSelect
 				v-model="form.client"
 				:options="clientOptions"
+				:aria-label-combobox="t('pipelinq', 'Client')"
 				:clearable="true"
 				label="label"
 				:reduce="o => o.value"
@@ -82,6 +87,7 @@
 			<NcSelect
 				v-model="form.contact"
 				:options="contactOptions"
+				:aria-label-combobox="t('pipelinq', 'Contact person')"
 				:clearable="true"
 				label="label"
 				:reduce="o => o.value"

--- a/src/views/contacts/ContactForm.vue
+++ b/src/views/contacts/ContactForm.vue
@@ -16,6 +16,7 @@
 			<NcSelect
 				v-model="selectedClient"
 				input-id="contact-client"
+				:aria-label-combobox="t('pipelinq', 'Client')"
 				:options="clientOptions"
 				:placeholder="t('pipelinq', 'Search for a client...')"
 				label="name"

--- a/src/views/forms/FormBuilder.vue
+++ b/src/views/forms/FormBuilder.vue
@@ -52,6 +52,7 @@
 							class="field-input">
 						<NcSelect v-model="field.type"
 							:options="fieldTypeOptions"
+							:input-label="t('pipelinq', 'Field type')"
 							label="label"
 							:reduce="opt => opt.value"
 							class="field-type" />
@@ -73,6 +74,7 @@
 							<label>{{ t('pipelinq', 'Map to') }}:</label>
 							<NcSelect v-model="mappingFor[index]"
 								:options="mappingOptions"
+								:aria-label-combobox="t('pipelinq', 'Map to')"
 								label="label"
 								:reduce="opt => opt.value"
 								:placeholder="t('pipelinq', 'Entity property')" />

--- a/src/views/leads/LeadForm.vue
+++ b/src/views/leads/LeadForm.vue
@@ -42,6 +42,7 @@
 				<label>{{ t('pipelinq', 'Source') }}</label>
 				<NcSelect v-model="form.source"
 					:options="sourceOptions"
+					:aria-label-combobox="t('pipelinq', 'Source')"
 					:clearable="true"
 					:placeholder="t('pipelinq', 'Select source')" />
 			</div>
@@ -49,6 +50,7 @@
 				<label>{{ t('pipelinq', 'Priority') }}</label>
 				<NcSelect v-model="form.priority"
 					:options="priorityOptions"
+					:aria-label-combobox="t('pipelinq', 'Priority')"
 					:clearable="false"
 					:placeholder="t('pipelinq', 'Select priority')" />
 			</div>
@@ -67,6 +69,7 @@
 			<label>{{ t('pipelinq', 'Client') }}</label>
 			<NcSelect v-model="form.client"
 				:options="clientOptions"
+				:aria-label-combobox="t('pipelinq', 'Client')"
 				:clearable="true"
 				label="label"
 				:reduce="o => o.value"
@@ -79,6 +82,7 @@
 				<label>{{ t('pipelinq', 'Pipeline') }}</label>
 				<NcSelect v-model="form.pipeline"
 					:options="pipelineOptions"
+					:aria-label-combobox="t('pipelinq', 'Pipeline')"
 					:clearable="true"
 					label="label"
 					:reduce="o => o.value"
@@ -89,6 +93,7 @@
 				<label>{{ t('pipelinq', 'Stage') }}</label>
 				<NcSelect v-model="form.stage"
 					:options="stageOptions"
+					:aria-label-combobox="t('pipelinq', 'Stage')"
 					:clearable="true"
 					:disabled="!form.pipeline"
 					:placeholder="form.pipeline ? t('pipelinq', 'Select stage') : t('pipelinq', 'Select pipeline first')" />

--- a/src/views/products/ProductForm.vue
+++ b/src/views/products/ProductForm.vue
@@ -27,6 +27,7 @@
 				<NcSelect
 					v-model="form.type"
 					input-id="product-type"
+					:aria-label-combobox="t('pipelinq', 'Type')"
 					:options="typeOptions"
 					:placeholder="t('pipelinq', 'Select type')"
 					@input="validateField('type')" />
@@ -39,6 +40,7 @@
 				<NcSelect
 					v-model="form.status"
 					input-id="product-status"
+					:aria-label-combobox="t('pipelinq', 'Status')"
 					:options="statusOptions"
 					:placeholder="t('pipelinq', 'Select status')" />
 			</div>
@@ -89,6 +91,7 @@
 			<NcSelect
 				v-model="form.category"
 				input-id="product-category"
+				:aria-label-combobox="t('pipelinq', 'Category')"
 				:options="categoryOptions"
 				:placeholder="t('pipelinq', 'Select category')"
 				label="name"

--- a/src/views/requests/RequestDetail.vue
+++ b/src/views/requests/RequestDetail.vue
@@ -65,7 +65,8 @@
 							{{ getStatusLabel(requestData.status) }}
 						</span>
 						<NcSelect
-							v-if="statusTransitions.length > 0 && !isConverted"
+							v-if="canChangeStatus"
+							:input-label="t('pipelinq', 'Change status')"
 							:value="null"
 							:options="statusTransitionOptions"
 							:placeholder="t('pipelinq', 'Change status')"
@@ -133,6 +134,7 @@
 					v-if="!isConverted"
 					:value="assigneeOption"
 					:options="userOptions"
+					:input-label="t('pipelinq', 'Assign to user')"
 					:clearable="true"
 					label="label"
 					:reduce="o => o.value"
@@ -150,6 +152,7 @@
 					v-if="!isConverted"
 					:value="queueOption || null"
 					:options="queueOptions"
+					:input-label="t('pipelinq', 'Queue')"
 					:clearable="true"
 					label="label"
 					:reduce="o => o.value"
@@ -399,6 +402,14 @@ export default {
 				id: s,
 				label: getStatusLabel(s),
 			}))
+		},
+		/**
+		 * Whether the status-transition control should be shown.
+		 *
+		 * @spec exclude trivial template guard helper
+		 */
+		canChangeStatus() {
+			return this.statusTransitions.length !== 0 && !this.isConverted
 		},
 		/**
 		 * @spec openspec/changes/reverse-2026-05-26-fe-requests-ui/tasks.md#task-3

--- a/src/views/requests/RequestForm.vue
+++ b/src/views/requests/RequestForm.vue
@@ -25,6 +25,7 @@
 				<NcSelect
 					v-model="form.status"
 					:options="availableStatuses"
+					:aria-label-combobox="t('pipelinq', 'Status')"
 					:clearable="false"
 					:placeholder="t('pipelinq', 'Status')" />
 			</div>
@@ -33,6 +34,7 @@
 				<NcSelect
 					v-model="form.priority"
 					:options="priorityOptions"
+					:aria-label-combobox="t('pipelinq', 'Priority')"
 					:clearable="false"
 					:placeholder="t('pipelinq', 'Priority')" />
 			</div>
@@ -45,6 +47,7 @@
 				<NcSelect
 					v-model="form.channel"
 					:options="channelOptions"
+					:aria-label-combobox="t('pipelinq', 'Channel')"
 					:clearable="true"
 					:placeholder="t('pipelinq', 'Select channel')" />
 			</div>
@@ -71,6 +74,7 @@
 			<NcSelect
 				v-model="form.client"
 				:options="clientOptions"
+				:aria-label-combobox="t('pipelinq', 'Client')"
 				:clearable="true"
 				label="label"
 				:reduce="o => o.value"
@@ -84,6 +88,7 @@
 				<NcSelect
 					v-model="form.pipeline"
 					:options="pipelineOptions"
+					:aria-label-combobox="t('pipelinq', 'Pipeline')"
 					:clearable="true"
 					label="label"
 					:reduce="o => o.value"
@@ -95,6 +100,7 @@
 				<NcSelect
 					v-model="form.stage"
 					:options="stageOptions"
+					:aria-label-combobox="t('pipelinq', 'Stage')"
 					:clearable="true"
 					:disabled="!form.pipeline"
 					:placeholder="form.pipeline ? t('pipelinq', 'Select stage') : t('pipelinq', 'Select pipeline first')" />

--- a/src/views/settings/PipelineForm.vue
+++ b/src/views/settings/PipelineForm.vue
@@ -24,6 +24,7 @@
 						<label>{{ t('pipelinq', 'View') }}</label>
 						<NcSelect v-model="form.viewId"
 							:options="viewOptions"
+							:aria-label-combobox="t('pipelinq', 'View')"
 							:clearable="true"
 							label="label"
 							:reduce="o => o.value"

--- a/src/views/settings/PipelineManager.vue
+++ b/src/views/settings/PipelineManager.vue
@@ -59,33 +59,20 @@
 			@save="onSave"
 			@cancel="showForm = false; editingPipeline = null" />
 
-		<NcDialog v-if="deletingPipeline"
-			:name="t('pipelinq', 'Delete pipeline')"
-			@closing="deletingPipeline = null">
-			<p>{{ t('pipelinq', 'Are you sure you want to delete "{title}"?', { title: deletingPipeline.title }) }}</p>
-			<p v-if="deleteAffectedCount > 0" class="delete-warning">
-				{{ t('pipelinq', '{count} leads/requests are on this pipeline. They will be removed from the pipeline but not deleted.', { count: deleteAffectedCount }) }}
-			</p>
-			<p v-if="deletingPipeline.stages && deletingPipeline.stages.length > 0" class="delete-warning">
-				{{ t('pipelinq', 'This pipeline has {count} stages. All stage configuration will be lost.', { count: deletingPipeline.stages.length }) }}
-			</p>
-			<template #actions>
-				<NcButton type="tertiary" @click="deletingPipeline = null">
-					{{ t('pipelinq', 'Cancel') }}
-				</NcButton>
-				<NcButton type="error" @click="onDeleteConfirm">
-					{{ t('pipelinq', 'Delete') }}
-				</NcButton>
-			</template>
-		</NcDialog>
+		<DeletePipelineDialog v-if="deletingPipeline"
+			:pipeline="deletingPipeline"
+			:affected-count="deleteAffectedCount"
+			@cancel="deletingPipeline = null"
+			@confirm="onDeleteConfirm" />
 	</div>
 </template>
 
 <script>
-import { NcButton, NcDialog, NcEmptyContent, NcLoadingIcon } from '@nextcloud/vue'
+import { NcButton, NcEmptyContent, NcLoadingIcon } from '@nextcloud/vue'
 import { showError } from '@nextcloud/dialogs'
 import { useObjectStore } from '../../store/modules/object.js'
 import PipelineForm from './PipelineForm.vue'
+import DeletePipelineDialog from '../../dialogs/DeletePipelineDialog.vue'
 import Delete from 'vue-material-design-icons/Delete.vue'
 import Pencil from 'vue-material-design-icons/Pencil.vue'
 import Plus from 'vue-material-design-icons/Plus.vue'
@@ -96,10 +83,10 @@ export default {
 	name: 'PipelineManager',
 	components: {
 		NcButton,
-		NcDialog,
 		NcEmptyContent,
 		NcLoadingIcon,
 		PipelineForm,
+		DeletePipelineDialog,
 		Delete,
 		Pencil,
 		Plus,

--- a/src/views/settings/ProspectSettings.vue
+++ b/src/views/settings/ProspectSettings.vue
@@ -44,6 +44,7 @@
 				<NcSelect
 					v-model="form.provinces"
 					:options="provinceOptions"
+					:aria-label-combobox="t('pipelinq', 'Provinces')"
 					:multiple="true"
 					:placeholder="t('pipelinq', 'Select provinces')" />
 			</div>
@@ -54,6 +55,7 @@
 				<NcSelect
 					v-model="form.legalForms"
 					:options="legalFormOptions"
+					:aria-label-combobox="t('pipelinq', 'Legal Forms')"
 					:multiple="true"
 					:placeholder="t('pipelinq', 'Select legal forms')" />
 			</div>

--- a/src/views/settings/Settings.vue
+++ b/src/views/settings/Settings.vue
@@ -102,6 +102,7 @@
 </template>
 
 <script>
+import { loadState } from '@nextcloud/initial-state'
 import { CnRegisterMapping, CnVersionInfoCard } from '@conduction/nextcloud-vue'
 import { NcButton, NcLoadingIcon, NcNoteCard, NcSettingsSection } from '@nextcloud/vue'
 import Refresh from 'vue-material-design-icons/Refresh.vue'
@@ -138,7 +139,7 @@ export default {
 	data() {
 		return {
 			config: {},
-			appVersion: document.getElementById('pipelinq-settings')?.dataset?.version || 'Unknown',
+			appVersion: loadState('pipelinq', 'version', 'Unknown'),
 			reimporting: false,
 			saving: false,
 			message: '',

--- a/src/views/widgets/CreateLeadWidget.vue
+++ b/src/views/widgets/CreateLeadWidget.vue
@@ -14,6 +14,7 @@
 
 			<NcSelect v-model="form.pipeline"
 				:options="pipelineOptions"
+				:input-label="t('pipelinq', 'Pipeline')"
 				:placeholder="t('pipelinq', 'Pipeline')"
 				label="label"
 				track-by="id"
@@ -26,6 +27,7 @@
 
 			<NcSelect v-model="form.source"
 				:options="sourceOptions"
+				:input-label="t('pipelinq', 'Source')"
 				:placeholder="t('pipelinq', 'Source')"
 				input-id="lead-source" />
 

--- a/src/views/widgets/FindClientWidget.vue
+++ b/src/views/widgets/FindClientWidget.vue
@@ -17,6 +17,7 @@
 				:error="newClientSubmitted && !newClient.name" />
 			<NcSelect v-model="newClient.type"
 				:options="typeOptions"
+				:input-label="t('pipelinq', 'Type')"
 				:placeholder="t('pipelinq', 'Type')"
 				input-id="new-client-type" />
 			<NcTextField :value.sync="newClient.email"

--- a/src/views/widgets/StartRequestWidget.vue
+++ b/src/views/widgets/StartRequestWidget.vue
@@ -14,16 +14,19 @@
 
 			<NcSelect v-model="form.category"
 				:options="categoryOptions"
+				:input-label="t('pipelinq', 'Category')"
 				:placeholder="t('pipelinq', 'Category')"
 				input-id="request-category" />
 
 			<NcSelect v-model="form.priority"
 				:options="priorityOptions"
+				:input-label="t('pipelinq', 'Priority')"
 				:placeholder="t('pipelinq', 'Priority')"
 				input-id="request-priority" />
 
 			<NcSelect v-model="form.channel"
 				:options="channelOptions"
+				:input-label="t('pipelinq', 'Channel')"
 				:placeholder="t('pipelinq', 'Channel')"
 				input-id="request-channel" />
 

--- a/templates/settings/admin.php
+++ b/templates/settings/admin.php
@@ -9,4 +9,4 @@ Util::addScript($appId, $appId . '-shared-vendor');
 Util::addScript($appId, $appId . '-shared-nc-vue');
 Util::addScript($appId, $appId . '-settings');
 ?>
-<div id="pipelinq-settings" data-config="<?php p($_['config'] ?? '{}'); ?>" data-version="<?php p($_['version'] ?? ''); ?>"></div>
+<div id="pipelinq-settings" data-config="<?php p($_['config'] ?? '{}'); ?>"></div>


### PR DESCRIPTION
Bucket-A safe fixes from the fleet-wide hydra-gates sweep: ADR-004 loadState/IInitialState for app version, accessible labels on NcSelect, extracted modal from PipelineManager. Security-semantic findings tracked in a separate backlog issue.