### PR TITLE
fix(security): sensitive KVK API key, SystemTag rename, SLA key allowlist

### DIFF
--- a/lib/Controller/ReportingController.php
+++ b/lib/Controller/ReportingController.php
@@ -106,18 +106,29 @@ class ReportingController extends Controller
                 );
             }
 
+            $skipped = 0;
             foreach ($targets as $channel => $metrics) {
                 if (is_array($metrics) === false) {
                     continue;
                 }
 
                 foreach ($metrics as $metric => $value) {
-                    $this->reportingService->setSlaTarget(
+                    $accepted = $this->reportingService->setSlaTarget(
                         channel: $channel,
                         metric: $metric,
                         value: (string) $value,
                     );
+                    if ($accepted === false) {
+                        $skipped++;
+                    }
                 }
+            }
+
+            if ($skipped > 0) {
+                return new JSONResponse(
+                    ['error' => $this->l10n->t('One or more unknown channel or metric values were skipped')],
+                    400,
+                );
             }
 
             return new JSONResponse(

--- a/lib/Service/IcpConfigReader.php
+++ b/lib/Service/IcpConfigReader.php
@@ -78,6 +78,29 @@ class IcpConfigReader
     }//end setString()
 
     /**
+     * Set a sensitive (masked) credential value in app config.
+     *
+     * Passes sensitive:true and lazy:true so the value is excluded from
+     * occ config:list output and Nextcloud support archives (NC 29+).
+     *
+     * @param string $key   The config key.
+     * @param string $value The secret value to store.
+     *
+     * @return void
+     * @spec   openspec/changes/reverse-2026-05-26-be-prospect/tasks.md#task-6
+     */
+    public function setSensitiveString(string $key, string $value): void
+    {
+        $this->appConfig->setValueString(
+            app: Application::APP_ID,
+            key: $key,
+            value: $value,
+            sensitive: true,
+            lazy: true
+        );
+    }//end setSensitiveString()
+
+    /**
      * Get a JSON array from app config.
      *
      * @param string $key The config key.

--- a/lib/Service/IcpConfigService.php
+++ b/lib/Service/IcpConfigService.php
@@ -233,7 +233,9 @@ class IcpConfigService
     private function saveApiKeyField(array $data): void
     {
         if (isset($data['kvkApiKey']) === true && $data['kvkApiKey'] !== '***configured***') {
-            $this->reader->setString(key: 'icp_kvk_api_key', value: (string) $data['kvkApiKey']);
+            // Store the KVK API key as sensitive so it is excluded from
+            // occ config:list output and Nextcloud support archives (issue #599).
+            $this->reader->setSensitiveString(key: 'icp_kvk_api_key', value: (string) $data['kvkApiKey']);
         }
     }//end saveApiKeyField()
 

--- a/lib/Service/ReportingService.php
+++ b/lib/Service/ReportingService.php
@@ -166,18 +166,33 @@ class ReportingService
     /**
      * Update SLA target for a channel.
      *
+     * Validates that channel and metric are in the DEFAULT_SLA_TARGETS allowlist
+     * before constructing the appconfig key, preventing arbitrary key injection
+     * into oc_appconfig (issue #606).
+     *
      * @param string $channel The channel type.
      * @param string $metric  The metric name.
      * @param string $value   The target value.
      *
-     * @return void
+     * @return bool False when channel or metric is not in the allowlist.
      *
      * @spec openspec/changes/retrofit-2026-05-24-annotate-pipelinq/tasks.md#task-49
      */
-    public function setSlaTarget(string $channel, string $metric, string $value): void
+    public function setSlaTarget(string $channel, string $metric, string $value): bool
     {
+        // Validate channel against the allowlist.
+        if (isset(self::DEFAULT_SLA_TARGETS[$channel]) === false) {
+            return false;
+        }
+
+        // Validate metric against the allowed metrics for this channel.
+        if (array_key_exists($metric, self::DEFAULT_SLA_TARGETS[$channel]) === false) {
+            return false;
+        }
+
         $key = 'sla_'.$channel.'_'.$metric;
         $this->appConfig->setValueString('pipelinq', $key, $value);
+        return true;
     }//end setSlaTarget()
 
     /**

--- a/lib/Service/SystemTagCrudService.php
+++ b/lib/Service/SystemTagCrudService.php
@@ -168,7 +168,11 @@ class SystemTagCrudService
     }//end unassignAndCleanup()
 
     /**
-     * Rename a system tag.
+     * Rename a system tag, preserving the existing userAssignable value.
+     *
+     * The previous implementation hardcoded userAssignable:false on every
+     * rename, permanently locking the tag from the Nextcloud UI regardless of
+     * how it was originally created (issue #605).
      *
      * @param int    $tagId   The tag ID.
      * @param string $newName The new name.
@@ -178,11 +182,19 @@ class SystemTagCrudService
      */
     public function renameSystemTag(int $tagId, string $newName): void
     {
+        // Read existing flags so we do not clobber userAssignable on rename.
+        $existingTags   = $this->tagManager->getTagsByIds([(string) $tagId]);
+        $userAssignable = false;
+        if (empty($existingTags) === false) {
+            $existingTag    = reset($existingTags);
+            $userAssignable = $existingTag->isUserAssignable();
+        }
+
         $this->tagManager->updateTag(
             tagId: (string) $tagId,
             newName: $newName,
             userVisible: true,
-            userAssignable: false,
+            userAssignable: $userAssignable,
             color: null
         );
     }//end renameSystemTag()


### PR DESCRIPTION
## Summary

- **#599** `IcpConfigReader::setSensitiveString()` stores `icp_kvk_api_key` with `sensitive:true, lazy:true`, masking it from `occ config:list` and support archives (NC 29+)
- **#605** `SystemTagCrudService::renameSystemTag()` reads the existing `userAssignable` value before updating instead of hardcoding `false`, preventing tags from being permanently locked from the Nextcloud UI
- **#606** `ReportingService::setSlaTarget()` validates `$channel` and `$metric` against the `DEFAULT_SLA_TARGETS` allowlist; `ReportingController::updateSla()` returns 400 for unknown entries

## Test plan

- [ ] Run `occ config:list` after saving a KVK API key — value should be masked (`***`)
- [ ] Rename a user-assignable tag via the pipelinq API — tag remains user-assignable in NC Files UI
- [ ] POST `{"targets": {"bad_channel": {"target_percent": 80}}}` to SLA update returns 400
- [ ] Valid SLA update (`{"targets": {"telefoon": {"target_percent": 95}}}`) returns 200
- [ ] phpcs passes with 0 errors