### PR TITLE
fix(misc): bug fixes and quality improvements (#603–#613)

### DIFF
--- a/lib/BackgroundJob/CallbackOverdueJob.php
+++ b/lib/BackgroundJob/CallbackOverdueJob.php
@@ -132,6 +132,9 @@ class CallbackOverdueJob extends TimedJob
     /**
      * Mark a task as notified at the current time.
      *
+     * Also prunes stale notification entries older than twice the cooldown
+     * window so the oc_appconfig table does not grow without bound.
+     *
      * @param string $taskId The task object ID.
      *
      * @return void
@@ -142,5 +145,39 @@ class CallbackOverdueJob extends TimedJob
     {
         $key = self::NOTIFIED_KEY_PREFIX.$taskId;
         $this->appConfig->setValueString(Application::APP_ID, $key, (string) time());
+        $this->pruneStaleNotifications();
     }//end markNotified()
+
+    /**
+     * Remove notification entries that are older than twice the cooldown window.
+     *
+     * This prevents unlimited growth of oc_appconfig rows created by markNotified().
+     *
+     * @return void
+     */
+    private function pruneStaleNotifications(): void
+    {
+        try {
+            $keys      = $this->appConfig->getKeys(Application::APP_ID);
+            $cutoff    = time() - (self::NOTIFICATION_COOLDOWN * 2);
+            $prefix    = self::NOTIFIED_KEY_PREFIX;
+            $prefixLen = strlen($prefix);
+
+            foreach ($keys as $key) {
+                if (substr($key, 0, $prefixLen) !== $prefix) {
+                    continue;
+                }
+
+                $timestamp = (int) $this->appConfig->getValueString(Application::APP_ID, $key, '0');
+                if ($timestamp > 0 && $timestamp < $cutoff) {
+                    $this->appConfig->deleteKey(Application::APP_ID, $key);
+                }
+            }
+        } catch (\Exception $e) {
+            $this->logger->warning(
+                'CallbackOverdueJob: failed to prune stale notifications',
+                ['exception' => $e]
+            );
+        }//end try
+    }//end pruneStaleNotifications()
 }//end class

--- a/lib/Controller/ContactSyncController.php
+++ b/lib/Controller/ContactSyncController.php
@@ -32,6 +32,7 @@ use OCP\AppFramework\Http\JSONResponse;
 use OCP\IL10N;
 use OCP\IRequest;
 use OCP\IUserSession;
+use Psr\Log\LoggerInterface;
 
 /**
  * Controller for contact synchronization.
@@ -45,12 +46,14 @@ class ContactSyncController extends Controller
      * @param ContactSyncService $contactSyncService The contact sync service.
      * @param IUserSession       $userSession        The user session.
      * @param IL10N              $l10n               The localization service.
+     * @param LoggerInterface    $logger             The logger.
      */
     public function __construct(
         IRequest $request,
         private ContactSyncService $contactSyncService,
         private IUserSession $userSession,
         private IL10N $l10n,
+        private LoggerInterface $logger,
     ) {
         parent::__construct(appName: Application::APP_ID, request: $request);
     }//end __construct()
@@ -80,10 +83,9 @@ class ContactSyncController extends Controller
             $results = $this->contactSyncService->searchContacts($query);
             return new JSONResponse(['results' => $results]);
         } catch (\Exception $e) {
+            $this->logger->error('ContactSyncController::search failed', ['exception' => $e]);
             return new JSONResponse(
-                    [
-                        'error' => $e->getMessage(),
-                    ],
+                    ['error' => $this->l10n->t('An unexpected error occurred')],
                     500
                     );
         }
@@ -128,10 +130,9 @@ class ContactSyncController extends Controller
                     ]
                     );
         } catch (\Exception $e) {
+            $this->logger->error('ContactSyncController::import failed', ['exception' => $e]);
             return new JSONResponse(
-                    [
-                        'error' => $e->getMessage(),
-                    ],
+                    ['error' => $this->l10n->t('An unexpected error occurred')],
                     500
                     );
         }//end try
@@ -176,10 +177,9 @@ class ContactSyncController extends Controller
                     ]
                     );
         } catch (\Exception $e) {
+            $this->logger->error('ContactSyncController::writeBack failed', ['exception' => $e]);
             return new JSONResponse(
-                    [
-                        'error' => $e->getMessage(),
-                    ],
+                    ['error' => $this->l10n->t('An unexpected error occurred')],
                     500
                     );
         }

--- a/lib/Controller/KennisbankController.php
+++ b/lib/Controller/KennisbankController.php
@@ -26,12 +26,16 @@ namespace OCA\Pipelinq\Controller;
 
 use OCA\Pipelinq\AppInfo\Application;
 use OCA\Pipelinq\Service\KennisbankService;
+use OCA\Pipelinq\Service\SettingsService;
+use OCP\App\IAppManager;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\IL10N;
 use OCP\IRequest;
 use OCP\IUserSession;
+use Psr\Container\ContainerInterface;
+use Psr\Log\LoggerInterface;
 
 /**
  * Controller for knowledge base public API and feedback.
@@ -44,16 +48,24 @@ class KennisbankController extends Controller
     /**
      * Constructor.
      *
-     * @param IRequest          $request           The request.
-     * @param KennisbankService $kennisbankService The kennisbank service.
-     * @param IUserSession      $userSession       The user session.
-     * @param IL10N             $l10n              The localization service.
+     * @param IRequest           $request           The request.
+     * @param KennisbankService  $kennisbankService The kennisbank service.
+     * @param IUserSession       $userSession       The user session.
+     * @param IL10N              $l10n              The localization service.
+     * @param SettingsService    $settingsService   The settings service.
+     * @param ContainerInterface $container         The DI container.
+     * @param IAppManager        $appManager        The app manager.
+     * @param LoggerInterface    $logger            The logger.
      */
     public function __construct(
         IRequest $request,
         private KennisbankService $kennisbankService,
         private IUserSession $userSession,
         private IL10N $l10n,
+        private SettingsService $settingsService,
+        private ContainerInterface $container,
+        private IAppManager $appManager,
+        private LoggerInterface $logger,
     ) {
         parent::__construct(appName: Application::APP_ID, request: $request);
     }//end __construct()
@@ -170,17 +182,58 @@ class KennisbankController extends Controller
                 comment: $comment,
             );
 
+            $saved = $this->persistFeedback(feedbackData: $feedbackData);
+
             return new JSONResponse(
                     [
-                        'feedback' => $feedbackData,
+                        'feedback' => $saved ?? $feedbackData,
                         'schema'   => 'kennisfeedback',
                     ]
                     );
         } catch (\Exception $e) {
+            $this->logger->error('KennisbankController::submitFeedback failed', ['exception' => $e]);
             return new JSONResponse(
                 ['error' => $this->l10n->t('Failed to submit feedback')],
                 500,
             );
-        }
+        }//end try
     }//end submitFeedback()
+
+    /**
+     * Persist feedback data via OpenRegister ObjectService.
+     *
+     * Returns the saved object or null if OpenRegister is unavailable.
+     *
+     * @param array $feedbackData The feedback data to persist.
+     *
+     * @return array|null The saved object or null.
+     */
+    private function persistFeedback(array $feedbackData): ?array
+    {
+        if (in_array('openregister', $this->appManager->getInstalledApps(), true) === false) {
+            $this->logger->warning('KennisbankController: OpenRegister not available, feedback not persisted');
+            return null;
+        }
+
+        try {
+            $settings = $this->settingsService->getSettings();
+            $register = $settings['register'] ?? '';
+            $schema   = $settings['kennisfeedback_schema'] ?? '';
+
+            if ($register === '' || $schema === '') {
+                $this->logger->warning('KennisbankController: register or kennisfeedback_schema not configured');
+                return null;
+            }
+
+            /*
+             * @var \OCA\OpenRegister\Service\ObjectService $objectService
+             */
+            $objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
+
+            return $objectService->saveObject($feedbackData, [], $register, $schema, null);
+        } catch (\Exception $e) {
+            $this->logger->error('KennisbankController: failed to persist feedback', ['exception' => $e]);
+            return null;
+        }//end try
+    }//end persistFeedback()
 }//end class

--- a/lib/Controller/LeadSourceController.php
+++ b/lib/Controller/LeadSourceController.php
@@ -32,6 +32,7 @@ use OCP\AppFramework\Http\Attribute\NoAdminRequired;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\IRequest;
 use OCP\IUserSession;
+use Psr\Log\LoggerInterface;
 
 /**
  * Controller for lead source management.
@@ -46,11 +47,13 @@ class LeadSourceController extends Controller
      * @param IRequest         $request          The request.
      * @param SystemTagService $systemTagService The system tag service.
      * @param IUserSession     $userSession      The user session.
+     * @param LoggerInterface  $logger           The logger.
      */
     public function __construct(
         IRequest $request,
         private SystemTagService $systemTagService,
         private IUserSession $userSession,
+        private LoggerInterface $logger,
     ) {
         parent::__construct(appName: Application::APP_ID, request: $request);
     }//end __construct()
@@ -148,7 +151,8 @@ class LeadSourceController extends Controller
             );
             return new JSONResponse(['success' => true]);
         } catch (\Exception $e) {
-            return new JSONResponse(['success' => false, 'message' => $e->getMessage()], 500);
+            $this->logger->error('LeadSourceController::destroy failed', ['exception' => $e]);
+            return new JSONResponse(['success' => false, 'message' => 'An unexpected error occurred'], 500);
         }
     }//end destroy()
 }//end class

--- a/lib/Controller/SettingsController.php
+++ b/lib/Controller/SettingsController.php
@@ -36,6 +36,7 @@ use OCP\IL10N;
 use OCP\IRequest;
 use OCP\IUserSession;
 use Psr\Container\ContainerInterface;
+use Psr\Log\LoggerInterface;
 use RuntimeException;
 
 /**
@@ -63,6 +64,7 @@ class SettingsController extends Controller
      * @param SettingsService    $settingsService The settings service.
      * @param IUserSession       $userSession     The user session.
      * @param IL10N              $l10n            The localization service.
+     * @param LoggerInterface    $logger          The logger.
      */
     public function __construct(
         IRequest $request,
@@ -72,6 +74,7 @@ class SettingsController extends Controller
         private SettingsService $settingsService,
         private IUserSession $userSession,
         private IL10N $l10n,
+        private LoggerInterface $logger,
     ) {
         parent::__construct(appName: Application::APP_ID, request: $request);
     }//end __construct()
@@ -185,10 +188,11 @@ class SettingsController extends Controller
                     ]
                     );
         } catch (\Exception $e) {
+            $this->logger->error('SettingsController::reimport failed', ['exception' => $e]);
             return new JSONResponse(
                     [
                         'success' => false,
-                        'message' => $e->getMessage(),
+                        'message' => $this->l10n->t('An unexpected error occurred'),
                     ],
                     500
                     );

--- a/lib/Service/AutomationService.php
+++ b/lib/Service/AutomationService.php
@@ -136,8 +136,17 @@ class AutomationService
     {
         foreach ($conditions as $field => $expected) {
             $actual = $entityData[$field] ?? null;
-            if ($actual === null) {
-                return false;
+
+            // A null actual value is valid for conditions that test for
+            // null/absence (e.g. neq with a non-null expected, or eq with null).
+            // Only short-circuit when the condition cannot possibly match.
+            if ($actual === null && is_array($expected) === false) {
+                // Simple equality check: null matches null expected only.
+                if ($expected !== null) {
+                    return false;
+                }
+
+                continue;
             }
 
             if (is_array($expected) === true) {

--- a/lib/Service/ContactVcardService.php
+++ b/lib/Service/ContactVcardService.php
@@ -35,6 +35,16 @@ use Psr\Log\LoggerInterface;
 class ContactVcardService
 {
     /**
+     * Allowed object types for vCard sync.
+     *
+     * Only these values may be used to construct an IAppConfig key, preventing
+     * an unvalidated caller-supplied $objectType from reaching arbitrary keys.
+     *
+     * @var string[]
+     */
+    private const ALLOWED_OBJECT_TYPES = ['client', 'contact'];
+
+    /**
      * Constructor.
      *
      * @param IContactsManager            $contactsManager The contacts manager.
@@ -102,6 +112,11 @@ class ContactVcardService
      */
     private function fetchPipelinqObject(string $objectType, string $objectId): ?array
     {
+        if (in_array($objectType, self::ALLOWED_OBJECT_TYPES, true) === false) {
+            $this->logger->warning('ContactVcardService: invalid objectType', ['objectType' => $objectType]);
+            return null;
+        }
+
         $objectService = $this->getObjectService();
         $registerId    = $this->appConfig->getValueString(Application::APP_ID, 'register', '');
         $schemaId      = $this->appConfig->getValueString(Application::APP_ID, "{$objectType}_schema", '');

--- a/lib/Service/MetricsRepository.php
+++ b/lib/Service/MetricsRepository.php
@@ -24,6 +24,8 @@ declare(strict_types=1);
 
 namespace OCA\Pipelinq\Service;
 
+use OCA\Pipelinq\AppInfo\Application;
+use OCP\IAppConfig;
 use OCP\IDBConnection;
 use Psr\Log\LoggerInterface;
 
@@ -35,41 +37,61 @@ class MetricsRepository
     /**
      * Constructor.
      *
-     * @param IDBConnection   $db     Database connection.
-     * @param LoggerInterface $logger Logger.
+     * @param IDBConnection   $db        Database connection.
+     * @param LoggerInterface $logger    Logger.
+     * @param IAppConfig      $appConfig App config for schema ID lookup.
      */
     public function __construct(
         private IDBConnection $db,
         private LoggerInterface $logger,
+        private IAppConfig $appConfig,
     ) {
     }//end __construct()
 
     /**
      * Get lead counts grouped by status and pipeline.
      *
-     * @return array<array{status: string, pipeline: string, cnt: string}> Grouped counts.
+     * Queries OpenRegister objects table using the configured lead schema ID
+     * to scope results to this app's data only (avoids cross-tenant leakage).
+     * Returns raw rows; JSON field extraction is done in PHP to remain
+     * portable across MySQL and PostgreSQL.
+     *
+     * @return array<array{status: string, pipeline: string, cnt: int}> Grouped counts.
      *
      * @spec openspec/changes/retrofit-2026-05-24-annotate-pipelinq/tasks.md#task-54
      */
     public function getLeadCounts(): array
     {
+        $schemaId = $this->appConfig->getValueString(Application::APP_ID, 'lead_schema', '');
+        if ($schemaId === '') {
+            return [];
+        }
+
         try {
             $qb = $this->db->getQueryBuilder();
-            $qb->select(
-                $qb->createFunction("JSON_UNQUOTE(JSON_EXTRACT(o.object, '$.status')) AS status"),
-                $qb->createFunction("JSON_UNQUOTE(JSON_EXTRACT(o.object, '$.pipeline')) AS pipeline"),
-            )
-                ->selectAlias($qb->func()->count('o.id'), 'cnt')
+            $qb->select('o.object')
                 ->from('openregister_objects', 'o')
-                ->innerJoin('o', 'openregister_schemas', 's', $qb->expr()->eq('o.schema', 's.id'))
-                ->where($qb->expr()->like('s.title', $qb->createNamedParameter('%ead%')))
-                ->groupBy('status', 'pipeline');
+                ->where($qb->expr()->eq('o.schema', $qb->createNamedParameter($schemaId)));
 
             $result = $qb->executeQuery();
             $rows   = $result->fetchAll();
             $result->closeCursor();
 
-            return $rows;
+            // Aggregate in PHP for DB-portability.
+            $counts = [];
+            foreach ($rows as $row) {
+                $obj      = json_decode($row['object'] ?? '{}', true) ?? [];
+                $status   = (string) ($obj['status'] ?? '');
+                $pipeline = (string) ($obj['pipeline'] ?? '');
+                $key      = $status.'|'.$pipeline;
+                if (isset($counts[$key]) === false) {
+                    $counts[$key] = ['status' => $status, 'pipeline' => $pipeline, 'cnt' => 0];
+                }
+
+                $counts[$key]['cnt']++;
+            }
+
+            return array_values($counts);
         } catch (\Exception $e) {
             $this->logger->warning(
                 message: '[MetricsRepository] Failed to get lead counts',
@@ -82,30 +104,44 @@ class MetricsRepository
     /**
      * Get lead value totals grouped by pipeline.
      *
-     * @return array<array{pipeline: string, total_value: string}> Pipeline values.
+     * Queries using the configured lead schema ID and aggregates in PHP
+     * to remain portable across MySQL and PostgreSQL.
+     *
+     * @return array<array{pipeline: string, total_value: float}> Pipeline values.
      *
      * @spec openspec/changes/retrofit-2026-05-24-annotate-pipelinq/tasks.md#task-56
      */
     public function getLeadValueByPipeline(): array
     {
-        try {
-            $valueSumExpr = "COALESCE(SUM(CAST(JSON_UNQUOTE(JSON_EXTRACT(o.object, '$.value')) AS DECIMAL(15,2))), 0)";
+        $schemaId = $this->appConfig->getValueString(Application::APP_ID, 'lead_schema', '');
+        if ($schemaId === '') {
+            return [];
+        }
 
+        try {
             $qb = $this->db->getQueryBuilder();
-            $qb->select(
-                $qb->createFunction("JSON_UNQUOTE(JSON_EXTRACT(o.object, '$.pipeline')) AS pipeline"),
-            )
-                ->selectAlias($qb->createFunction($valueSumExpr), 'total_value')
+            $qb->select('o.object')
                 ->from('openregister_objects', 'o')
-                ->innerJoin('o', 'openregister_schemas', 's', $qb->expr()->eq('o.schema', 's.id'))
-                ->where($qb->expr()->like('s.title', $qb->createNamedParameter('%ead%')))
-                ->groupBy('pipeline');
+                ->where($qb->expr()->eq('o.schema', $qb->createNamedParameter($schemaId)));
 
             $result = $qb->executeQuery();
             $rows   = $result->fetchAll();
             $result->closeCursor();
 
-            return $rows;
+            // Aggregate in PHP for DB-portability.
+            $totals = [];
+            foreach ($rows as $row) {
+                $obj      = json_decode($row['object'] ?? '{}', true) ?? [];
+                $pipeline = (string) ($obj['pipeline'] ?? '');
+                $value    = (float) ($obj['value'] ?? 0);
+                if (isset($totals[$pipeline]) === false) {
+                    $totals[$pipeline] = ['pipeline' => $pipeline, 'total_value' => 0.0];
+                }
+
+                $totals[$pipeline]['total_value'] += $value;
+            }
+
+            return array_values($totals);
         } catch (\Exception $e) {
             $this->logger->warning(
                 message: '[MetricsRepository] Failed to get lead values',
@@ -150,28 +186,43 @@ class MetricsRepository
     /**
      * Get service request counts grouped by status.
      *
-     * @return array<array{status: string, cnt: string}> Grouped counts.
+     * Queries using the configured request schema ID and aggregates in PHP
+     * to remain portable across MySQL and PostgreSQL.
+     *
+     * @return array<array{status: string, cnt: int}> Grouped counts.
      *
      * @spec openspec/changes/retrofit-2026-05-24-annotate-pipelinq/tasks.md#task-54
      */
     public function getRequestCounts(): array
     {
+        $schemaId = $this->appConfig->getValueString(Application::APP_ID, 'request_schema', '');
+        if ($schemaId === '') {
+            return [];
+        }
+
         try {
             $qb = $this->db->getQueryBuilder();
-            $qb->select(
-                $qb->createFunction("JSON_UNQUOTE(JSON_EXTRACT(o.object, '$.status')) AS status"),
-            )
-                ->selectAlias($qb->func()->count('o.id'), 'cnt')
+            $qb->select('o.object')
                 ->from('openregister_objects', 'o')
-                ->innerJoin('o', 'openregister_schemas', 's', $qb->expr()->eq('o.schema', 's.id'))
-                ->where($qb->expr()->like('s.title', $qb->createNamedParameter('%equest%')))
-                ->groupBy('status');
+                ->where($qb->expr()->eq('o.schema', $qb->createNamedParameter($schemaId)));
 
             $result = $qb->executeQuery();
             $rows   = $result->fetchAll();
             $result->closeCursor();
 
-            return $rows;
+            // Aggregate in PHP for DB-portability.
+            $counts = [];
+            foreach ($rows as $row) {
+                $obj    = json_decode($row['object'] ?? '{}', true) ?? [];
+                $status = (string) ($obj['status'] ?? '');
+                if (isset($counts[$status]) === false) {
+                    $counts[$status] = ['status' => $status, 'cnt' => 0];
+                }
+
+                $counts[$status]['cnt']++;
+            }
+
+            return array_values($counts);
         } catch (\Exception $e) {
             $this->logger->warning(
                 message: '[MetricsRepository] Failed to get request counts',

--- a/lib/Service/ProspectDiscoveryService.php
+++ b/lib/Service/ProspectDiscoveryService.php
@@ -21,6 +21,8 @@ declare(strict_types=1);
 
 namespace OCA\Pipelinq\Service;
 
+use OCP\App\IAppManager;
+use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
 
 /**
@@ -45,12 +47,14 @@ class ProspectDiscoveryService
     /**
      * Constructor.
      *
-     * @param IcpConfigService        $icpConfig The ICP config service.
-     * @param KvkApiClient            $kvkClient The KVK API client.
-     * @param OpenCorporatesApiClient $ocClient  The OpenCorporates client.
-     * @param ProspectScoringService  $scoring   The scoring service.
-     * @param SettingsService         $settings  The settings service.
-     * @param LoggerInterface         $logger    The logger.
+     * @param IcpConfigService        $icpConfig  The ICP config service.
+     * @param KvkApiClient            $kvkClient  The KVK API client.
+     * @param OpenCorporatesApiClient $ocClient   The OpenCorporates client.
+     * @param ProspectScoringService  $scoring    The scoring service.
+     * @param SettingsService         $settings   The settings service.
+     * @param LoggerInterface         $logger     The logger.
+     * @param ContainerInterface      $container  The DI container.
+     * @param IAppManager             $appManager The app manager.
      */
     public function __construct(
         private IcpConfigService $icpConfig,
@@ -59,6 +63,8 @@ class ProspectDiscoveryService
         private ProspectScoringService $scoring,
         private SettingsService $settings,
         private LoggerInterface $logger,
+        private ContainerInterface $container,
+        private IAppManager $appManager,
     ) {
     }//end __construct()
 
@@ -226,29 +232,20 @@ class ProspectDiscoveryService
                 array: $prospects,
                 callback: function (array $prospect) use ($clientNames): bool {
                     $tradeName = strtolower(string: trim(string: $prospect['tradeName'] ?? ''));
-                    foreach ($clientNames as $clientName) {
-                        if ($tradeName === $clientName) {
-                            return false;
-                        }
-
-                        // Fuzzy match: check if one contains the other.
-                        if ($tradeName !== '' && $clientName !== '') {
-                            if (str_contains(haystack: $tradeName, needle: $clientName) === true
-                                || str_contains(haystack: $clientName, needle: $tradeName) === true
-                            ) {
-                                return false;
-                            }
-                        }
+                    if ($tradeName === '') {
+                        return true;
                     }
 
-                    return true;
+                    // Use strict normalised equality only; bidirectional str_contains
+                    // produces false positives on common substrings like "BV" or "Group".
+                    return in_array($tradeName, $clientNames, true) === false;
                 }
             )
         );
     }//end excludeExistingClients()
 
     /**
-     * Get names of existing clients (lowercased).
+     * Get names of existing clients (lowercased) from OpenRegister.
      *
      * @return array The client names.
      */
@@ -262,9 +259,34 @@ class ProspectDiscoveryService
                 return [];
             }
 
-            // Use the OpenRegister API internally via curl to get clients.
-            // This is a simplification; in production, inject ObjectService.
-            return [];
+            if (in_array('openregister', $this->appManager->getInstalledApps(), true) === false) {
+                return [];
+            }
+
+            /*
+             * @var \OCA\OpenRegister\Service\ObjectService $objectService
+             */
+            $objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
+
+            $clients = $objectService->findAll(
+                [
+                    'filters' => [
+                        'register' => $register,
+                        'schema'   => $schema,
+                    ],
+                    'limit'   => 1000,
+                ]
+            );
+
+            $names = [];
+            foreach ($clients as $client) {
+                $name = $client['name'] ?? $client['tradeName'] ?? '';
+                if ($name !== '') {
+                    $names[] = strtolower(trim($name));
+                }
+            }
+
+            return $names;
         } catch (\Exception $e) {
             $this->logger->warning(
                 message: 'Failed to fetch existing clients for exclusion',

--- a/lib/Service/ScheduledTaskService.php
+++ b/lib/Service/ScheduledTaskService.php
@@ -154,7 +154,18 @@ class ScheduledTaskService
             $filters['deadline']['<='] = $params['to'];
         }
 
+        $items = [];
+        $total = 0;
+
         try {
+            // Fetch the total count without pagination so the envelope
+            // reflects the true result-set size, not just the page size.
+            $allItems = $this->getObjectService()->findAll(
+                ['filters' => $filters]
+            );
+            $total    = count($allItems);
+
+            // Fetch the paginated page.
             $items = $this->getObjectService()->findAll(
                 [
                     'filters' => $filters,
@@ -168,11 +179,12 @@ class ScheduledTaskService
                 'ScheduledTaskService: findAll failed',
                 ['exception' => $e]
             );
-            $items = [];
-        }
+        }//end try
 
-        $total = count($items);
-        $pages = (int) ceil($total / $limit);
+        $pages = 0;
+        if ($total > 0) {
+            $pages = (int) ceil($total / $limit);
+        }
 
         return [
             'items' => $items,


### PR DESCRIPTION
## Summary

- **#603 Feedback persistence** — `KennisbankController::submitFeedback()` built and returned feedback data but never saved it. Now wired to OR `saveObject()` via injected container; gracefully skips if OpenRegister is unavailable
- **#604 Prospect exclusion stub + false positives** — `ProspectDiscoveryService::getExistingClientNames()` was hardcoded `return []`. Now calls OR `findAll()` to fetch real client names. Bidirectional `str_contains` match replaced with strict normalised equality to avoid false positives on common suffixes like "BV" or "Group"
- **#608 MetricsRepository portability + cross-tenant leak** — Replaced MySQL-specific `JSON_UNQUOTE(JSON_EXTRACT(...))` queries and `%ead%`/`%equest%` LIKE patterns with portable PHP-side aggregation scoped to configured schema IDs
- **#609 Unbounded oc_appconfig growth** — `CallbackOverdueJob::markNotified()` now calls `pruneStaleNotifications()` to delete entries older than 2× the cooldown window after each write
- **#610 Exception message leaks** — `ContactSyncController`, `LeadSourceController`, `SettingsController` replaced `$e->getMessage()` in HTTP responses with a generic user message and server-side `$this->logger->error()` per ADR-005
- **#611 Incorrect pagination total** — `ScheduledTaskService::getScheduledTasks()` counted items on the current page; now performs a separate unpaginated `findAll()` to compute the true total
- **#612 Null-value condition evaluation** — `AutomationService::evaluateConditions()` returned `false` immediately when `$actual === null`, preventing null-to-value automation triggers. Now correctly handles `null` vs non-null expected values
- **#613 Unvalidated objectType in appconfig key** — `ContactVcardService` added an `ALLOWED_OBJECT_TYPES` allowlist check before using caller-supplied `$objectType` to construct an `IAppConfig` key

## Test plan

- [ ] Submit kennisbank feedback while OR is available — verify object appears in OR
- [ ] Submit kennisbank feedback without OR installed — verify 200 with `feedback` payload and no fatal
- [ ] Run prospect discovery with existing clients in OR — verify exclusion works
- [ ] Call `MetricsRepository::getLeadCounts()` on PostgreSQL — verify no SQL error
- [ ] Call `CallbackOverdueJob::markNotified()` 3 times with old timestamps — verify old entries pruned
- [ ] Trigger a contact sync failure — verify response is generic, not raw exception message
- [ ] Call `getScheduledTasks()` with 25 items and page 1, limit 10 — verify `total=25`, `pages=3`
- [ ] Fire automation with `$actual=null` and condition `neq: "active"` — verify trigger fires
- [ ] Call `ContactVcardService::syncToContacts("malicious_type", "...")` — verify null returned

Closes #603, #604, #608, #609, #610, #611, #612, #613