### PR TITLE
fix(security): neutralize CSV injection, fix rate-limiter bypass, drop write CSRF bypass

### DIFF
--- a/lib/Controller/PreferencesController.php
+++ b/lib/Controller/PreferencesController.php
@@ -101,7 +101,6 @@ class PreferencesController extends Controller
      * @return JSONResponse `{value: string|null}`.
      *
      * @NoAdminRequired
-     * @NoCSRFRequired
      * @spec            openspec/changes/reverse-2026-05-26-be-settings/tasks.md#task-2
      */
     public function setPreference(string $key, string $value=''): JSONResponse

--- a/lib/Service/IntakeFormService.php
+++ b/lib/Service/IntakeFormService.php
@@ -88,7 +88,11 @@ class IntakeFormService
      */
     public function isRateLimited(string $ip, string $formId): bool
     {
-        $key = 'pipelinq_intake_'.md5($ip.'_'.$formId);
+        // Key on IP only so that cycling formId cannot bypass the per-IP budget.
+        // The $formId parameter is retained in the signature for callers that may
+        // log or trace it, but it is intentionally NOT included in the cache key.
+        unset($formId);
+        $key = 'pipelinq_intake_'.md5($ip);
 
         if (function_exists('apcu_fetch') === false) {
             return false;
@@ -207,7 +211,7 @@ class IntakeFormService
             $headers[] = $field['label'] ?? $field['name'] ?? 'Unknown';
         }
 
-        $rows = [implode(',', array_map(fn($h) => '"'.str_replace('"', '""', $h).'"', $headers))];
+        $rows = [implode(',', array_map([$this, 'neutralizeCsvCell'], $headers))];
 
         foreach ($submissions as $sub) {
             $row  = [
@@ -223,9 +227,29 @@ class IntakeFormService
                 $row[] = $value;
             }
 
-            $rows[] = implode(',', array_map(fn($v) => '"'.str_replace('"', '""', (string) $v).'"', $row));
+            $rows[] = implode(',', array_map([$this, 'neutralizeCsvCell'], $row));
         }//end foreach
 
         return implode("\n", $rows);
     }//end exportCsv()
+
+    /**
+     * Neutralize a CSV cell value to prevent formula injection.
+     *
+     * Prefixes cells starting with =, +, -, @, tab, or CR with a single
+     * quote so spreadsheet applications treat them as plain text.
+     *
+     * @param mixed $value The raw cell value.
+     *
+     * @return string The quoted and injection-safe cell string.
+     */
+    private function neutralizeCsvCell(mixed $value): string
+    {
+        $str = (string) $value;
+        if (preg_match('/^[=+\-@\t\r]/', $str) === 1) {
+            $str = "'".$str;
+        }
+
+        return '"'.str_replace('"', '""', $str).'"';
+    }//end neutralizeCsvCell()
 }//end class

--- a/lib/Service/ReportingService.php
+++ b/lib/Service/ReportingService.php
@@ -195,20 +195,37 @@ class ReportingService
     public function generateCsv(array $headers, array $rows): string
     {
         $bom    = "\xEF\xBB\xBF";
-        $output = $bom.implode(';', $headers)."\n";
+        $output = $bom.implode(';', array_map([$this, 'neutralizeCsvCell'], $headers))."\n";
 
         foreach ($rows as $row) {
             $output .= implode(
                     ';',
-                    array_map(
-                static fn($v) => '"'.str_replace('"', '""', (string) $v).'"',
-                $row,
-            )
+                    array_map([$this, 'neutralizeCsvCell'], $row)
                     )."\n";
         }
 
         return $output;
     }//end generateCsv()
+
+    /**
+     * Neutralize a CSV cell value to prevent formula injection.
+     *
+     * Prefixes cells starting with =, +, -, @, tab, or CR with a single
+     * quote so spreadsheet applications treat them as plain text.
+     *
+     * @param mixed $value The raw cell value.
+     *
+     * @return string The quoted and injection-safe cell string.
+     */
+    private function neutralizeCsvCell(mixed $value): string
+    {
+        $str = (string) $value;
+        if (preg_match('/^[=+\-@\t\r]/', $str) === 1) {
+            $str = "'".$str;
+        }
+
+        return '"'.str_replace('"', '""', $str).'"';
+    }//end neutralizeCsvCell()
 
     /**
      * Calculate average handling time from durations.


### PR DESCRIPTION
## Summary

- **#600 CSV injection** — `ReportingService::generateCsv()` and `IntakeFormService::exportCsv()` now prefix cells starting with `=`, `+`, `-`, `@`, tab, or CR with a single-quote, preventing formula injection when opened in spreadsheet apps
- **#601 Rate-limiter bypass** — `IntakeFormService::isRateLimited()` keyed on `IP + formId`; an attacker could cycle arbitrary `formId` values to reset the counter. Now keyed on IP only, enforcing a true per-IP global submission budget
- **#602 CSRF bypass on write endpoint** — `PreferencesController::setPreference()` had `@NoCSRFRequired` on a state-mutating POST; annotation removed. The read-only `getPreference()` GET retains it per Nextcloud convention

## Test plan

- [ ] Export a CSV with a cell value starting with `=HYPERLINK(...)` — verify it renders as `'=HYPERLINK(...)` (plain text) in Excel/LibreOffice
- [ ] POST to `/api/user/preferences/{key}` without a CSRF token — verify 401 response
- [ ] Submit a public intake form 11 times from the same IP with different `formId` values — verify blocked on the 11th attempt
- [ ] Normal preference get/set with a valid CSRF token still works

Closes #600, #601, #602