### PR TITLE
fix(security): M3/M5/L1/L3 stub jobs, getMessage leaks, 501 stubs, error redaction

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -85,8 +85,6 @@ Vrij en open source onder de AGPL-licentie.
     <background-jobs>
         <job>OCA\Pipelinq\BackgroundJob\TaskExpiryJob</job>
         <job>OCA\Pipelinq\BackgroundJob\QueueOverflowJob</job>
-        <job>OCA\Pipelinq\BackgroundJob\ComplaintSlaJob</job>
-        <job>OCA\Pipelinq\BackgroundJob\CallbackOverdueJob</job>
         <job>OCA\Pipelinq\BackgroundJob\ScheduledTaskJob</job>
     </background-jobs>
 

--- a/lib/Controller/ContactmomentController.php
+++ b/lib/Controller/ContactmomentController.php
@@ -33,6 +33,7 @@ use OCP\Files\NotPermittedException;
 use OCP\IL10N;
 use OCP\IRequest;
 use OCP\IUserSession;
+use Psr\Log\LoggerInterface;
 
 /**
  * Controller for contactmoment API operations.
@@ -46,12 +47,14 @@ class ContactmomentController extends Controller
      * @param ContactmomentService $contactmomentService The contactmoment service.
      * @param IUserSession         $userSession          The user session.
      * @param IL10N                $l10n                 The localization service.
+     * @param LoggerInterface      $logger               The logger.
      */
     public function __construct(
         IRequest $request,
         private ContactmomentService $contactmomentService,
         private IUserSession $userSession,
         private IL10N $l10n,
+        private LoggerInterface $logger,
     ) {
         parent::__construct(appName: Application::APP_ID, request: $request);
     }//end __construct()
@@ -96,8 +99,9 @@ class ContactmomentController extends Controller
                 403
             );
         } catch (\Exception $e) {
+            $this->logger->error('ContactmomentController::destroy failed', ['exception' => $e]);
             return new JSONResponse(
-                ['error' => $e->getMessage()],
+                ['error' => $this->l10n->t('Operation failed')],
                 500
             );
         }//end try

--- a/lib/Controller/IntakeFormController.php
+++ b/lib/Controller/IntakeFormController.php
@@ -89,7 +89,7 @@ class IntakeFormController extends Controller
      *
      * @param string $id The form ID.
      *
-     * @return DataDownloadResponse The CSV download response.
+     * @return DataDownloadResponse|JSONResponse The CSV download or 501 stub response.
      *
      * @NoAdminRequired
      *
@@ -102,13 +102,8 @@ class IntakeFormController extends Controller
             return new JSONResponse(['message' => 'Authentication required'], Http::STATUS_UNAUTHORIZED);
         }
 
-        // In production, fetch form and submissions from OpenRegister.
-        $csv = $this->intakeFormService->exportCsv(submissions: [], fields: []);
-
-        return new DataDownloadResponse(
-            data: $csv,
-            filename: 'submissions-'.$id.'.csv',
-            contentType: 'text/csv'
-        );
+        // CSV export requires OpenRegister data integration.
+        // Returning 501 until OR submission retrieval is wired.
+        return new JSONResponse(['message' => 'Export not yet implemented'], Http::STATUS_NOT_IMPLEMENTED);
     }//end export()
 }//end class

--- a/lib/Controller/ProspectController.php
+++ b/lib/Controller/ProspectController.php
@@ -31,6 +31,7 @@ use OCP\AppFramework\Http\JSONResponse;
 use OCP\IL10N;
 use OCP\IRequest;
 use OCP\IUserSession;
+use Psr\Log\LoggerInterface;
 
 /**
  * Controller for prospect discovery.
@@ -44,12 +45,14 @@ class ProspectController extends Controller
      * @param ProspectDiscoveryService $discoveryService The discovery service.
      * @param IUserSession             $userSession      The user session.
      * @param IL10N                    $l10n             The localization service.
+     * @param LoggerInterface          $logger           The logger.
      */
     public function __construct(
         IRequest $request,
         private ProspectDiscoveryService $discoveryService,
         private IUserSession $userSession,
         private IL10N $l10n,
+        private LoggerInterface $logger,
     ) {
         parent::__construct(appName: Application::APP_ID, request: $request);
     }//end __construct()
@@ -124,8 +127,9 @@ class ProspectController extends Controller
 
             return new JSONResponse(data: $result, statusCode: 201);
         } catch (\Exception $e) {
+            $this->logger->error('ProspectController::createLead failed', ['exception' => $e]);
             return new JSONResponse(
-                data: ['error' => $e->getMessage()],
+                data: ['error' => $this->l10n->t('Operation failed')],
                 statusCode: 500
             );
         }//end try

--- a/lib/Controller/ReportingController.php
+++ b/lib/Controller/ReportingController.php
@@ -161,37 +161,11 @@ class ReportingController extends Controller
             return new JSONResponse(['error' => $this->l10n->t('Authentication required')], Http::STATUS_UNAUTHORIZED);
         }
 
-        try {
-            $headers = [
-                $this->l10n->t('Date'),
-                $this->l10n->t('Channel'),
-                $this->l10n->t('Agent'),
-                $this->l10n->t('Client'),
-                $this->l10n->t('Subject'),
-                $this->l10n->t('Result'),
-                $this->l10n->t('Duration'),
-            ];
-
-            // In production, data would be fetched from OpenRegister based on filters.
-            $rows = [];
-
-            $csv = $this->reportingService->generateCsv(
-                headers: $headers,
-                rows: $rows,
-            );
-
-            $filename = 'contactmomenten-rapport-'.date('Y-m-d').'.csv';
-
-            return new DataDownloadResponse(
-                $csv,
-                $filename,
-                'text/csv; charset=utf-8',
-            );
-        } catch (\Exception $e) {
-            return new JSONResponse(
-                ['error' => $this->l10n->t('Failed to generate export')],
-                500,
-            );
-        }//end try
+        // CSV export requires OpenRegister data integration.
+        // Returning 501 until OR contactmoment retrieval is wired.
+        return new JSONResponse(
+            ['error' => $this->l10n->t('Export not yet implemented')],
+            Http::STATUS_NOT_IMPLEMENTED,
+        );
     }//end exportCsv()
 }//end class

--- a/lib/Controller/RequestChannelController.php
+++ b/lib/Controller/RequestChannelController.php
@@ -32,6 +32,7 @@ use OCP\AppFramework\Http\Attribute\NoAdminRequired;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\IRequest;
 use OCP\IUserSession;
+use Psr\Log\LoggerInterface;
 
 /**
  * Controller for request channel management.
@@ -46,11 +47,13 @@ class RequestChannelController extends Controller
      * @param IRequest         $request          The request.
      * @param SystemTagService $systemTagService The system tag service.
      * @param IUserSession     $userSession      The user session.
+     * @param LoggerInterface  $logger           The logger.
      */
     public function __construct(
         IRequest $request,
         private SystemTagService $systemTagService,
         private IUserSession $userSession,
+        private LoggerInterface $logger,
     ) {
         parent::__construct(appName: Application::APP_ID, request: $request);
     }//end __construct()
@@ -148,7 +151,8 @@ class RequestChannelController extends Controller
             );
             return new JSONResponse(['success' => true]);
         } catch (\Exception $e) {
-            return new JSONResponse(['success' => false, 'message' => $e->getMessage()], 500);
+            $this->logger->error('RequestChannelController::destroy failed', ['exception' => $e]);
+            return new JSONResponse(['success' => false, 'message' => 'An unexpected error occurred'], 500);
         }
     }//end destroy()
 }//end class

--- a/tests/Unit/Controller/ContactmomentControllerTest.php
+++ b/tests/Unit/Controller/ContactmomentControllerTest.php
@@ -28,6 +28,7 @@ use OCP\IRequest;
 use OCP\IUser;
 use OCP\IUserSession;
 use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
 
 /**
  * Tests for ContactmomentController.
@@ -73,6 +74,7 @@ class ContactmomentControllerTest extends TestCase
             $this->contactmomentService,
             $this->userSession,
             $l10n,
+            $this->createMock(LoggerInterface::class),
         );
     }//end setUp()
 

--- a/tests/Unit/Controller/ProspectControllerTest.php
+++ b/tests/Unit/Controller/ProspectControllerTest.php
@@ -27,6 +27,7 @@ use OCP\IRequest;
 use OCP\IUser;
 use OCP\IUserSession;
 use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
 
 /**
  * Tests for ProspectController.
@@ -75,6 +76,7 @@ class ProspectControllerTest extends TestCase
             $this->discoveryService,
             $userSession,
             $l10n,
+            $this->createMock(LoggerInterface::class),
         );
     }//end setUp()
 

--- a/tests/Unit/Controller/RequestChannelControllerTest.php
+++ b/tests/Unit/Controller/RequestChannelControllerTest.php
@@ -26,6 +26,7 @@ use OCP\IRequest;
 use OCP\IUser;
 use OCP\IUserSession;
 use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
 
 /**
  * Tests for RequestChannelController.
@@ -72,6 +73,7 @@ class RequestChannelControllerTest extends TestCase
             $request,
             $this->tagService,
             $this->userSession,
+            $this->createMock(LoggerInterface::class),
         );
     }//end setUp()
 


### PR DESCRIPTION
M3: Remove ComplaintSlaJob and CallbackOverdueJob from info.xml background-jobs (both are log-only stubs, causing phantom scheduling). M5: ProspectController::createLead and ContactmomentController::destroy now log internal exceptions and return a generic message instead of leaking exception details. L1: IntakeFormController::export and ReportingController::exportCsv return HTTP 501 Not Implemented instead of silent empty responses. L3: RequestChannelController::destroy logs and returns a generic error instead of leaking exception details.