### PR TITLE
fix(security): resolve 6 critical RBAC, stub, SSRF, and automation issues

### DIFF
--- a/lib/Controller/CallbackController.php
+++ b/lib/Controller/CallbackController.php
@@ -24,11 +24,13 @@ namespace OCA\Pipelinq\Controller;
 use OCA\Pipelinq\AppInfo\Application;
 use OCA\Pipelinq\Service\CallbackService;
 use OCA\Pipelinq\Service\NotificationService;
+use OCA\Pipelinq\Service\ScheduledTaskService;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\Attribute\NoAdminRequired;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\IAppConfig;
+use OCP\IGroupManager;
 use OCP\IL10N;
 use OCP\IRequest;
 use OCP\IUserSession;
@@ -49,19 +51,23 @@ class CallbackController extends Controller
     /**
      * Constructor.
      *
-     * @param IRequest            $request             The request.
-     * @param CallbackService     $callbackService     The callback service.
-     * @param NotificationService $notificationService The notification service.
-     * @param IAppConfig          $appConfig           The app config.
-     * @param IUserSession        $userSession         The user session.
-     * @param IL10N               $l10n                The localization service.
-     * @param LoggerInterface     $logger              The logger.
+     * @param IRequest             $request              The request.
+     * @param CallbackService      $callbackService      The callback service.
+     * @param NotificationService  $notificationService  The notification service.
+     * @param ScheduledTaskService $scheduledTaskService The scheduled task service.
+     * @param IAppConfig           $appConfig            The app config.
+     * @param IGroupManager        $groupManager         The group manager.
+     * @param IUserSession         $userSession          The user session.
+     * @param IL10N                $l10n                 The localization service.
+     * @param LoggerInterface      $logger               The logger.
      */
     public function __construct(
         IRequest $request,
         private CallbackService $callbackService,
         private NotificationService $notificationService,
+        private ScheduledTaskService $scheduledTaskService,
         private IAppConfig $appConfig,
+        private IGroupManager $groupManager,
         private IUserSession $userSession,
         private IL10N $l10n,
         private LoggerInterface $logger,
@@ -97,8 +103,7 @@ class CallbackController extends Controller
         }
 
         try {
-            // Build task data stub — in production, fetch from OpenRegister.
-            $taskData = $this->getTaskStub(id: $id);
+            $taskData = $this->fetchTask(id: $id);
             if ($taskData === null) {
                 return new JSONResponse(
                     ['error' => $this->l10n->t('Task not found')],
@@ -106,7 +111,13 @@ class CallbackController extends Controller
                 );
             }
 
+            $authCheck = $this->checkTaskAuth(task: $taskData, userId: $user->getUID());
+            if ($authCheck !== null) {
+                return $authCheck;
+            }
+
             $taskData     = $this->callbackService->addAttempt($taskData, $result, $notes);
+            $taskData     = $this->scheduledTaskService->updateScheduledTask($id, $taskData);
             $suggestClose = $this->callbackService->isAttemptThresholdReached($taskData);
 
             return new JSONResponse(
@@ -143,7 +154,7 @@ class CallbackController extends Controller
         }
 
         try {
-            $taskData = $this->getTaskStub(id: $id);
+            $taskData = $this->fetchTask(id: $id);
             if ($taskData === null) {
                 return new JSONResponse(
                     ['error' => $this->l10n->t('Task not found')],
@@ -160,6 +171,7 @@ class CallbackController extends Controller
             }
 
             $taskData = $this->callbackService->applyClaim($taskData);
+            $taskData = $this->scheduledTaskService->updateScheduledTask($id, $taskData);
 
             return new JSONResponse(['task' => $taskData]);
         } catch (\Exception $e) {
@@ -191,12 +203,17 @@ class CallbackController extends Controller
         $resultText = $this->request->getParam('resultText', '');
 
         try {
-            $taskData = $this->getTaskStub(id: $id);
+            $taskData = $this->fetchTask(id: $id);
             if ($taskData === null) {
                 return new JSONResponse(
                     ['error' => $this->l10n->t('Task not found')],
                     Http::STATUS_NOT_FOUND
                 );
+            }
+
+            $authCheck = $this->checkTaskAuth(task: $taskData, userId: $user->getUID());
+            if ($authCheck !== null) {
+                return $authCheck;
             }
 
             $transition = $this->callbackService->validateStatusTransition(
@@ -212,15 +229,12 @@ class CallbackController extends Controller
             }
 
             $taskData = $this->callbackService->applyCompletion($taskData, $resultText);
+            $taskData = $this->scheduledTaskService->updateScheduledTask($id, $taskData);
 
             // Notify the creating agent about completion.
             $createdBy = $taskData['createdBy'] ?? '';
             if (empty($createdBy) === false) {
-                $user   = $this->userSession->getUser();
-                $author = 'system';
-                if ($user !== null) {
-                    $author = $user->getUID();
-                }
+                $author = $user->getUID();
 
                 $this->notificationService->notifyTaskCompleted(
                     $taskData['subject'] ?? '',
@@ -268,8 +282,16 @@ class CallbackController extends Controller
             );
         }
 
+        // Reassign is a manager/admin-only operation.
+        if ($this->groupManager->isAdmin($user->getUID()) === false) {
+            return new JSONResponse(
+                ['error' => $this->l10n->t('Only administrators may reassign tasks')],
+                Http::STATUS_FORBIDDEN
+            );
+        }
+
         try {
-            $taskData = $this->getTaskStub(id: $id);
+            $taskData = $this->fetchTask(id: $id);
             if ($taskData === null) {
                 return new JSONResponse(
                     ['error' => $this->l10n->t('Task not found')],
@@ -281,14 +303,11 @@ class CallbackController extends Controller
 
             // Log the reassignment as an attempt entry.
             $taskData = $this->callbackService->addAttempt($taskData, 'hertoegewezen', '');
+            $taskData = $this->scheduledTaskService->updateScheduledTask($id, $taskData);
 
             // Notify the new assignee if it's a user.
             if ($assigneeType === 'user') {
-                $user   = $this->userSession->getUser();
-                $author = 'system';
-                if ($user !== null) {
-                    $author = $user->getUID();
-                }
+                $author = $user->getUID();
 
                 $this->notificationService->notifyTaskReassigned(
                     $taskData['subject'] ?? '',
@@ -310,38 +329,42 @@ class CallbackController extends Controller
     }//end reassign()
 
     /**
-     * Get a task data stub by ID.
-     *
-     * In production, this queries OpenRegister. For now, returns a minimal
-     * structure that the frontend can use.
+     * Fetch a task from the real persistence layer (ScheduledTaskService).
      *
      * @param string $id The task object ID.
      *
      * @return array<string, mixed>|null Task data or null if not found.
      */
-    private function getTaskStub(string $id): ?array
+    private function fetchTask(string $id): ?array
     {
-        $register = $this->appConfig->getValueString(Application::APP_ID, 'register', '');
-        $schema   = $this->appConfig->getValueString(Application::APP_ID, 'task_schema', '');
-
-        if ($register === '' || $schema === '') {
-            $this->logger->warning('CallbackController: register or task_schema not configured');
+        try {
+            return $this->scheduledTaskService->getScheduledTask($id);
+        } catch (\RuntimeException $e) {
             return null;
         }
+    }//end fetchTask()
 
-        // NOTE: In production, fetch the actual task from OpenRegister:
-        // GET /api/registers/{register}/schemas/{schema}/objects/{id}
-        // For now, return a stub indicating the task exists.
-        return [
-            'id'              => $id,
-            'status'          => 'open',
-            'type'            => 'terugbelverzoek',
-            'subject'         => '',
-            'attempts'        => [],
-            'assigneeUserId'  => null,
-            'assigneeGroupId' => null,
-            'createdBy'       => '',
-            'deadline'        => '',
-        ];
-    }//end getTaskStub()
+    /**
+     * Check that the current user is authorised to mutate a task.
+     *
+     * Returns a JSONResponse with a 403 status when the user is not allowed,
+     * or null when the user is authorised.
+     *
+     * @param array<string, mixed> $task   The task object.
+     * @param string               $userId The acting user ID.
+     *
+     * @return JSONResponse|null Null on success, 403 response on failure.
+     */
+    private function checkTaskAuth(array $task, string $userId): ?JSONResponse
+    {
+        try {
+            $this->scheduledTaskService->authorizeTaskMutation($task, $userId);
+            return null;
+        } catch (\OCP\AppFramework\OCS\OCSForbiddenException $e) {
+            return new JSONResponse(
+                ['error' => $this->l10n->t('Not authorized to modify this task')],
+                Http::STATUS_FORBIDDEN
+            );
+        }
+    }//end checkTaskAuth()
 }//end class

--- a/lib/Controller/PublicFormController.php
+++ b/lib/Controller/PublicFormController.php
@@ -26,28 +26,42 @@ namespace OCA\Pipelinq\Controller;
 
 use OCA\Pipelinq\AppInfo\Application;
 use OCA\Pipelinq\Service\IntakeFormService;
+use OCP\App\IAppManager;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http\JSONResponse;
-use OCP\AppFramework\Http\Response;
+use OCP\IAppConfig;
 use OCP\IRequest;
+use Psr\Container\ContainerInterface;
+use Psr\Log\LoggerInterface;
 
 /**
  * Public controller for intake form rendering and submission.
  *
  * All endpoints are public (no authentication required) and include
  * CORS headers for cross-origin embedding.
+ *
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
+ * @spec                                           openspec/changes/retrofit-2026-05-24-annotate-pipelinq/tasks.md#task-31
  */
 class PublicFormController extends Controller
 {
     /**
      * Constructor.
      *
-     * @param IRequest          $request           The request.
-     * @param IntakeFormService $intakeFormService The intake form service.
+     * @param IRequest           $request           The request.
+     * @param IntakeFormService  $intakeFormService The intake form service.
+     * @param IAppConfig         $appConfig         The app config.
+     * @param ContainerInterface $container         The DI container.
+     * @param IAppManager        $appManager        The app manager.
+     * @param LoggerInterface    $logger            The logger.
      */
     public function __construct(
         IRequest $request,
         private IntakeFormService $intakeFormService,
+        private IAppConfig $appConfig,
+        private ContainerInterface $container,
+        private IAppManager $appManager,
+        private LoggerInterface $logger,
     ) {
         parent::__construct(appName: Application::APP_ID, request: $request);
     }//end __construct()
@@ -70,16 +84,34 @@ class PublicFormController extends Controller
      */
     public function show(string $id): JSONResponse
     {
-        // Form data would be fetched from OpenRegister in production.
-        // This endpoint returns the public-facing form definition.
-        $response = new JSONResponse(
-                [
-                    'id'             => $id,
-                    'fields'         => [],
-                    'successMessage' => '',
-                    'isActive'       => true,
-                ]
-                );
+        try {
+            $objectService = $this->getObjectService();
+            $config        = $this->getFormConfig();
+
+            if ($config === null) {
+                $response = new JSONResponse(['error' => 'Form service not available'], 503);
+                return $this->addCorsHeaders(response: $response);
+            }
+
+            $form = $objectService->find($id, []);
+            if ($form === null || ($form['isActive'] ?? false) !== true) {
+                $response = new JSONResponse(['error' => 'Form not found'], 404);
+                return $this->addCorsHeaders(response: $response);
+            }
+
+            // Return only the fields safe for public consumption.
+            $publicForm = [
+                'id'             => $id,
+                'fields'         => $form['fields'] ?? [],
+                'successMessage' => $form['successMessage'] ?? '',
+                'isActive'       => true,
+            ];
+
+            $response = new JSONResponse($publicForm);
+        } catch (\Exception $e) {
+            $this->logger->error('PublicFormController::show failed: '.$e->getMessage());
+            $response = new JSONResponse(['error' => 'Form not available'], 500);
+        }//end try
 
         return $this->addCorsHeaders(response: $response);
     }//end show()
@@ -88,7 +120,7 @@ class PublicFormController extends Controller
      * Process a public form submission.
      *
      * Validates the submission, checks for spam (honeypot) and rate limiting,
-     * then creates contact and lead entities in Pipelinq.
+     * then creates contact and lead entities in Pipelinq via ObjectService.
      *
      * @param string $id The form ID.
      *
@@ -121,23 +153,121 @@ class PublicFormController extends Controller
             return $this->addCorsHeaders(response: $response);
         }
 
-        // In production, this would:
-        // 1. Fetch form config from OpenRegister.
-        // 2. Validate submission against form fields.
-        // 3. Map fields to contact/lead properties.
-        // 4. Deduplicate contact by email.
-        // 5. Create contact and lead.
-        // 6. Record submission.
-        // 7. Notify configured user.
-        $response = new JSONResponse(
+        try {
+            $objectService = $this->getObjectService();
+            $config        = $this->getFormConfig();
+
+            if ($config === null || $objectService === null) {
+                $response = new JSONResponse(
+                    ['success' => false, 'message' => 'Service temporarily unavailable.'],
+                    503
+                );
+                return $this->addCorsHeaders(response: $response);
+            }
+
+            $registerId = $this->appConfig->getValueString(Application::APP_ID, 'register', '');
+            $leadSchema = $this->appConfig->getValueString(Application::APP_ID, 'lead_schema', '');
+
+            if ($registerId === '' || $leadSchema === '') {
+                $this->logger->error('PublicFormController: register or lead_schema not configured');
+                $response = new JSONResponse(
+                    ['success' => false, 'message' => 'Service not properly configured.'],
+                    500
+                );
+                return $this->addCorsHeaders(response: $response);
+            }
+
+            // Build lead data from submission (strip internal/honeypot fields).
+            $leadData = $this->buildLeadData(submission: $submission, formId: $id);
+
+            $saved = $objectService->saveObject(
+                $leadData,
+                [],
+                $registerId,
+                $leadSchema,
+                null
+            );
+
+            if ($saved === null) {
+                throw new \RuntimeException('Failed to persist submission');
+            }
+
+            $response = new JSONResponse(
                 [
                     'success' => true,
                     'message' => 'Thank you for your submission.',
                 ]
-                );
+            );
+        } catch (\Exception $e) {
+            $this->logger->error('PublicFormController::submit failed: '.$e->getMessage());
+            $response = new JSONResponse(
+                ['success' => false, 'message' => 'Submission could not be processed.'],
+                500
+            );
+        }//end try
 
         return $this->addCorsHeaders(response: $response);
     }//end submit()
+
+    /**
+     * Build lead data from a raw submission, stripping internal fields.
+     *
+     * @param array<string, mixed> $submission The submitted form data.
+     * @param string               $formId     The form ID.
+     *
+     * @return array<string, mixed> The lead data for OpenRegister.
+     */
+    private function buildLeadData(array $submission, string $formId): array
+    {
+        $data = ['source' => 'public_form', 'formId' => $formId, 'status' => 'nieuw'];
+
+        foreach ($submission as $key => $value) {
+            // Skip honeypot and framework-internal fields.
+            if (str_starts_with($key, '_') === true) {
+                continue;
+            }
+
+            $data[$key] = $value;
+        }
+
+        return $data;
+    }//end buildLeadData()
+
+    /**
+     * Get the OpenRegister ObjectService, or null if unavailable.
+     *
+     * @return object|null The ObjectService instance or null.
+     */
+    private function getObjectService(): ?object
+    {
+        if (in_array('openregister', $this->appManager->getInstalledApps(), true) === false) {
+            return null;
+        }
+
+        try {
+            return $this->container->get('OCA\OpenRegister\Service\ObjectService');
+        } catch (\Exception $e) {
+            $this->logger->error('PublicFormController: failed to load ObjectService: '.$e->getMessage());
+            return null;
+        }
+    }//end getObjectService()
+
+    /**
+     * Get the app form configuration from app config.
+     *
+     * @return array<string, string>|null Config array or null if incomplete.
+     */
+    private function getFormConfig(): ?array
+    {
+        $register   = $this->appConfig->getValueString(Application::APP_ID, 'register', '');
+        $leadSchema = $this->appConfig->getValueString(Application::APP_ID, 'lead_schema', '');
+
+        if ($register === '' || $leadSchema === '') {
+            return null;
+        }
+
+        return ['register' => $register, 'lead_schema' => $leadSchema];
+    }//end getFormConfig()
 
     /**
      * Add CORS headers to allow cross-origin form embedding.

--- a/lib/Controller/PublicKennisbankController.php
+++ b/lib/Controller/PublicKennisbankController.php
@@ -34,6 +34,8 @@ use Psr\Log\LoggerInterface;
 
 /**
  * Public controller for kennisbank article listing and detail.
+ *
+ * @spec openspec/changes/retrofit-2026-05-24-annotate-pipelinq/tasks.md#task-31
  */
 class PublicKennisbankController extends Controller
 {
@@ -70,11 +72,12 @@ class PublicKennisbankController extends Controller
     public function index(): JSONResponse
     {
         try {
-            $objectService = $this->getObjectService();
-            $config        = $this->settingsService->getSettings();
+            $config = $this->settingsService->getSettings();
             if (empty($config['register']) === true || empty($config['kennisartikel_schema']) === true) {
-                return new JSONResponse(data: ['results' => [], 'total' => 0]);
+                return new JSONResponse(['results' => [], 'total' => 0]);
             }
+
+            $objectService = $this->getObjectService();
 
             $filters = ['status' => 'gepubliceerd', 'visibility' => 'openbaar', '_limit' => 20];
             $search  = $this->request->getParam('_search', '');
@@ -82,22 +85,34 @@ class PublicKennisbankController extends Controller
                 $filters['_search'] = $search;
             }
 
-            $result   = $objectService->findAll(
-                register: $config['register'],
-                schema: $config['kennisartikel_schema'],
-                filters: $filters,
+            $result = $objectService->findAll(
+                [
+                    'filters' => array_merge(
+                        ['register' => $config['register'], 'schema' => $config['kennisartikel_schema']],
+                        $filters
+                    ),
+                ]
             );
-            $articles = array_map(
-                callback: [$this, 'stripInternalFields'],
-                array: ($result['results'] ?? []),
+
+            // Server-side guard: only expose gepubliceerd + openbaar articles regardless
+            // of what the OR filter layer returns (defensive enforcement).
+            $rawArticles  = $result['results'] ?? [];
+            $safeArticles = array_values(
+                array_filter(
+                    $rawArticles,
+                    static function (array $a): bool {
+                        return ($a['status'] ?? '') === 'gepubliceerd'
+                            && ($a['visibility'] ?? '') === 'openbaar';
+                    }
+                )
             );
-            $total    = ($result['total'] ?? count(value: $articles));
-            return new JSONResponse(
-                data: ['results' => $articles, 'total' => $total],
-            );
+
+            $articles = array_map([$this, 'stripInternalFields'], $safeArticles);
+            $total    = count($articles);
+            return new JSONResponse(['results' => $articles, 'total' => $total]);
         } catch (\Exception $e) {
             $this->logger->error('Public kennisbank error: '.$e->getMessage());
-            return new JSONResponse(data: ['error' => 'Failed to fetch articles'], statusCode: 500);
+            return new JSONResponse(['error' => 'Failed to fetch articles'], 500);
         }//end try
     }//end index()
 
@@ -117,28 +132,34 @@ class PublicKennisbankController extends Controller
     public function show(string $id): JSONResponse
     {
         try {
-            $objectService = $this->getObjectService();
-            $config        = $this->settingsService->getSettings();
+            $config = $this->settingsService->getSettings();
             if (empty($config['register']) === true || empty($config['kennisartikel_schema']) === true) {
-                return new JSONResponse(data: ['error' => 'Not configured'], statusCode: 404);
+                return new JSONResponse(['error' => 'Not configured'], 404);
             }
 
-            $article = $objectService->findOne(
-                register: $config['register'],
-                schema: $config['kennisartikel_schema'],
-                id: $id,
+            $objectService = $this->getObjectService();
+
+            $results = $objectService->findAll(
+                [
+                    'filters' => [
+                        'register' => $config['register'],
+                        'schema'   => $config['kennisartikel_schema'],
+                        'id'       => $id,
+                    ],
+                ]
             );
+            $article = ($results['results'] ?? $results)[0] ?? null;
             if ($article === null
                 || ($article['status'] ?? '') !== 'gepubliceerd'
                 || ($article['visibility'] ?? '') !== 'openbaar'
             ) {
-                return new JSONResponse(data: ['error' => 'Article not found'], statusCode: 404);
+                return new JSONResponse(['error' => 'Article not found'], 404);
             }
 
-            return new JSONResponse(data: $this->stripInternalFields(article: $article));
+            return new JSONResponse($this->stripInternalFields(article: $article));
         } catch (\Exception $e) {
             $this->logger->error('Public kennisbank show error: '.$e->getMessage());
-            return new JSONResponse(data: ['error' => 'Failed to fetch article'], statusCode: 500);
+            return new JSONResponse(['error' => 'Failed to fetch article'], 500);
         }//end try
     }//end show()
 

--- a/lib/Service/ActivityTimelineService.php
+++ b/lib/Service/ActivityTimelineService.php
@@ -315,7 +315,7 @@ class ActivityTimelineService
                 'limit'   => self::PER_SCHEMA_CEILING,
             ];
 
-            $results = $objectService->findAll($params, _rbac: false, _multitenancy: false);
+            $results = $objectService->findAll($params);
 
             return $this->normaliseResultset(results: $results);
         } catch (\Throwable $e) {
@@ -607,9 +607,7 @@ class ActivityTimelineService
             [],
             $config['register'],
             $config['contactmoment'],
-            null,
-            _rbac: false,
-            _multitenancy: false
+            null
         );
 
         $savedArray = $this->extractObjectArray(saved: $saved);

--- a/lib/Service/AutomationService.php
+++ b/lib/Service/AutomationService.php
@@ -31,6 +31,7 @@ use Psr\Log\LoggerInterface;
  * Service for CRM workflow automation management.
  *
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
+ * @spec                                           openspec/changes/reverse-2026-05-26-be-automation/tasks.md#task-1
  */
 class AutomationService
 {
@@ -77,6 +78,7 @@ class AutomationService
      * Get the list of valid trigger types.
      *
      * @return array The valid trigger types.
+     * @spec   openspec/changes/reverse-2026-05-26-be-automation/tasks.md#task-1
      */
     public function getValidTriggers(): array
     {
@@ -87,6 +89,7 @@ class AutomationService
      * Get the list of valid action types.
      *
      * @return array The valid action types.
+     * @spec   openspec/changes/reverse-2026-05-26-be-automation/tasks.md#task-1
      */
     public function getValidActions(): array
     {
@@ -213,16 +216,28 @@ class AutomationService
     /**
      * Execute a webhook action by sending entity data to the configured URL.
      *
+     * The URL is validated against an SSRF allow-list before firing:
+     * - Scheme must be http or https.
+     * - Resolved IP must not be loopback (127.x, ::1), link-local (169.254.x),
+     *   RFC-1918 private (10.x, 172.16-31.x, 192.168.x), or ULA IPv6 (fc00::/7).
+     * - Response body is never returned to the caller (SSRF exfiltration guard).
+     *
      * @param string $webhookUrl The target webhook URL.
      * @param array  $payload    The payload to send.
      *
-     * @return array The execution result with status and response.
+     * @return array The execution result with status (no response body exposed).
      * @spec   openspec/changes/reverse-2026-05-26-be-automation/tasks.md#task-4
      */
     public function fireWebhook(string $webhookUrl, array $payload): array
     {
         if (empty($webhookUrl) === true) {
             return ['status' => 'skipped', 'reason' => 'No webhook URL configured'];
+        }
+
+        $ssrfCheck = $this->validateWebhookUrl(webhookUrl: $webhookUrl);
+        if ($ssrfCheck !== null) {
+            $this->logger->warning('Automation webhook blocked (SSRF guard): '.$ssrfCheck, ['url' => $webhookUrl]);
+            return ['status' => 'blocked', 'reason' => $ssrfCheck];
         }
 
         try {
@@ -232,9 +247,13 @@ class AutomationService
             curl_setopt($ch, CURLOPT_HTTPHEADER, ['Content-Type: application/json']);
             curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
             curl_setopt($ch, CURLOPT_TIMEOUT, 10);
+            // Disable redirects to prevent SSRF via redirect chains.
+            curl_setopt($ch, CURLOPT_FOLLOWLOCATION, false);
+            // Cap response body to prevent memory exhaustion.
+            curl_setopt($ch, CURLOPT_BUFFERSIZE, 65536);
 
-            $response = curl_exec($ch);
-            $httpCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+            $rawResponse = curl_exec($ch);
+            $httpCode    = curl_getinfo($ch, CURLINFO_HTTP_CODE);
             curl_close($ch);
 
             if ($httpCode >= 200 && $httpCode < 300) {
@@ -243,10 +262,10 @@ class AutomationService
                 $status = 'failure';
             }
 
+            // Never return raw response body to the caller (SSRF exfiltration guard).
             return [
                 'status'   => $status,
                 'httpCode' => $httpCode,
-                'response' => $response,
             ];
         } catch (\Exception $e) {
             $this->logger->error('Automation webhook failed: '.$e->getMessage());
@@ -256,4 +275,122 @@ class AutomationService
             ];
         }//end try
     }//end fireWebhook()
+
+    /**
+     * Validate a webhook URL against the SSRF allow-list.
+     *
+     * Returns a string describing the rejection reason, or null when the URL is safe.
+     *
+     * @param string $webhookUrl The URL to validate.
+     *
+     * @return string|null Rejection reason or null when allowed.
+     * @spec   openspec/changes/reverse-2026-05-26-be-automation/tasks.md#task-4
+     */
+    public function validateWebhookUrl(string $webhookUrl): ?string
+    {
+        $parsed = parse_url($webhookUrl);
+        if ($parsed === false || empty($parsed['scheme']) === true || empty($parsed['host']) === true) {
+            return 'Malformed URL';
+        }
+
+        $scheme = strtolower($parsed['scheme']);
+        if (in_array($scheme, ['http', 'https'], true) === false) {
+            return 'Only http and https schemes are allowed';
+        }
+
+        $host = $parsed['host'];
+
+        // Resolve the hostname to an IP.
+        $ip = gethostbyname($host);
+
+        // Gethostbyname returns the original string on failure.
+        if ($ip === $host && filter_var($host, FILTER_VALIDATE_IP) === false) {
+            return 'Could not resolve hostname';
+        }
+
+        if (filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4) !== false) {
+            return $this->validateIpv4(ip: $ip);
+        }
+
+        if (filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV6) !== false) {
+            return $this->validateIpv6(ip: $ip);
+        }
+
+        return null;
+    }//end validateWebhookUrl()
+
+    /**
+     * Validate an IPv4 address against the SSRF block-list.
+     *
+     * @param string $ip The IPv4 address.
+     *
+     * @return string|null Rejection reason or null when allowed.
+     */
+    private function validateIpv4(string $ip): ?string
+    {
+        $long = ip2long($ip);
+        if ($long === false) {
+            return 'Invalid IPv4 address';
+        }
+
+        // Loopback: 127.0.0.0/8.
+        if (($long & 0xFF000000) === 0x7F000000) {
+            return 'Loopback addresses are not allowed';
+        }
+
+        // Link-local: 169.254.0.0/16.
+        if (($long & 0xFFFF0000) === 0xA9FE0000) {
+            return 'Link-local addresses are not allowed';
+        }
+
+        // RFC-1918: 10.0.0.0/8.
+        if (($long & 0xFF000000) === 0x0A000000) {
+            return 'Private (RFC-1918) addresses are not allowed';
+        }
+
+        // RFC-1918: 172.16.0.0/12.
+        if (($long & 0xFFF00000) === 0xAC100000) {
+            return 'Private (RFC-1918) addresses are not allowed';
+        }
+
+        // RFC-1918: 192.168.0.0/16.
+        if (($long & 0xFFFF0000) === 0xC0A80000) {
+            return 'Private (RFC-1918) addresses are not allowed';
+        }
+
+        return null;
+    }//end validateIpv4()
+
+    /**
+     * Validate an IPv6 address against the SSRF block-list.
+     *
+     * @param string $ip The IPv6 address.
+     *
+     * @return string|null Rejection reason or null when allowed.
+     */
+    private function validateIpv6(string $ip): ?string
+    {
+        // Loopback: ::1.
+        if ($ip === '::1') {
+            return 'Loopback addresses are not allowed';
+        }
+
+        // ULA: fc00::/7 — first byte is 0xFC or 0xFD.
+        $packed = inet_pton($ip);
+        if ($packed !== false) {
+            $firstByte = ord($packed[0]);
+            if (($firstByte & 0xFE) === 0xFC) {
+                return 'ULA (private) IPv6 addresses are not allowed';
+            }
+
+            // Link-local: fe80::/10.
+            $firstTwoBits = ($firstByte & 0xC0);
+            $secondBits   = (ord($packed[0]) & 0x3F);
+            if ($firstByte === 0xFE && ($ord1 = ord($packed[1])) >= 0x80 && $ord1 <= 0xBF) {
+                return 'Link-local IPv6 addresses are not allowed';
+            }
+        }
+
+        return null;
+    }//end validateIpv6()
 }//end class

--- a/lib/Service/ContactImportService.php
+++ b/lib/Service/ContactImportService.php
@@ -105,12 +105,10 @@ class ContactImportService
 
         $created = $objectService->saveObject(
             $data,
-                [],
-                $registerId,
-                $schemaId,
-                null,
-                _rbac: false,
-                _multitenancy: false
+            [],
+            $registerId,
+            $schemaId,
+            null
         );
 
         return $this->serializeResult(result: $created);

--- a/lib/Service/ContactLinkedUidsService.php
+++ b/lib/Service/ContactLinkedUidsService.php
@@ -89,9 +89,7 @@ class ContactLinkedUidsService
 
         try {
             $objects = $objectService->findAll(
-                ['filters' => ['register' => $registerId, 'schema' => $schemaId], 'limit' => 500],
-                _rbac: false,
-                _multitenancy: false
+                ['filters' => ['register' => $registerId, 'schema' => $schemaId], 'limit' => 500]
             );
 
             foreach ($objects as $obj) {

--- a/lib/Service/ContactVcardPropertyBuilder.php
+++ b/lib/Service/ContactVcardPropertyBuilder.php
@@ -159,10 +159,8 @@ class ContactVcardPropertyBuilder
         try {
             $client = $objectService->findObject(
                 $clientId,
-                    $registerId,
-                    $schemaId,
-                    _rbac: false,
-                    _multitenancy: false
+                $registerId,
+                $schemaId
             );
             $data   = $this->serializeResult(result: $client);
             return $data['name'] ?? null;

--- a/lib/Service/ContactVcardService.php
+++ b/lib/Service/ContactVcardService.php
@@ -114,10 +114,8 @@ class ContactVcardService
         try {
             $object = $objectService->findObject(
                 $objectId,
-                    $registerId,
-                    $schemaId,
-                    _rbac: false,
-                    _multitenancy: false
+                $registerId,
+                $schemaId
             );
         } catch (\Exception $e) {
             $this->logger->error('Pipelinq: Failed to fetch object for sync', ['exception' => $e->getMessage()]);

--- a/lib/Service/ContactVcardWriterService.php
+++ b/lib/Service/ContactVcardWriterService.php
@@ -147,12 +147,10 @@ class ContactVcardWriterService
             $updateData['contactsUid'] = $contactsUid;
             $objectService->saveObject(
                 $updateData,
-                    [],
-                    $registerId,
-                    $schemaId,
-                    null,
-                    _rbac: false,
-                    _multitenancy: false
+                [],
+                $registerId,
+                $schemaId,
+                null
             );
         } catch (\Exception $e) {
             $this->logger->warning(

--- a/lib/Service/DefaultPipelineService.php
+++ b/lib/Service/DefaultPipelineService.php
@@ -79,9 +79,7 @@ class DefaultPipelineService
                         'title'    => 'Sales Pipeline',
                     ],
                     'limit'   => 1,
-                ],
-                _rbac: false,
-                _multitenancy: false
+                ]
             );
 
             if (empty($existing) === false) {
@@ -131,9 +129,7 @@ class DefaultPipelineService
             [],
             $registerId,
             $schemaId,
-            null,
-            _rbac: false,
-            _multitenancy: false
+            null
         );
 
         $title = $data['title'] ?? 'Unknown';

--- a/lib/Service/DefaultQueueService.php
+++ b/lib/Service/DefaultQueueService.php
@@ -144,9 +144,7 @@ class DefaultQueueService
                         'schema'   => $queueSchemaId,
                     ],
                     'limit'   => 1,
-                ],
-                _rbac: false,
-                _multitenancy: false
+                ]
             );
 
             if (empty($existing) === false) {
@@ -160,9 +158,7 @@ class DefaultQueueService
                     [],
                     $registerId,
                     $queueSchemaId,
-                    null,
-                    _rbac: false,
-                    _multitenancy: false
+                    null
                 );
                 $this->logger->info("Pipelinq: Created default queue '{$queueData['title']}'");
             }
@@ -203,9 +199,7 @@ class DefaultQueueService
                         'schema'   => $skillSchemaId,
                     ],
                     'limit'   => 1,
-                ],
-                _rbac: false,
-                _multitenancy: false
+                ]
             );
 
             if (empty($existing) === false) {
@@ -219,9 +213,7 @@ class DefaultQueueService
                     [],
                     $registerId,
                     $skillSchemaId,
-                    null,
-                    _rbac: false,
-                    _multitenancy: false
+                    null
                 );
                 $this->logger->info("Pipelinq: Created default skill '{$skillData['title']}'");
             }

--- a/lib/Service/ObjectEventHandlerService.php
+++ b/lib/Service/ObjectEventHandlerService.php
@@ -23,8 +23,16 @@ declare(strict_types=1);
 
 namespace OCA\Pipelinq\Service;
 
+use OCA\Pipelinq\AppInfo\Application;
+use OCP\IAppConfig;
+use Psr\Container\ContainerInterface;
+use Psr\Log\LoggerInterface;
+
 /**
  * Service for handling object event business logic.
+ *
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
+ * @spec                                           openspec/changes/retrofit-2026-05-24-annotate-pipelinq/tasks.md#task-47
  */
 class ObjectEventHandlerService
 {
@@ -35,12 +43,18 @@ class ObjectEventHandlerService
      * @param ObjectEventDispatcher   $dispatcher        The event dispatcher.
      * @param ObjectUpdateDiffService $diffService       The update diff service.
      * @param AutomationService       $automationService The automation service.
+     * @param IAppConfig              $appConfig         The app config.
+     * @param ContainerInterface      $container         The DI container.
+     * @param LoggerInterface         $logger            The logger.
      */
     public function __construct(
         private SchemaMapService $schemaMapService,
         private ObjectEventDispatcher $dispatcher,
         private ObjectUpdateDiffService $diffService,
         private AutomationService $automationService,
+        private IAppConfig $appConfig,
+        private ContainerInterface $container,
+        private LoggerInterface $logger,
     ) {
     }//end __construct()
 
@@ -174,7 +188,14 @@ class ObjectEventHandlerService
     }//end extractOldData()
 
     /**
-     * Fire matching automations for entity creation.
+     * Fire matching automations for entity creation or update events.
+     *
+     * Loads automation rules from OpenRegister, evaluates each rule's conditions
+     * against the trigger + entity data, and dispatches webhook actions for
+     * every matching, active automation.
+     *
+     * Failures are caught and logged; automation errors must never break the
+     * main object-event flow.
      *
      * @param string $trigger    The trigger event name.
      * @param array  $entityData The entity data.
@@ -187,17 +208,110 @@ class ObjectEventHandlerService
     private function fireAutomations(string $trigger, array $entityData, string $objectId): void
     {
         try {
-            $payload = $this->automationService->buildWebhookPayload(
-                automation: ['name' => $trigger],
-                trigger: $trigger,
-                entityData: array_merge($entityData, ['id' => $objectId])
-            );
-            // Webhook firing is handled by the automation execution engine.
-            // This is a placeholder for the full automation matching pipeline.
+            $automations = $this->loadAutomationRules();
+            if ($automations === []) {
+                return;
+            }
+
+            $fullEntityData = array_merge($entityData, ['id' => $objectId]);
+
+            foreach ($automations as $automation) {
+                if ($this->automationService->matchesConditions($automation, $trigger, $fullEntityData) === false) {
+                    continue;
+                }
+
+                $actions = $automation['actions'] ?? [];
+                foreach ($actions as $action) {
+                    if (($action['type'] ?? '') !== 'webhook') {
+                        continue;
+                    }
+
+                    $webhookUrl = (string) ($action['webhookUrl'] ?? '');
+                    if ($webhookUrl === '') {
+                        continue;
+                    }
+
+                    $payload = $this->automationService->buildWebhookPayload(
+                        automation: $automation,
+                        trigger: $trigger,
+                        entityData: $fullEntityData
+                    );
+
+                    $result = $this->automationService->fireWebhook($webhookUrl, $payload);
+                    $this->logger->info(
+                        'ObjectEventHandlerService: automation webhook fired',
+                        [
+                            'trigger'        => $trigger,
+                            'automationName' => $automation['name'] ?? '',
+                            'status'         => $result['status'] ?? 'unknown',
+                        ]
+                    );
+                }//end foreach
+            }//end foreach
         } catch (\Exception $e) {
             // Automation failures must not break the main event flow.
-        }
+            $this->logger->error(
+                'ObjectEventHandlerService: fireAutomations failed',
+                ['trigger' => $trigger, 'error' => $e->getMessage()]
+            );
+        }//end try
     }//end fireAutomations()
+
+    /**
+     * Load automation rules from OpenRegister.
+     *
+     * Returns an empty array when OR is unavailable or not configured.
+     *
+     * @return array<int, array<string, mixed>> The automation rule objects.
+     */
+    private function loadAutomationRules(): array
+    {
+        $registerId       = $this->appConfig->getValueString(Application::APP_ID, 'register', '');
+        $automationSchema = $this->appConfig->getValueString(Application::APP_ID, 'automation_schema', '');
+
+        if ($registerId === '' || $automationSchema === '') {
+            return [];
+        }
+
+        try {
+            $objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
+            $results       = $objectService->findAll(
+                [
+                    'filters' => [
+                        'register' => $registerId,
+                        'schema'   => $automationSchema,
+                        'isActive' => true,
+                    ],
+                    'limit'   => 200,
+                ]
+            );
+
+            if (is_array($results) === false) {
+                return [];
+            }
+
+            // Normalise ObjectEntity-or-array items to plain arrays.
+            $rules = [];
+            foreach ($results as $item) {
+                if (is_array($item) === true) {
+                    $rules[] = $item;
+                } else if (is_object($item) === true && method_exists($item, 'getObject') === true) {
+                    $data = $item->getObject();
+                    if (is_array($data) === true) {
+                        $rules[] = $data;
+                    }
+                }
+            }
+
+            return $rules;
+        } catch (\Exception $e) {
+            $this->logger->warning(
+                'ObjectEventHandlerService: could not load automation rules',
+                ['error' => $e->getMessage()]
+            );
+            return [];
+        }//end try
+    }//end loadAutomationRules()
 
     /**
      * Fire matching automations for entity update events.

--- a/lib/Service/QueueService.php
+++ b/lib/Service/QueueService.php
@@ -75,9 +75,7 @@ class QueueService
                         'queue'    => $queueId,
                     ],
                     'limit'   => 1,
-                ],
-                _rbac: false,
-                _multitenancy: false
+                ]
             );
 
             return count($results);
@@ -169,9 +167,7 @@ class QueueService
                         'schema'   => $queueSchemaId,
                     ],
                     'limit'   => 200,
-                ],
-                _rbac: false,
-                _multitenancy: false
+                ]
             );
 
             foreach ($queues as $queue) {
@@ -261,9 +257,7 @@ class QueueService
                     ],
                     'limit'   => $count,
                     'order'   => ['dateCreated' => 'DESC'],
-                ],
-                _rbac: false,
-                _multitenancy: false
+                ]
             );
 
             foreach ($items as $item) {
@@ -312,9 +306,7 @@ class QueueService
                 [],
                 $registerId,
                 $schemaId,
-                null,
-                _rbac: false,
-                _multitenancy: false
+                null
             );
 
             return true;

--- a/lib/Service/RoutingService.php
+++ b/lib/Service/RoutingService.php
@@ -101,9 +101,7 @@ class RoutingService
         try {
             $entity = $objectService->find(
                 $entityId,
-                [],
-                _rbac: false,
-                _multitenancy: false
+                []
             );
         } catch (\Throwable $e) {
             $this->logger->error(
@@ -191,9 +189,7 @@ class RoutingService
                             'assignee' => $userId,
                         ],
                         'limit'   => 999,
-                    ],
-                    _rbac: false,
-                    _multitenancy: false
+                    ]
                 );
 
                 foreach ($requests as $request) {
@@ -222,9 +218,7 @@ class RoutingService
                             'status'   => 'open',
                         ],
                         'limit'   => 999,
-                    ],
-                    _rbac: false,
-                    _multitenancy: false
+                    ]
                 );
 
                 $count += count($leads);
@@ -276,9 +270,7 @@ class RoutingService
                         'isActive' => true,
                     ],
                     'limit'   => 999,
-                ],
-                _rbac: false,
-                _multitenancy: false
+                ]
             );
         } catch (\Throwable $e) {
             $this->logger->error(
@@ -320,9 +312,7 @@ class RoutingService
                         'schema'   => $agentProfileSchemaId,
                     ],
                     'limit'   => 999,
-                ],
-                _rbac: false,
-                _multitenancy: false
+                ]
             );
         } catch (\Throwable $e) {
             $this->logger->error(

--- a/lib/Service/ScheduledTaskService.php
+++ b/lib/Service/ScheduledTaskService.php
@@ -161,9 +161,7 @@ class ScheduledTaskService
                     'limit'   => $limit,
                     'offset'  => (($page - 1) * $limit),
                     'order'   => ['deadline' => 'ASC'],
-                ],
-                _rbac: false,
-                _multitenancy: false
+                ]
             );
         } catch (Throwable $e) {
             $this->logger->error(
@@ -206,9 +204,7 @@ class ScheduledTaskService
             $object = $this->getObjectService()->findObject(
                 $id,
                 $registerId,
-                $schemaId,
-                _rbac: false,
-                _multitenancy: false
+                $schemaId
             );
         } catch (Throwable $e) {
             $this->logger->error(
@@ -276,9 +272,7 @@ class ScheduledTaskService
             [],
             $registerId,
             $schemaId,
-            null,
-            _rbac: false,
-            _multitenancy: false
+            null
         );
 
         return $this->normalizeToArray(object: $saved);
@@ -312,9 +306,7 @@ class ScheduledTaskService
             [],
             $registerId,
             $schemaId,
-            $id,
-            _rbac: false,
-            _multitenancy: false
+            $id
         );
 
         return $this->normalizeToArray(object: $saved);
@@ -331,11 +323,7 @@ class ScheduledTaskService
      */
     public function deleteScheduledTask(string $id): void
     {
-        $this->getObjectService()->deleteObject(
-            $id,
-            _rbac: false,
-            _multitenancy: false
-        );
+        $this->getObjectService()->deleteObject($id);
     }//end deleteScheduledTask()
 
     /**
@@ -381,9 +369,7 @@ class ScheduledTaskService
                     ],
                     'limit'   => 100,
                     'order'   => ['deadline' => 'ASC'],
-                ],
-                _rbac: false,
-                _multitenancy: false
+                ]
             );
         } catch (Throwable $e) {
             $this->logger->error(
@@ -500,9 +486,7 @@ class ScheduledTaskService
                     [],
                     $registerId,
                     $schemaId,
-                    (string) ($task['id'] ?? ''),
-                    _rbac: false,
-                    _multitenancy: false
+                    (string) ($task['id'] ?? '')
                 );
             } catch (Throwable $e) {
                 $this->logger->error(

--- a/openspec/architecture/adr-003-tenancy-and-rbac-model.md
+++ b/openspec/architecture/adr-003-tenancy-and-rbac-model.md
@@ -1,0 +1,41 @@
+# ADR-003: Tenancy and RBAC Model
+
+**Status:** Accepted  
+**Date:** 2026-05-27  
+**Deciders:** Conduction Development Team
+
+## Context
+
+The initial Pipelinq codebase passed `_rbac: false` and `_multitenancy: false` to every
+OpenRegister `ObjectService` call, completely bypassing OR's built-in row-level access
+control. This caused an instance-wide IDOR: any authenticated user could read or mutate
+CRM data belonging to any other user or organisation on the same NC instance.
+
+## Decision
+
+All `ObjectService` calls (findAll, findObject, saveObject, deleteObject, find) in this
+application must rely on OpenRegister's built-in RBAC and multi-tenancy enforcement. The
+`_rbac` and `_multitenancy` override parameters must never be set to `false` in production
+code.
+
+Per-object ownership scoping (where needed) is achieved through field filters on
+`assigneeUserId`, `createdBy`, or group membership, and through OR's native
+permission system — not by disabling the ACL.
+
+**Mutation authorisation** for tasks and callbacks uses `ScheduledTaskService::authorizeTaskMutation`,
+which allows the action only when the acting user is:
+1. The assignee (`assigneeUserId`), or
+2. A member of the assigned group (`assigneeGroupId`), or
+3. A Nextcloud administrator.
+
+**Reassignment** of tasks to arbitrary users is restricted to administrators only (via
+`IGroupManager::isAdmin`) to prevent notification spam and privilege escalation.
+
+## Consequences
+
+- OpenRegister's row-level isolation is enforced for all CRM objects.
+- Per-user task management is correctly scoped; cross-user access is blocked.
+- Background jobs (ScheduledTaskJob, CallbackOverdueJob) run with system context; they must
+  only operate on objects owned by the system or globally visible tasks.
+- Any future code that needs elevated access must add an explicit exception with a documented
+  justification comment — never a blanket flag suppression.

--- a/tests/Unit/Controller/CallbackControllerTest.php
+++ b/tests/Unit/Controller/CallbackControllerTest.php
@@ -22,7 +22,9 @@ namespace OCA\Pipelinq\Tests\Unit\Controller;
 use OCA\Pipelinq\Controller\CallbackController;
 use OCA\Pipelinq\Service\CallbackService;
 use OCA\Pipelinq\Service\NotificationService;
+use OCA\Pipelinq\Service\ScheduledTaskService;
 use OCP\IAppConfig;
+use OCP\IGroupManager;
 use OCP\IL10N;
 use OCP\IRequest;
 use OCP\IUserSession;
@@ -64,11 +66,25 @@ class CallbackControllerTest extends TestCase
     private IRequest $request;
 
     /**
+     * Mock scheduled task service.
+     *
+     * @var ScheduledTaskService&MockObject
+     */
+    private ScheduledTaskService $scheduledTaskService;
+
+    /**
      * Mock app config.
      *
      * @var IAppConfig&MockObject
      */
     private IAppConfig $appConfig;
+
+    /**
+     * Mock group manager.
+     *
+     * @var IGroupManager&MockObject
+     */
+    private IGroupManager $groupManager;
 
     /**
      * Mock user session.
@@ -84,23 +100,27 @@ class CallbackControllerTest extends TestCase
      */
     protected function setUp(): void
     {
-        $this->request             = $this->createMock(IRequest::class);
-        $this->callbackService     = $this->createMock(CallbackService::class);
-        $this->notificationService = $this->createMock(NotificationService::class);
-        $this->appConfig           = $this->createMock(IAppConfig::class);
-        $this->userSession         = $this->createMock(IUserSession::class);
-        $user                      = $this->createMock(\OCP\IUser::class);
+        $this->request               = $this->createMock(IRequest::class);
+        $this->callbackService       = $this->createMock(CallbackService::class);
+        $this->notificationService   = $this->createMock(NotificationService::class);
+        $this->scheduledTaskService  = $this->createMock(ScheduledTaskService::class);
+        $this->appConfig             = $this->createMock(IAppConfig::class);
+        $this->groupManager          = $this->createMock(IGroupManager::class);
+        $this->userSession           = $this->createMock(IUserSession::class);
+        $user                        = $this->createMock(\OCP\IUser::class);
         $user->method('getUID')->willReturn('test-agent');
         $this->userSession->method('getUser')->willReturn($user);
-        $logger                    = $this->createMock(LoggerInterface::class);
-        $l10n                      = $this->createMock(IL10N::class);
+        $logger                      = $this->createMock(LoggerInterface::class);
+        $l10n                        = $this->createMock(IL10N::class);
         $l10n->method('t')->willReturnArgument(0);
 
         $this->controller = new CallbackController(
             $this->request,
             $this->callbackService,
             $this->notificationService,
+            $this->scheduledTaskService,
             $this->appConfig,
+            $this->groupManager,
             $this->userSession,
             $l10n,
             $logger,
@@ -125,7 +145,7 @@ class CallbackControllerTest extends TestCase
     }//end testAttemptReturns400WhenResultMissing()
 
     /**
-     * Test attempt returns 404 when task not found (no config).
+     * Test attempt returns 404 when task not found.
      *
      * @return void
      */
@@ -136,7 +156,8 @@ class CallbackControllerTest extends TestCase
             ['notes', '', ''],
         ]);
 
-        $this->appConfig->method('getValueString')->willReturn('');
+        $this->scheduledTaskService->method('getScheduledTask')
+            ->willThrowException(new \RuntimeException('Task not found'));
 
         $response = $this->controller->attempt('task-123');
 
@@ -155,11 +176,14 @@ class CallbackControllerTest extends TestCase
             ['notes', '', 'Voicemail'],
         ]);
 
-        $this->appConfig->method('getValueString')->willReturn('configured');
+        $taskData = ['id' => 'task-123', 'status' => 'open', 'assigneeUserId' => 'test-agent', 'attempts' => []];
+        $this->scheduledTaskService->method('getScheduledTask')->willReturn($taskData);
+        // authorizeTaskMutation is void; not throwing = authorized.
 
         $updatedTask = ['id' => 'task-123', 'attempts' => [['result' => 'niet_bereikbaar']]];
         $this->callbackService->method('addAttempt')->willReturn($updatedTask);
         $this->callbackService->method('isAttemptThresholdReached')->willReturn(false);
+        $this->scheduledTaskService->method('updateScheduledTask')->willReturn($updatedTask);
 
         $response = $this->controller->attempt('task-123');
 
@@ -173,7 +197,8 @@ class CallbackControllerTest extends TestCase
      */
     public function testClaimReturns403WhenNotEligible(): void
     {
-        $this->appConfig->method('getValueString')->willReturn('configured');
+        $taskData = ['id' => 'task-123', 'status' => 'open', 'assigneeGroupId' => 'support'];
+        $this->scheduledTaskService->method('getScheduledTask')->willReturn($taskData);
         $this->callbackService->method('validateClaim')->willReturn([
             'eligible' => false,
             'reason'   => 'User is not a member of the assigned group',
@@ -191,14 +216,15 @@ class CallbackControllerTest extends TestCase
      */
     public function testClaimReturnsSuccessWhenEligible(): void
     {
-        $this->appConfig->method('getValueString')->willReturn('configured');
+        $taskData = ['id' => 'task-123', 'status' => 'open'];
+        $this->scheduledTaskService->method('getScheduledTask')->willReturn($taskData);
         $this->callbackService->method('validateClaim')->willReturn([
             'eligible' => true,
             'reason'   => '',
         ]);
-        $this->callbackService->method('applyClaim')->willReturn([
-            'id' => 'task-123', 'assigneeUserId' => 'agent-001', 'status' => 'in_behandeling',
-        ]);
+        $claimedTask = ['id' => 'task-123', 'assigneeUserId' => 'agent-001', 'status' => 'in_behandeling'];
+        $this->callbackService->method('applyClaim')->willReturn($claimedTask);
+        $this->scheduledTaskService->method('updateScheduledTask')->willReturn($claimedTask);
 
         $response = $this->controller->claim('task-123');
 
@@ -212,7 +238,9 @@ class CallbackControllerTest extends TestCase
      */
     public function testCompleteReturns400ForInvalidTransition(): void
     {
-        $this->appConfig->method('getValueString')->willReturn('configured');
+        $taskData = ['id' => 'task-123', 'status' => 'open', 'assigneeUserId' => 'test-agent'];
+        $this->scheduledTaskService->method('getScheduledTask')->willReturn($taskData);
+        // authorizeTaskMutation is void; not throwing = authorized.
         $this->callbackService->method('validateStatusTransition')->willReturn([
             'valid'  => false,
             'reason' => 'Transition not allowed',
@@ -234,6 +262,8 @@ class CallbackControllerTest extends TestCase
             ['assignee', '', ''],
             ['assigneeType', '', ''],
         ]);
+        // Admin check: user is admin.
+        $this->groupManager->method('isAdmin')->willReturn(true);
 
         $response = $this->controller->reassign('task-123');
 
@@ -241,7 +271,25 @@ class CallbackControllerTest extends TestCase
     }//end testReassignReturns400WhenAssigneeMissing()
 
     /**
-     * Test reassign returns success with valid data.
+     * Test reassign returns 403 when caller is not an admin.
+     *
+     * @return void
+     */
+    public function testReassignReturns403WhenNotAdmin(): void
+    {
+        $this->request->method('getParam')->willReturnMap([
+            ['assignee', '', 'new-user'],
+            ['assigneeType', '', 'user'],
+        ]);
+        $this->groupManager->method('isAdmin')->willReturn(false);
+
+        $response = $this->controller->reassign('task-123');
+
+        $this->assertSame(403, $response->getStatus());
+    }//end testReassignReturns403WhenNotAdmin()
+
+    /**
+     * Test reassign returns success with valid data (admin user).
      *
      * @return void
      */
@@ -251,18 +299,16 @@ class CallbackControllerTest extends TestCase
             ['assignee', '', 'new-user'],
             ['assigneeType', '', 'user'],
         ]);
+        $this->groupManager->method('isAdmin')->willReturn(true);
 
-        $this->appConfig->method('getValueString')->willReturn('configured');
-        $this->callbackService->method('applyReassignment')->willReturn([
-            'id' => 'task-123', 'assigneeUserId' => 'new-user',
-        ]);
-        $this->callbackService->method('addAttempt')->willReturn([
-            'id' => 'task-123', 'assigneeUserId' => 'new-user', 'attempts' => [],
-        ]);
+        $taskData        = ['id' => 'task-123', 'status' => 'open', 'subject' => 'Call'];
+        $reassignedTask  = ['id' => 'task-123', 'assigneeUserId' => 'new-user'];
+        $withAttemptTask = ['id' => 'task-123', 'assigneeUserId' => 'new-user', 'attempts' => []];
 
-        $user = $this->createMock(\OCP\IUser::class);
-        $user->method('getUID')->willReturn('current-user');
-        $this->userSession->method('getUser')->willReturn($user);
+        $this->scheduledTaskService->method('getScheduledTask')->willReturn($taskData);
+        $this->callbackService->method('applyReassignment')->willReturn($reassignedTask);
+        $this->callbackService->method('addAttempt')->willReturn($withAttemptTask);
+        $this->scheduledTaskService->method('updateScheduledTask')->willReturn($withAttemptTask);
 
         $response = $this->controller->reassign('task-123');
 

--- a/tests/Unit/Controller/PublicKennisbankControllerTest.php
+++ b/tests/Unit/Controller/PublicKennisbankControllerTest.php
@@ -76,12 +76,6 @@ class PublicKennisbankControllerTest extends TestCase
      */
     protected function setUp(): void
     {
-        $this->markTestSkipped(
-            'See https://github.com/ConductionNL/pipelinq/issues/286 — '
-            .'PublicKennisbankController calls findOne()/findAll() on OpenRegister ObjectService '
-            .'with named args that do not match the real API. Unskip once #286 is resolved.'
-        );
-
         $this->request         = $this->createMock(IRequest::class);
         $this->container       = $this->createMock(ContainerInterface::class);
         $this->appManager      = $this->createMock(IAppManager::class);
@@ -141,7 +135,10 @@ class PublicKennisbankControllerTest extends TestCase
         $this->request->method('getParam')->willReturn('');
 
         $objectServiceMock = $this->getMockBuilder(\stdClass::class)->addMethods(['findAll'])->getMock();
-        $objectServiceMock->method('findAll')->willReturn(['results' => [['id' => '1', 'title' => 'Article']], 'total' => 1]);
+        $objectServiceMock->method('findAll')->willReturn([
+            'results' => [['id' => '1', 'title' => 'Article', 'status' => 'gepubliceerd', 'visibility' => 'openbaar']],
+            'total'   => 1,
+        ]);
         $this->container->method('get')->willReturn($objectServiceMock);
 
         $data = $this->buildController()->index()->getData();
@@ -193,16 +190,8 @@ class PublicKennisbankControllerTest extends TestCase
     public function testIndexStripsInternalFields(): void
     {
         $this->appManager->method('getInstalledApps')->willReturn(['openregister']);
-        $this->settingsService->method('getSettings')->willReturn(['register' => 'r', 'kennisartikel_schema' => 's']);
-        $this->request->method('getParam')->willReturn('');
-
-        $objectServiceMock = $this->getMockBuilder(\stdClass::class)->addMethods(['findAll'])->getMock();
-        $objectServiceMock->method('findAll')->willReturn(['results' => [['id' => '1', 'title' => 'A', 'author' => 'secret', 'lastUpdatedBy' => 'u', 'zaaktypeLinks' => []]]]);
-        $this->container->method('get')->willReturn($objectServiceMock);
-
-        $article = $this->buildController()->index()->getData()['results'][0];
         $this->settingsService->method('getSettings')->willReturn([
-            'register'           => 'reg-uuid',
+            'register'             => 'reg-uuid',
             'kennisartikel_schema' => 'schema-uuid',
         ]);
         $this->request->method('getParam')->willReturn('');
@@ -214,6 +203,8 @@ class PublicKennisbankControllerTest extends TestCase
             'results' => [[
                 'id'            => '1',
                 'title'         => 'Article',
+                'status'        => 'gepubliceerd',
+                'visibility'    => 'openbaar',
                 'author'        => 'secret-user',
                 'lastUpdatedBy' => 'another-user',
                 'zaaktypeLinks' => ['link1'],
@@ -254,8 +245,8 @@ class PublicKennisbankControllerTest extends TestCase
         $this->appManager->method('getInstalledApps')->willReturn(['openregister']);
         $this->settingsService->method('getSettings')->willReturn(['register' => 'r', 'kennisartikel_schema' => 's']);
 
-        $objectServiceMock = $this->getMockBuilder(\stdClass::class)->addMethods(['findOne'])->getMock();
-        $objectServiceMock->method('findOne')->willReturn(null);
+        $objectServiceMock = $this->getMockBuilder(\stdClass::class)->addMethods(['findAll'])->getMock();
+        $objectServiceMock->method('findAll')->willReturn(['results' => []]);
         $this->container->method('get')->willReturn($objectServiceMock);
 
         $this->assertSame(404, $this->buildController()->show(id: 'missing')->getStatus());
@@ -271,10 +262,15 @@ class PublicKennisbankControllerTest extends TestCase
         $this->appManager->method('getInstalledApps')->willReturn(['openregister']);
         $this->settingsService->method('getSettings')->willReturn(['register' => 'r', 'kennisartikel_schema' => 's']);
 
-        $objectServiceMock = $this->getMockBuilder(\stdClass::class)->addMethods(['findOne'])->getMock();
-        $objectServiceMock->method('findOne')->willReturn(['id' => 'abc', 'title' => 'Public', 'status' => 'gepubliceerd', 'visibility' => 'openbaar']);
-        $this->assertArrayHasKey('error', $response->getData());
-    }//end testIndexReturns500OnException()
+        $objectServiceMock = $this->getMockBuilder(\stdClass::class)->addMethods(['findAll'])->getMock();
+        $objectServiceMock->method('findAll')->willReturn([
+            'results' => [['id' => 'abc', 'title' => 'Public', 'status' => 'gepubliceerd', 'visibility' => 'openbaar']],
+        ]);
+        $this->container->method('get')->willReturn($objectServiceMock);
+
+        $response = $this->buildController()->show(id: 'abc');
+        $this->assertSame(200, $response->getStatus());
+    }//end testShowReturnsPublicArticle()
 
     /**
      * Test that show returns 404 when article is not found.
@@ -285,14 +281,14 @@ class PublicKennisbankControllerTest extends TestCase
     {
         $this->appManager->method('getInstalledApps')->willReturn(['openregister']);
         $this->settingsService->method('getSettings')->willReturn([
-            'register'           => 'reg-uuid',
+            'register'             => 'reg-uuid',
             'kennisartikel_schema' => 'schema-uuid',
         ]);
 
         $objectServiceMock = $this->getMockBuilder(\stdClass::class)
-            ->addMethods(['findOne'])
+            ->addMethods(['findAll'])
             ->getMock();
-        $objectServiceMock->method('findOne')->willReturn(null);
+        $objectServiceMock->method('findAll')->willReturn(['results' => []]);
         $this->container->method('get')->willReturn($objectServiceMock);
 
         $response = $this->buildController()->show(id: 'nonexistent');
@@ -301,7 +297,7 @@ class PublicKennisbankControllerTest extends TestCase
     }//end testShowReturns404WhenArticleNotFound()
 
     /**
-     * Test that show returns 404 for non-public articles.
+     * Test that show returns 404 for non-public articles (visibility=intern).
      *
      * @return void
      */
@@ -309,15 +305,17 @@ class PublicKennisbankControllerTest extends TestCase
     {
         $this->appManager->method('getInstalledApps')->willReturn(['openregister']);
         $this->settingsService->method('getSettings')->willReturn([
-            'register'           => 'reg-uuid',
+            'register'             => 'reg-uuid',
             'kennisartikel_schema' => 'schema-uuid',
         ]);
 
         $objectServiceMock = $this->getMockBuilder(\stdClass::class)
-            ->addMethods(['findOne'])
+            ->addMethods(['findAll'])
             ->getMock();
-        // Article exists but visibility is 'intern', not 'openbaar'.
-        $objectServiceMock->method('findOne')->willReturn(['id' => '1', 'status' => 'gepubliceerd', 'visibility' => 'intern']);
+        // Article exists but visibility is 'intern', not 'openbaar' — server-side guard must reject it.
+        $objectServiceMock->method('findAll')->willReturn([
+            'results' => [['id' => '1', 'status' => 'gepubliceerd', 'visibility' => 'intern']],
+        ]);
         $this->container->method('get')->willReturn($objectServiceMock);
 
         $response = $this->buildController()->show(id: '1');
@@ -334,18 +332,22 @@ class PublicKennisbankControllerTest extends TestCase
     {
         $this->appManager->method('getInstalledApps')->willReturn(['openregister']);
         $this->settingsService->method('getSettings')->willReturn([
-            'register'           => 'reg-uuid',
+            'register'             => 'reg-uuid',
             'kennisartikel_schema' => 'schema-uuid',
         ]);
 
         $objectServiceMock = $this->getMockBuilder(\stdClass::class)
-            ->addMethods(['findOne'])
+            ->addMethods(['findAll'])
             ->getMock();
-        $objectServiceMock->method('findOne')->willReturn([
-            'id'         => 'abc',
-            'title'      => 'Public Article',
-            'status'     => 'gepubliceerd',
-            'visibility' => 'openbaar',
+        $objectServiceMock->method('findAll')->willReturn([
+            'results' => [
+                [
+                    'id'         => 'abc',
+                    'title'      => 'Public Article',
+                    'status'     => 'gepubliceerd',
+                    'visibility' => 'openbaar',
+                ],
+            ],
         ]);
         $this->container->method('get')->willReturn($objectServiceMock);
 
@@ -353,5 +355,5 @@ class PublicKennisbankControllerTest extends TestCase
 
         $this->assertSame(200, $response->getStatus());
         $this->assertSame('Public Article', $response->getData()['title']);
-    }//end testShowReturnsPublicArticle()
+    }//end testShowReturnsArticleForPublicArticle()
 }//end class

--- a/tests/Unit/Service/AutomationServiceTest.php
+++ b/tests/Unit/Service/AutomationServiceTest.php
@@ -1,0 +1,218 @@
+<?php
+
+/**
+ * Unit tests for AutomationService — SSRF guard and condition matching.
+ *
+ * @category Test
+ * @package  OCA\Pipelinq\Tests\Unit\Service
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2024 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://pipelinq.nl
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Pipelinq\Tests\Unit\Service;
+
+use OCA\Pipelinq\Service\AutomationService;
+use OCP\IAppConfig;
+use OCP\IUserSession;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Tests for AutomationService.
+ */
+class AutomationServiceTest extends TestCase
+{
+    /**
+     * The service under test.
+     *
+     * @var AutomationService
+     */
+    private AutomationService $service;
+
+    /**
+     * Set up the test.
+     *
+     * @return void
+     */
+    protected function setUp(): void
+    {
+        $appConfig   = $this->createMock(IAppConfig::class);
+        $userSession = $this->createMock(IUserSession::class);
+        $logger      = $this->createMock(LoggerInterface::class);
+
+        $this->service = new AutomationService($appConfig, $userSession, $logger);
+    }//end setUp()
+
+    /**
+     * Test that loopback IPv4 is blocked.
+     *
+     * @return void
+     */
+    public function testValidateWebhookUrlBlocksLoopback(): void
+    {
+        $result = $this->service->validateWebhookUrl('http://127.0.0.1/metadata');
+        $this->assertNotNull($result);
+        $this->assertStringContainsString('Loopback', $result);
+    }//end testValidateWebhookUrlBlocksLoopback()
+
+    /**
+     * Test that link-local IP is blocked.
+     *
+     * @return void
+     */
+    public function testValidateWebhookUrlBlocksLinkLocal(): void
+    {
+        $result = $this->service->validateWebhookUrl('http://169.254.169.254/latest/meta-data/');
+        $this->assertNotNull($result);
+        $this->assertStringContainsString('Link-local', $result);
+    }//end testValidateWebhookUrlBlocksLinkLocal()
+
+    /**
+     * Test that RFC-1918 10.x range is blocked.
+     *
+     * @return void
+     */
+    public function testValidateWebhookUrlBlocksRfc1918TenRange(): void
+    {
+        $result = $this->service->validateWebhookUrl('http://10.0.0.1/internal');
+        $this->assertNotNull($result);
+        $this->assertStringContainsString('RFC-1918', $result);
+    }//end testValidateWebhookUrlBlocksRfc1918TenRange()
+
+    /**
+     * Test that RFC-1918 192.168.x range is blocked.
+     *
+     * @return void
+     */
+    public function testValidateWebhookUrlBlocksRfc1918NatRange(): void
+    {
+        $result = $this->service->validateWebhookUrl('http://192.168.1.100/api');
+        $this->assertNotNull($result);
+        $this->assertStringContainsString('RFC-1918', $result);
+    }//end testValidateWebhookUrlBlocksRfc1918NatRange()
+
+    /**
+     * Test that RFC-1918 172.16.x range is blocked.
+     *
+     * @return void
+     */
+    public function testValidateWebhookUrlBlocksRfc1918DockerRange(): void
+    {
+        $result = $this->service->validateWebhookUrl('http://172.17.0.1/api');
+        $this->assertNotNull($result);
+        $this->assertStringContainsString('RFC-1918', $result);
+    }//end testValidateWebhookUrlBlocksRfc1918DockerRange()
+
+    /**
+     * Test that non-http schemes (file://) are blocked.
+     *
+     * @return void
+     */
+    public function testValidateWebhookUrlBlocksFileScheme(): void
+    {
+        // file:/// has no host, so it is caught by the malformed-URL check.
+        $result = $this->service->validateWebhookUrl('file:///etc/passwd');
+        $this->assertNotNull($result);
+    }//end testValidateWebhookUrlBlocksFileScheme()
+
+    /**
+     * Test that gopher scheme is blocked.
+     *
+     * @return void
+     */
+    public function testValidateWebhookUrlBlocksGopherScheme(): void
+    {
+        $result = $this->service->validateWebhookUrl('gopher://internal.host/');
+        $this->assertNotNull($result);
+    }//end testValidateWebhookUrlBlocksGopherScheme()
+
+    /**
+     * Test that malformed URL is blocked.
+     *
+     * @return void
+     */
+    public function testValidateWebhookUrlBlocksMalformedUrl(): void
+    {
+        $result = $this->service->validateWebhookUrl('not-a-url');
+        $this->assertNotNull($result);
+    }//end testValidateWebhookUrlBlocksMalformedUrl()
+
+    /**
+     * Test that IPv6 loopback is blocked.
+     *
+     * @return void
+     */
+    public function testValidateWebhookUrlBlocksIpv6Loopback(): void
+    {
+        $result = $this->service->validateWebhookUrl('http://[::1]/api');
+        $this->assertNotNull($result);
+    }//end testValidateWebhookUrlBlocksIpv6Loopback()
+
+    /**
+     * Test that fireWebhook skips empty URL.
+     *
+     * @return void
+     */
+    public function testFireWebhookSkipsEmptyUrl(): void
+    {
+        $result = $this->service->fireWebhook('', ['event' => 'test']);
+        $this->assertSame('skipped', $result['status']);
+    }//end testFireWebhookSkipsEmptyUrl()
+
+    /**
+     * Test that fireWebhook blocks SSRF URLs.
+     *
+     * @return void
+     */
+    public function testFireWebhookBlocksSsrfUrl(): void
+    {
+        $result = $this->service->fireWebhook('http://127.0.0.1/steal', ['event' => 'test']);
+        $this->assertSame('blocked', $result['status']);
+    }//end testFireWebhookBlocksSsrfUrl()
+
+    /**
+     * Test that matchesConditions returns false for inactive automation.
+     *
+     * @return void
+     */
+    public function testMatchesConditionsReturnsFalseForInactive(): void
+    {
+        $automation = ['isActive' => false, 'trigger' => 'lead_created'];
+        $this->assertFalse($this->service->matchesConditions($automation, 'lead_created', []));
+    }//end testMatchesConditionsReturnsFalseForInactive()
+
+    /**
+     * Test that matchesConditions returns false for wrong trigger.
+     *
+     * @return void
+     */
+    public function testMatchesConditionsReturnsFalseForWrongTrigger(): void
+    {
+        $automation = ['isActive' => true, 'trigger' => 'contact_created'];
+        $this->assertFalse($this->service->matchesConditions($automation, 'lead_created', []));
+    }//end testMatchesConditionsReturnsFalseForWrongTrigger()
+
+    /**
+     * Test that matchesConditions returns true when conditions match.
+     *
+     * @return void
+     */
+    public function testMatchesConditionsReturnsTrueForMatch(): void
+    {
+        $automation = [
+            'isActive'          => true,
+            'trigger'           => 'lead_created',
+            'triggerConditions' => ['stage' => 'new'],
+        ];
+        $this->assertTrue($this->service->matchesConditions($automation, 'lead_created', ['stage' => 'new']));
+    }//end testMatchesConditionsReturnsTrueForMatch()
+}//end class

--- a/tests/Unit/Service/ObjectEventHandlerServiceTest.php
+++ b/tests/Unit/Service/ObjectEventHandlerServiceTest.php
@@ -24,7 +24,10 @@ use OCA\Pipelinq\Service\ObjectEventDispatcher;
 use OCA\Pipelinq\Service\ObjectEventHandlerService;
 use OCA\Pipelinq\Service\ObjectUpdateDiffService;
 use OCA\Pipelinq\Service\SchemaMapService;
+use OCP\IAppConfig;
 use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+use Psr\Log\LoggerInterface;
 
 /**
  * Tests for ObjectEventHandlerService.
@@ -63,12 +66,19 @@ class ObjectEventHandlerServiceTest extends TestCase
         $this->dispatcher       = $this->createMock(ObjectEventDispatcher::class);
         $diffService            = new ObjectUpdateDiffService();
         $automationService      = $this->createMock(AutomationService::class);
+        $appConfig              = $this->createMock(IAppConfig::class);
+        $appConfig->method('getValueString')->willReturn('');
+        $container              = $this->createMock(ContainerInterface::class);
+        $logger                 = $this->createMock(LoggerInterface::class);
 
         $this->service = new ObjectEventHandlerService(
             $this->schemaMapService,
             $this->dispatcher,
             $diffService,
             $automationService,
+            $appConfig,
+            $container,
+            $logger,
         );
     }//end setUp()
 


### PR DESCRIPTION
## Summary

Fixes 6 CRITICAL security and functionality issues found during the deep-review pass (2026-05-27).

- **#589 C1 — IDOR via `_rbac:false`/`_multitenancy:false`**: Removed both flags from all `ObjectService` call sites across 10 service files. OpenRegister's row-level access control is now enforced for all CRM data.
- **#590 C2 — CallbackController was a stub**: Wired `attempt`, `claim`, `complete`, and `reassign` to real `ScheduledTaskService` persistence. Added per-task authorisation (`authorizeTaskMutation`) and admin-only gate on `reassign` via `IGroupManager::isAdmin`.
- **#591 C3 — PublicFormController was a no-op**: `submit()` now persists leads via `ObjectService::saveObject`; `show()` fetches the real form object and guards on `isActive`. Honeypot and rate-limit checks added.
- **#592 C4 — PublicKennisbankController threw 500**: Fixed `findAll()` named-parameter calls to positional-array form; replaced non-existent `findOne()` with `findAll(id:)` + pick-first. Added server-side `gepubliceerd + openbaar` visibility guard.
- **#593 — SSRF in AutomationService**: `validateWebhookUrl()` blocks loopback (127.x, ::1), link-local (169.254.x), RFC-1918 private (10.x, 172.16-31.x, 192.168.x), ULA IPv6 (fc00::/7), and non-http/https schemes. `CURLOPT_FOLLOWLOCATION=false` prevents redirect-chain bypass. Response body never returned to caller.
- **#594 — fireAutomations was wired to nothing**: `ObjectEventHandlerService::fireAutomations` now loads automation rules from OR, evaluates conditions via `AutomationService::matchesConditions`, and dispatches matching webhook actions via `fireWebhook`.

## Added / Updated

- `openspec/architecture/adr-003-tenancy-and-rbac-model.md` — documents the tenancy, RBAC, and task-mutation auth model.
- `tests/Unit/Service/AutomationServiceTest.php` — 14 new tests covering SSRF guard and condition matching.
- Updated: `CallbackControllerTest`, `PublicKennisbankControllerTest`, `ObjectEventHandlerServiceTest`.

## Test plan

- [ ] `php vendor/bin/phpunit tests/Unit/ --no-coverage` — 364 tests, 8 pre-existing OC\ stub errors only
- [ ] `php vendor/bin/phpcs --standard=phpcs.xml lib/` — 0 errors on changed files
- [ ] Verify issues #589–#594 closed after merge

Closes #589, closes #590, closes #591, closes #592, closes #593, closes #594.