### PR TITLE
fix: phpstan dead-branch + null-guard (fleet quality sweep)

### DIFF
--- a/lib/Controller/SettingsController.php
+++ b/lib/Controller/SettingsController.php
@@ -28,6 +28,7 @@ use OCA\Pipelinq\AppInfo\Application;
 use OCA\Pipelinq\Service\SettingsService;
 use OCP\App\IAppManager;
 use OCP\AppFramework\Controller;
+use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\IGroupManager;
 use OCP\IL10N;
@@ -202,10 +203,13 @@ class SettingsController extends Controller
      */
     public function getUserSettings(): JSONResponse
     {
-        $userId = $this->userSession->getUser()->getUID();
+        $user = $this->userSession->getUser();
+        if ($user === null) {
+            return new JSONResponse(data: ['message' => 'Not logged in'], statusCode: Http::STATUS_UNAUTHORIZED);
+        }
 
         return new JSONResponse(
-            data: $this->settingsService->getUserSettings(userId: $userId)
+            data: $this->settingsService->getUserSettings(userId: $user->getUID())
         );
     }//end getUserSettings()
 
@@ -219,11 +223,15 @@ class SettingsController extends Controller
      */
     public function updateUserSettings(): JSONResponse
     {
-        $userId = $this->userSession->getUser()->getUID();
-        $data   = $this->request->getParams();
+        $user = $this->userSession->getUser();
+        if ($user === null) {
+            return new JSONResponse(data: ['message' => 'Not logged in'], statusCode: Http::STATUS_UNAUTHORIZED);
+        }
+
+        $data = $this->request->getParams();
 
         return new JSONResponse(
-            data: $this->settingsService->updateUserSettings(userId: $userId, data: $data)
+            data: $this->settingsService->updateUserSettings(userId: $user->getUID(), data: $data)
         );
     }//end updateUserSettings()
 }//end class

--- a/lib/Service/ComplaintSlaService.php
+++ b/lib/Service/ComplaintSlaService.php
@@ -135,12 +135,7 @@ class ComplaintSlaService
             $start = new DateTimeImmutable();
         }
 
-        $deadline = $start->modify('+'.$hours.' hours');
-        if ($deadline === false) {
-            return null;
-        }
-
-        return $deadline;
+        return $start->modify('+'.$hours.' hours');
     }//end calculateDeadline()
 
     /**


### PR DESCRIPTION
## Summary

Two real PHPStan findings from the fleet quality sweep, fixed without behaviour change:

- **`lib/Service/ComplaintSlaService.php`** — `DateTimeImmutable::modify()` always returns `DateTimeImmutable` (never `false`); the `if ($deadline === false)` branch was dead code that also triggered a PHPStan type error. Removed; the return value is now passed through directly.
- **`lib/Controller/SettingsController.php`** — `getUserSettings()` and `updateUserSettings()` called `$this->userSession->getUser()->getUID()` without a null check. `getUser()` returns `null` for unauthenticated requests, causing a `PossiblyNullReference` crash. Added null guards returning `401 Unauthorized`, matching the established pattern in `PreferencesController`.

## Verification

- `php -l` clean on both files
- `vendor/bin/phpstan analyse` → **0 errors** (full project, no new errors introduced)

## Test plan

- [ ] Authenticated request to `GET /api/user-settings` returns user settings as before
- [ ] Authenticated request to `PUT /api/user-settings` updates settings as before
- [ ] Unauthenticated request to either endpoint returns `401 Unauthorized` (new guard)
- [ ] SLA deadline calculation still works correctly for all complaint categories