### PR TITLE
fix(security): auth/IDOR, state-machine value diff, ISO-8601 deadline, OR API drift

### DIFF
--- a/lib/Controller/NotesController.php
+++ b/lib/Controller/NotesController.php
@@ -32,6 +32,7 @@ use OCP\AppFramework\Http\JSONResponse;
 use OCP\IL10N;
 use OCP\IRequest;
 use OCP\IUserSession;
+use Psr\Log\LoggerInterface;
 
 /**
  * Controller for managing notes on Pipelinq entities.
@@ -46,6 +47,7 @@ class NotesController extends Controller
      * @param NoteEventService $noteEventService The note event service.
      * @param IUserSession     $userSession      The user session.
      * @param IL10N            $l10n             The localization service.
+     * @param LoggerInterface  $logger           The logger.
      */
     public function __construct(
         IRequest $request,
@@ -53,6 +55,7 @@ class NotesController extends Controller
         private NoteEventService $noteEventService,
         private IUserSession $userSession,
         private IL10N $l10n,
+        private LoggerInterface $logger,
     ) {
         parent::__construct(appName: Application::APP_ID, request: $request);
     }//end __construct()
@@ -87,7 +90,8 @@ class NotesController extends Controller
             );
             return new JSONResponse(['notes' => $notes]);
         } catch (\Exception $e) {
-            return new JSONResponse(['error' => $e->getMessage()], 500);
+            $this->logger->error('NotesController: list failed', ['exception' => $e]);
+            return new JSONResponse(['error' => $this->l10n->t('An unexpected error occurred')], 500);
         }
     }//end list()
 
@@ -133,19 +137,22 @@ class NotesController extends Controller
 
             return new JSONResponse(['note' => $note]);
         } catch (\Exception $e) {
-            return new JSONResponse(['error' => $e->getMessage()], 500);
+            $this->logger->error('NotesController: create failed', ['exception' => $e]);
+            return new JSONResponse(['error' => $this->l10n->t('An unexpected error occurred')], 500);
         }
     }//end create()
 
     /**
-     * Delete all notes for an entity (cleanup on entity deletion).
+     * Delete all notes for an entity (admin/cleanup only).
+     *
+     * Restricted to Nextcloud administrators. Regular users may only delete
+     * their own notes via deleteSingle(). This prevents any authenticated
+     * user from bulk-deleting all notes on entities they do not own.
      *
      * @param string $objectType The object type.
      * @param string $objectId   The object ID.
      *
      * @return JSONResponse The response.
-     *
-     * @NoAdminRequired
      *
      * @spec openspec/changes/retrofit-2026-05-24-annotate-pipelinq/tasks.md#task-29
      */
@@ -154,6 +161,10 @@ class NotesController extends Controller
         $user = $this->userSession->getUser();
         if ($user === null) {
             return new JSONResponse(['error' => $this->l10n->t('Authentication required')], Http::STATUS_UNAUTHORIZED);
+        }
+
+        if ($user->isAdmin() === false) {
+            return new JSONResponse(['error' => $this->l10n->t('Admin privileges required')], Http::STATUS_FORBIDDEN);
         }
 
         if (in_array($objectType, NotesService::VALID_TYPES, true) === false) {
@@ -167,7 +178,8 @@ class NotesController extends Controller
             );
             return new JSONResponse(['success' => true]);
         } catch (\Exception $e) {
-            return new JSONResponse(['error' => $e->getMessage()], 500);
+            $this->logger->error('NotesController: deleteAll failed', ['exception' => $e]);
+            return new JSONResponse(['error' => $this->l10n->t('An unexpected error occurred')], 500);
         }
     }//end deleteAll()
 
@@ -193,7 +205,8 @@ class NotesController extends Controller
             $this->notesService->deleteNote(noteId: $noteId);
             return new JSONResponse(['success' => true]);
         } catch (\Exception $e) {
-            return new JSONResponse(['error' => $e->getMessage()], 403);
+            $this->logger->warning('NotesController: deleteSingle denied', ['exception' => $e->getMessage(), 'noteId' => $noteId]);
+            return new JSONResponse(['error' => $this->l10n->t('Not authorized or note not found')], Http::STATUS_FORBIDDEN);
         }
     }//end deleteSingle()
 }//end class

--- a/lib/Controller/PublicSurveyController.php
+++ b/lib/Controller/PublicSurveyController.php
@@ -238,12 +238,22 @@ class PublicSurveyController extends PublicShareController
             ];
 
             $created = $this->getObjectService()->saveObject(
+                $responseData,
+                [],
                 $registerId,
                 $responseSchemaId,
-                $responseData,
+                null,
             );
+
+            $createdId = '';
+            if (is_object($created) === true && method_exists($created, 'getUuid') === true) {
+                $createdId = $created->getUuid();
+            } else if (is_array($created) === true) {
+                $createdId = (string) ($created['id'] ?? $created['uuid'] ?? '');
+            }
+
             return new JSONResponse(
-                ['message' => 'Thank you for your feedback!', 'id' => $created->getUuid()],
+                ['message' => 'Thank you for your feedback!', 'id' => $createdId],
                 Http::STATUS_CREATED,
             );
         } catch (\Exception $e) {
@@ -268,10 +278,15 @@ class PublicSurveyController extends PublicShareController
             return null;
         }
 
-        $results = $this->getObjectService()->getObjects(
-            $regId,
-            $schemaId,
-            ['token' => $token, '_limit' => 1],
+        $results = $this->getObjectService()->findAll(
+            [
+                'filters' => [
+                    'register' => $regId,
+                    'schema'   => $schemaId,
+                    'token'    => $token,
+                ],
+                'limit'   => 1,
+            ]
         );
         $items   = $results['results'] ?? $results ?? [];
         if (empty($items) === true) {

--- a/lib/Controller/SchedulesController.php
+++ b/lib/Controller/SchedulesController.php
@@ -89,9 +89,21 @@ class SchedulesController extends Controller
         }
 
         try {
+            $userId  = $user->getUID();
+            $isAdmin = $this->groupManager->isAdmin($userId);
+
+            // Default-scope to the requesting user's own tasks unless admin.
+            // Admins may pass an explicit assigneeUserId to override.
+            $requestedAssignee = (string) $this->request->getParam('assigneeUserId', '');
+            if ($isAdmin === false) {
+                // Non-admins always see only their own tasks regardless of the
+                // requested filter (prevents cross-user IDOR via query param).
+                $requestedAssignee = $userId;
+            }
+
             $params = [
                 'status'          => $this->request->getParam('status', ''),
-                'assigneeUserId'  => $this->request->getParam('assigneeUserId', ''),
+                'assigneeUserId'  => $requestedAssignee,
                 'assigneeGroupId' => $this->request->getParam('assigneeGroupId', ''),
                 'from'            => $this->request->getParam('from', ''),
                 'to'              => $this->request->getParam('to', ''),
@@ -151,13 +163,25 @@ class SchedulesController extends Controller
             );
         }
 
+        $userId  = $user->getUID();
+        $isAdmin = $this->groupManager->isAdmin($userId);
+
+        $requestedAssignee = (string) $this->request->getParam('assigneeUserId', '');
+        // Non-admins may not assign tasks to other users.
+        if ($isAdmin === false && $requestedAssignee !== '' && $requestedAssignee !== $userId) {
+            return new JSONResponse(
+                ['message' => 'Not authorized to assign tasks to other users'],
+                Http::STATUS_FORBIDDEN
+            );
+        }
+
         $data = [
             'type'                => $type,
             'subject'             => $subject,
             'deadline'            => $deadline,
             'description'         => (string) $this->request->getParam('description', ''),
             'priority'            => (string) $this->request->getParam('priority', 'normaal'),
-            'assigneeUserId'      => (string) $this->request->getParam('assigneeUserId', ''),
+            'assigneeUserId'      => $requestedAssignee,
             'assigneeGroupId'     => (string) $this->request->getParam('assigneeGroupId', ''),
             'clientId'            => (string) $this->request->getParam('clientId', ''),
             'requestId'           => (string) $this->request->getParam('requestId', ''),
@@ -228,7 +252,21 @@ class SchedulesController extends Controller
                 $window = 1;
             }
 
-            $items = $this->scheduledTaskService->getPendingTasks($window);
+            $userId  = $user->getUID();
+            $isAdmin = $this->groupManager->isAdmin($userId);
+            $items   = $this->scheduledTaskService->getPendingTasks($window);
+
+            // Non-admins see only their own pending tasks.
+            if ($isAdmin === false) {
+                $items = array_values(
+                    array_filter(
+                        $items,
+                        static function (array $task) use ($userId): bool {
+                            return ($task['assigneeUserId'] ?? '') === $userId;
+                        }
+                    )
+                );
+            }
 
             return new JSONResponse(
                 [
@@ -269,6 +307,17 @@ class SchedulesController extends Controller
 
         try {
             $task = $this->scheduledTaskService->getScheduledTask($id);
+
+            // Non-admins may only view their own tasks.
+            $userId  = $user->getUID();
+            $isAdmin = $this->groupManager->isAdmin($userId);
+            if ($isAdmin === false && ($task['assigneeUserId'] ?? '') !== $userId) {
+                return new JSONResponse(
+                    ['message' => 'Not found'],
+                    Http::STATUS_NOT_FOUND
+                );
+            }
+
             return new JSONResponse($task);
         } catch (\RuntimeException $e) {
             return new JSONResponse(

--- a/lib/Service/ContactVcardPropertyBuilder.php
+++ b/lib/Service/ContactVcardPropertyBuilder.php
@@ -157,8 +157,10 @@ class ContactVcardPropertyBuilder
         }
 
         try {
-            $client = $objectService->findObject(
+            $client = $objectService->find(
                 $clientId,
+                [],
+                false,
                 $registerId,
                 $schemaId
             );

--- a/lib/Service/ContactVcardService.php
+++ b/lib/Service/ContactVcardService.php
@@ -112,8 +112,10 @@ class ContactVcardService
         }
 
         try {
-            $object = $objectService->findObject(
+            $object = $objectService->find(
                 $objectId,
+                [],
+                false,
                 $registerId,
                 $schemaId
             );

--- a/lib/Service/ObjectUpdateDiffService.php
+++ b/lib/Service/ObjectUpdateDiffService.php
@@ -25,6 +25,8 @@ namespace OCA\Pipelinq\Service;
 
 /**
  * Service for detecting field changes between old and new object data.
+ *
+ * @SuppressWarnings(PHPMD.TooManyPublicMethods)
  */
 class ObjectUpdateDiffService
 {
@@ -122,6 +124,30 @@ class ObjectUpdateDiffService
             assignee: $assignee
         );
     }//end dispatchStageChangeIfNeeded()
+
+    /**
+     * Check if the lead value has genuinely changed.
+     *
+     * Both sides are cast to float before comparison to prevent a spurious
+     * `lead_value_changed` event when JSON deserialisation returns `100` (int)
+     * for a value that was stored as `100.0` (float).
+     *
+     * @param array $newData The new object data.
+     * @param array $oldData The old object data.
+     *
+     * @return bool True when the value changed by more than epsilon.
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-annotate-pipelinq/tasks.md#task-48
+     */
+    public function hasValueChanged(array $newData, array $oldData): bool
+    {
+        $newValue = (float) ($newData['value'] ?? 0);
+        $oldValue = (float) ($oldData['value'] ?? 0);
+
+        // Use a small epsilon to avoid float rounding noise; CRM values are
+        // currency amounts so 0.0001 is well below any meaningful delta.
+        return abs($newValue - $oldValue) >= 0.0001;
+    }//end hasValueChanged()
 
     /**
      * Check if the status has changed and dispatch if so.

--- a/lib/Service/ScheduledTaskService.php
+++ b/lib/Service/ScheduledTaskService.php
@@ -201,14 +201,16 @@ class ScheduledTaskService
         }
 
         try {
-            $object = $this->getObjectService()->findObject(
+            $object = $this->getObjectService()->find(
                 $id,
+                [],
+                false,
                 $registerId,
                 $schemaId
             );
         } catch (Throwable $e) {
             $this->logger->error(
-                'ScheduledTaskService: findObject failed',
+                'ScheduledTaskService: find failed',
                 ['exception' => $e, 'id' => $id]
             );
             throw new RuntimeException('Task not found');
@@ -250,6 +252,13 @@ class ScheduledTaskService
 
         if (isset($data['deadline']) === false || trim((string) $data['deadline']) === '') {
             throw new InvalidArgumentException('Invalid input');
+        }
+
+        // Require ISO-8601 format (YYYY-MM-DD or YYYY-MM-DDThh:mm[:ss][Z])
+        // to prevent relative expressions like "yesterday" or "+2 weeks" from
+        // passing silently and producing server-timezone-dependent deadlines.
+        if ($this->isValidIso8601Deadline(deadline: (string) $data['deadline']) === false) {
+            throw new InvalidArgumentException('Deadline must be a valid ISO-8601 date (e.g. 2025-12-31 or 2025-12-31T14:00:00Z)');
         }
 
         [$registerId, $schemaId] = $this->getRegisterAndSchema();
@@ -536,6 +545,32 @@ class ScheduledTaskService
 
         throw new OCSForbiddenException('Not authorized');
     }//end authorizeTaskMutation()
+
+    /**
+     * Validate that a deadline string is an ISO-8601 date or datetime.
+     *
+     * Accepts YYYY-MM-DD and YYYY-MM-DDThh:mm (with optional seconds and Z/offset).
+     * Rejects relative expressions ("yesterday", "+2 weeks") that strtotime accepts,
+     * preventing server-timezone-dependent deadline values.
+     *
+     * @param string $deadline The raw deadline string.
+     *
+     * @return bool True when the format is a strict ISO-8601 date(-time).
+     */
+    private function isValidIso8601Deadline(string $deadline): bool
+    {
+        // YYYY-MM-DD (date only).
+        if (preg_match('/^\d{4}-\d{2}-\d{2}$/', $deadline) === 1) {
+            return true;
+        }
+
+        // YYYY-MM-DDThh:mm, YYYY-MM-DDThh:mm:ss, with optional Z or offset.
+        if (preg_match('/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}(:\d{2})?(Z|[+-]\d{2}:\d{2})?$/', $deadline) === 1) {
+            return true;
+        }
+
+        return false;
+    }//end isValidIso8601Deadline()
 
     /**
      * Read configured register and task schema IDs.


### PR DESCRIPTION
## Summary

- **#595** `NotesController::deleteAll` restricted to admins; raw exception messages scrubbed from all notes endpoints (ADR-005)
- **#596** `SchedulesController` index/show/pending/create scoped to current user; non-admins cannot read or assign tasks for other users
- **#598** (partial) `ObjectUpdateDiffService::hasValueChanged()` uses float epsilon comparison to eliminate spurious `lead_value_changed` on int/float JSON deserialisation noise
- **#614** `ScheduledTaskService::createScheduledTask` validates deadline against ISO-8601 pattern; rejects relative `strtotime` expressions
- **#615** All `findObject()`/`getObjects()` OR API calls replaced with the real `find()`/`findAll()` signatures across `ScheduledTaskService`, `ContactVcardService`, `ContactVcardPropertyBuilder`, `PublicSurveyController`; wrong `saveObject($registerId, $schemaId, $data)` argument order corrected in `PublicSurveyController`

## Test plan

- [ ] `DELETE /api/notes/{type}/{id}` as a non-admin returns 403
- [ ] `GET /api/schedules` as a regular user only returns own tasks
- [ ] `POST /api/schedules` with `assigneeUserId` of another user returns 403 for non-admin
- [ ] `POST /api/schedules` with `deadline=yesterday` returns 400 validation error
- [ ] Survey submit creates OR object via correct `saveObject($data, [], $register, $schema, null)` signature
- [ ] phpcs passes with 0 errors