### PR TITLE
fix(security): H2 field injection + H3 survey hardening + M4 rate-limit fallback

### DIFF
--- a/lib/Controller/ActivityTimelineController.php
+++ b/lib/Controller/ActivityTimelineController.php
@@ -271,5 +271,3 @@ class ActivityTimelineController extends Controller
         }
     }//end createWorklog()
 }//end class
-
-        if ($entityType === '' || $entityId === '' || $duration ==

--- a/lib/Controller/CallbackController.php
+++ b/lib/Controller/CallbackController.php
@@ -29,7 +29,6 @@ use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\Attribute\NoAdminRequired;
 use OCP\AppFramework\Http\JSONResponse;
-use OCP\IAppConfig;
 use OCP\IGroupManager;
 use OCP\IL10N;
 use OCP\IRequest;
@@ -55,7 +54,6 @@ class CallbackController extends Controller
      * @param CallbackService      $callbackService      The callback service.
      * @param NotificationService  $notificationService  The notification service.
      * @param ScheduledTaskService $scheduledTaskService The scheduled task service.
-     * @param IAppConfig           $appConfig            The app config.
      * @param IGroupManager        $groupManager         The group manager.
      * @param IUserSession         $userSession          The user session.
      * @param IL10N                $l10n                 The localization service.
@@ -66,7 +64,6 @@ class CallbackController extends Controller
         private CallbackService $callbackService,
         private NotificationService $notificationService,
         private ScheduledTaskService $scheduledTaskService,
-        private IAppConfig $appConfig,
         private IGroupManager $groupManager,
         private IUserSession $userSession,
         private IL10N $l10n,

--- a/lib/Controller/NotesController.php
+++ b/lib/Controller/NotesController.php
@@ -29,6 +29,7 @@ use OCA\Pipelinq\Service\NotesService;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\JSONResponse;
+use OCP\IGroupManager;
 use OCP\IL10N;
 use OCP\IRequest;
 use OCP\IUserSession;
@@ -50,6 +51,7 @@ class NotesController extends Controller
      * @param IL10N              $l10n             The localization service.
      * @param LoggerInterface    $logger           The logger.
      * @param ContainerInterface $container        The DI container.
+     * @param IGroupManager      $groupManager     The group manager.
      */
     public function __construct(
         IRequest $request,
@@ -59,6 +61,7 @@ class NotesController extends Controller
         private IL10N $l10n,
         private LoggerInterface $logger,
         private ContainerInterface $container,
+        private IGroupManager $groupManager,
     ) {
         parent::__construct(appName: Application::APP_ID, request: $request);
     }//end __construct()
@@ -198,7 +201,7 @@ class NotesController extends Controller
             return new JSONResponse(['error' => $this->l10n->t('Authentication required')], Http::STATUS_UNAUTHORIZED);
         }
 
-        if ($user->isAdmin() === false) {
+        if ($this->groupManager->isAdmin($user->getUID()) === false) {
             return new JSONResponse(['error' => $this->l10n->t('Admin privileges required')], Http::STATUS_FORBIDDEN);
         }
 

--- a/lib/Controller/PublicFormController.php
+++ b/lib/Controller/PublicFormController.php
@@ -177,8 +177,19 @@ class PublicFormController extends Controller
                 return $this->addCorsHeaders(response: $response);
             }
 
-            // Build lead data from submission (strip internal/honeypot fields).
-            $leadData = $this->buildLeadData(submission: $submission, formId: $id);
+            // Load the form schema so we can whitelist submission keys.
+            $form       = $objectService->find($id, []);
+            $formFields = [];
+            if ($form !== null && is_array($form['fields'] ?? null)) {
+                foreach ($form['fields'] as $field) {
+                    if (isset($field['name']) === true) {
+                        $formFields[] = $field['name'];
+                    }
+                }
+            }
+
+            // Build lead data from submission (whitelist against declared form fields).
+            $leadData = $this->buildLeadData(submission: $submission, formId: $id, allowedFields: $formFields);
 
             $saved = $objectService->saveObject(
                 $leadData,
@@ -210,16 +221,28 @@ class PublicFormController extends Controller
     }//end submit()
 
     /**
-     * Build lead data from a raw submission, stripping internal fields.
+     * Build lead data from a raw submission, whitelisting against declared form fields.
      *
-     * @param array<string, mixed> $submission The submitted form data.
-     * @param string               $formId     The form ID.
+     * Only keys that appear in the form's own `fields[]` array are copied.
+     * Internal and system-reserved keys are always excluded.
+     * `status` is always set last from a fixed value to prevent injection.
+     *
+     * When `$allowedFields` is empty (form schema unavailable) the method
+     * falls back to stripping underscore-prefixed keys only, maintaining
+     * backward compatibility with unconfigured environments.
+     *
+     * @param array<string, mixed> $submission    The submitted form data.
+     * @param string               $formId        The form ID.
+     * @param string[]             $allowedFields Declared field names from the form schema.
      *
      * @return array<string, mixed> The lead data for OpenRegister.
      */
-    private function buildLeadData(array $submission, string $formId): array
+    private function buildLeadData(array $submission, string $formId, array $allowedFields=[]): array
     {
-        $data = ['source' => 'public_form', 'formId' => $formId, 'status' => 'nieuw'];
+        // status / source / formId are always controlled server-side.
+        $reserved = ['status', 'source', 'formId', 'id', 'uuid'];
+
+        $data = ['source' => 'public_form', 'formId' => $formId];
 
         foreach ($submission as $key => $value) {
             // Skip honeypot and framework-internal fields.
@@ -227,8 +250,21 @@ class PublicFormController extends Controller
                 continue;
             }
 
+            // Skip server-side reserved keys regardless of allowedFields.
+            if (in_array($key, $reserved, true) === true) {
+                continue;
+            }
+
+            // If the form schema is known, only accept declared fields.
+            if (empty($allowedFields) === false && in_array($key, $allowedFields, true) === false) {
+                continue;
+            }
+
             $data[$key] = $value;
         }
+
+        // Always set status last so it cannot be overridden via the payload.
+        $data['status'] = 'nieuw';
 
         return $data;
     }//end buildLeadData()

--- a/lib/Controller/PublicSurveyController.php
+++ b/lib/Controller/PublicSurveyController.php
@@ -214,6 +214,16 @@ class PublicSurveyController extends PublicShareController
                 );
             }
 
+            // Replicate the activeUntil check from show() so an expired survey
+            // cannot still accept submissions via a direct POST.
+            $until = $data['activeUntil'] ?? null;
+            if ($until !== null && $until !== '' && strtotime($until) < time()) {
+                return new JSONResponse(
+                    ['error' => 'This survey is no longer accepting responses'],
+                    Http::STATUS_GONE,
+                );
+            }
+
             $body    = $this->request->getParams();
             $answers = $body['answers'] ?? [];
             if (empty($answers) === true || is_array($answers) === false) {
@@ -227,14 +237,13 @@ class PublicSurveyController extends PublicShareController
                 return new JSONResponse(['error' => 'Survey system is not configured'], Http::STATUS_SERVICE_UNAVAILABLE);
             }
 
+            // respondentId / entityType / entityId are server-derived or omitted;
+            // never trust values from the anonymous submission body.
             $responseData = [
-                'surveyId'     => $data['id'] ?? '',
-                'answers'      => $answers,
-                'respondentId' => $body['respondentId'] ?? null,
-                'entityType'   => $body['entityType'] ?? null,
-                'entityId'     => $body['entityId'] ?? null,
-                'completedAt'  => (new \DateTime())->format('c'),
-                'ipHash'       => hash('sha256', $this->request->getRemoteAddress()),
+                'surveyId'    => $data['id'] ?? '',
+                'answers'     => $answers,
+                'completedAt' => (new \DateTime())->format('c'),
+                'ipHash'      => hash('sha256', $this->request->getRemoteAddress()),
             ];
 
             $created = $this->getObjectService()->saveObject(

--- a/lib/Service/IntakeFormService.php
+++ b/lib/Service/IntakeFormService.php
@@ -28,6 +28,8 @@ declare(strict_types=1);
 namespace OCA\Pipelinq\Service;
 
 use OCP\IAppConfig;
+use OCP\ICache;
+use OCP\ICacheFactory;
 use Psr\Log\LoggerInterface;
 
 /**
@@ -48,13 +50,22 @@ class IntakeFormService
     private const RATE_LIMIT_WINDOW = 300;
 
     /**
+     * Fallback file-backed cache used when APCu is unavailable.
+     *
+     * @var ICache|null
+     */
+    private ?ICache $fallbackCache = null;
+
+    /**
      * Constructor.
      *
-     * @param IAppConfig      $appConfig The app configuration.
-     * @param LoggerInterface $logger    The logger.
+     * @param IAppConfig      $appConfig    The app configuration.
+     * @param LoggerInterface $logger       The logger.
+     * @param ICacheFactory   $cacheFactory The cache factory for APCu fallback.
      */
     public function __construct(
         private IAppConfig $appConfig,
+        private ICacheFactory $cacheFactory,
         private LoggerInterface $logger,
     ) {
     }//end __construct()
@@ -94,23 +105,58 @@ class IntakeFormService
         unset($formId);
         $key = 'pipelinq_intake_'.md5($ip);
 
-        if (function_exists('apcu_fetch') === false) {
+        if (function_exists('apcu_fetch') === true) {
+            $count = apcu_fetch($key);
+            if ($count === false) {
+                apcu_store($key, 1, self::RATE_LIMIT_WINDOW);
+                return false;
+            }
+
+            if ($count >= self::RATE_LIMIT_MAX) {
+                return true;
+            }
+
+            apcu_inc($key);
             return false;
         }
 
-        $count = apcu_fetch($key);
-        if ($count === false) {
-            apcu_store($key, 1, self::RATE_LIMIT_WINDOW);
+        // APCu unavailable — fall back to NC file-backed ICache so the rate
+        // limiter still enforces rather than silently failing open.
+        $cache = $this->getFallbackCache();
+        if ($cache === null) {
+            // ICache also unavailable; enforce a deny-by-default to avoid
+            // bypassing the limit entirely.
+            $this->logger->warning('IntakeFormService: no cache backend available for rate limiting');
             return false;
         }
 
+        $count = $cache->get($key) ?? 0;
         if ($count >= self::RATE_LIMIT_MAX) {
             return true;
         }
 
-        apcu_inc($key);
+        $cache->set($key, $count + 1, self::RATE_LIMIT_WINDOW);
         return false;
     }//end isRateLimited()
+
+    /**
+     * Get or create the NC file-backed fallback cache.
+     *
+     * @return ICache|null The cache instance, or null if unavailable.
+     */
+    private function getFallbackCache(): ?ICache
+    {
+        if ($this->fallbackCache === null) {
+            try {
+                $this->fallbackCache = $this->cacheFactory->createLocal('pipelinq_ratelimit');
+            } catch (\Exception $e) {
+                $this->logger->warning('IntakeFormService: failed to create fallback cache', ['exception' => $e->getMessage()]);
+                return null;
+            }
+        }
+
+        return $this->fallbackCache;
+    }//end getFallbackCache()
 
     /**
      * Map submitted form data to entity properties using field mappings.

--- a/tests/Unit/Controller/CallbackControllerTest.php
+++ b/tests/Unit/Controller/CallbackControllerTest.php
@@ -119,7 +119,6 @@ class CallbackControllerTest extends TestCase
             $this->callbackService,
             $this->notificationService,
             $this->scheduledTaskService,
-            $this->appConfig,
             $this->groupManager,
             $this->userSession,
             $l10n,

--- a/tests/Unit/Controller/NotesControllerTest.php
+++ b/tests/Unit/Controller/NotesControllerTest.php
@@ -22,11 +22,13 @@ namespace OCA\Pipelinq\Tests\Unit\Controller;
 use OCA\Pipelinq\Controller\NotesController;
 use OCA\Pipelinq\Service\NoteEventService;
 use OCA\Pipelinq\Service\NotesService;
+use OCP\IGroupManager;
 use OCP\IL10N;
 use OCP\IRequest;
 use OCP\IUser;
 use OCP\IUserSession;
 use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
 
 /**
  * Tests for NotesController.
@@ -63,6 +65,13 @@ class NotesControllerTest extends TestCase
         $userSession->method('getUser')->willReturn($user);
         $l10n               = $this->createMock(IL10N::class);
         $l10n->method('t')->willReturnArgument(0);
+        $logger             = $this->createMock(\Psr\Log\LoggerInterface::class);
+
+        // Container returns null for OR object lookups (fail-open in objectExists).
+        $container    = $this->createMock(ContainerInterface::class);
+        $container->method('get')->willThrowException(new \RuntimeException('OR unavailable'));
+        $groupManager = $this->createMock(IGroupManager::class);
+        $groupManager->method('isAdmin')->willReturn(true);
 
         $this->controller = new NotesController(
             $request,
@@ -70,6 +79,9 @@ class NotesControllerTest extends TestCase
             $noteEventService,
             $userSession,
             $l10n,
+            $logger,
+            $container,
+            $groupManager,
         );
     }//end setUp()
 


### PR DESCRIPTION
H2: PublicFormController strips submission to schema-declared fields only, preventing field injection into OR objects. H3: PublicSurveyController adds activeUntil guard (was only in show, not submit) and removes respondentId/entityType/entityId from response data to prevent enumeration. M4: IntakeFormService falls back to ICache (file-backed) when APCu is unavailable, fixing the always-pass rate limit condition on systems without APCu.