### PR TITLE
fix(security): wave-3 critical fixes

### DIFF
--- a/lib/Controller/NotesController.php
+++ b/lib/Controller/NotesController.php
@@ -26,6 +26,7 @@ namespace OCA\Pipelinq\Controller;
 use OCA\Pipelinq\AppInfo\Application;
 use OCA\Pipelinq\Service\NoteEventService;
 use OCA\Pipelinq\Service\NotesService;
+use OCA\Pipelinq\Service\SettingsService;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\JSONResponse;
@@ -42,6 +43,21 @@ use Psr\Log\LoggerInterface;
 class NotesController extends Controller
 {
     /**
+     * Maps the pipelinq_ objectType prefix to its settings config key for schema resolution.
+     *
+     * This ensures objectExists() scopes OR lookups to this app's own register+schema,
+     * preventing IDOR against objects in other apps or registers.
+     *
+     * @var array<string, string>
+     */
+    private const OBJECT_TYPE_TO_SCHEMA_KEY = [
+        'pipelinq_client'  => 'client_schema',
+        'pipelinq_contact' => 'contact_schema',
+        'pipelinq_lead'    => 'lead_schema',
+        'pipelinq_request' => 'request_schema',
+    ];
+
+    /**
      * Constructor.
      *
      * @param IRequest           $request          The request.
@@ -52,6 +68,7 @@ class NotesController extends Controller
      * @param LoggerInterface    $logger           The logger.
      * @param ContainerInterface $container        The DI container.
      * @param IGroupManager      $groupManager     The group manager.
+     * @param SettingsService    $settingsService  The settings service.
      */
     public function __construct(
         IRequest $request,
@@ -62,31 +79,57 @@ class NotesController extends Controller
         private LoggerInterface $logger,
         private ContainerInterface $container,
         private IGroupManager $groupManager,
+        private SettingsService $settingsService,
     ) {
         parent::__construct(appName: Application::APP_ID, request: $request);
     }//end __construct()
 
     /**
-     * Verify that the underlying OR object exists and is accessible.
+     * Verify that the underlying OR object exists within this app's own register+schema.
      *
-     * Returns true if the object is found, false (404-worthy) if not.
-     * On any service error the method returns true (fail-open is safer
-     * than blocking all notes when OR is temporarily unavailable).
+     * Scopes the lookup to the app's register and the schema that corresponds to
+     * the given objectType. Returns false when the object is not found in the
+     * expected schema (including when it exists in a different app's schema — IDOR
+     * prevention). Returns false on all unexpected errors (fail-closed) so that
+     * a broken OR connection does not silently grant access.
      *
-     * @param string $objectId The OR object UUID.
+     * @param string $objectType The pipelinq object type (must be in VALID_TYPES).
+     * @param string $objectId   The OR object UUID.
      *
-     * @return bool Whether the object can be accessed.
+     * @return bool Whether the object exists and belongs to this app.
      */
-    private function objectExists(string $objectId): bool
+    private function objectExists(string $objectType, string $objectId): bool
     {
+        $schemaKey = self::OBJECT_TYPE_TO_SCHEMA_KEY[$objectType] ?? null;
+        if ($schemaKey === null) {
+            return false;
+        }
+
         try {
+            $settings   = $this->settingsService->getSettings();
+            $registerId = $settings['register'] ?? '';
+            $schemaId   = $settings[$schemaKey] ?? '';
+
+            if ($registerId === '' || $schemaId === '') {
+                // Settings not yet configured — fail closed.
+                $this->logger->warning('NotesController: register or schema not configured', ['objectType' => $objectType]);
+                return false;
+            }
+
             $objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
-            $object        = $objectService->find($objectId, []);
+            $object        = $objectService->find(
+                id: $objectId,
+                register: $registerId,
+                schema: $schemaId
+            );
             return $object !== null;
+        } catch (\OCP\DB\Exception | \OCP\AppFramework\Db\DoesNotExistException $e) {
+            // Expected "not found" path — return false without noise.
+            return false;
         } catch (\Throwable $e) {
-            // OR unavailable — allow the operation rather than blocking all notes.
-            $this->logger->warning('NotesController: could not verify object existence', ['objectId' => $objectId, 'exception' => $e->getMessage()]);
-            return true;
+            // Unexpected error — fail closed and log.
+            $this->logger->error('NotesController: objectExists check failed', ['objectId' => $objectId, 'exception' => $e->getMessage()]);
+            return false;
         }
     }//end objectExists()
 
@@ -113,7 +156,7 @@ class NotesController extends Controller
             return new JSONResponse(['error' => $this->l10n->t('Invalid object type')], 400);
         }
 
-        if ($this->objectExists(objectId: $objectId) === false) {
+        if ($this->objectExists(objectType: $objectType, objectId: $objectId) === false) {
             return new JSONResponse(['error' => $this->l10n->t('Object not found')], Http::STATUS_NOT_FOUND);
         }
 
@@ -152,7 +195,7 @@ class NotesController extends Controller
             return new JSONResponse(['error' => $this->l10n->t('Invalid object type')], 400);
         }
 
-        if ($this->objectExists(objectId: $objectId) === false) {
+        if ($this->objectExists(objectType: $objectType, objectId: $objectId) === false) {
             return new JSONResponse(['error' => $this->l10n->t('Object not found')], Http::STATUS_NOT_FOUND);
         }
 
@@ -209,7 +252,7 @@ class NotesController extends Controller
             return new JSONResponse(['error' => $this->l10n->t('Invalid object type')], 400);
         }
 
-        if ($this->objectExists(objectId: $objectId) === false) {
+        if ($this->objectExists(objectType: $objectType, objectId: $objectId) === false) {
             return new JSONResponse(['error' => $this->l10n->t('Object not found')], Http::STATUS_NOT_FOUND);
         }
 

--- a/lib/Controller/PublicSurveyController.php
+++ b/lib/Controller/PublicSurveyController.php
@@ -230,6 +230,41 @@ class PublicSurveyController extends PublicShareController
                 return new JSONResponse(['error' => 'Answers are required'], Http::STATUS_BAD_REQUEST);
             }
 
+            // Cap the total answers payload to 64 KiB to prevent DOS-via-blob.
+            if (strlen((string) json_encode($answers)) > 65536) {
+                return new JSONResponse(['error' => 'Answers payload too large'], Http::STATUS_REQUEST_ENTITY_TOO_LARGE);
+            }
+
+            // Validate each answer key against the survey's declared question IDs.
+            // Unknown keys (attacker-injected fields) are stripped silently.
+            $questions   = $data['questions'] ?? [];
+            $questionIds = [];
+            if (is_array($questions) === true) {
+                foreach ($questions as $question) {
+                    if (is_array($question) === true && isset($question['id']) === true) {
+                        $questionIds[] = (string) $question['id'];
+                    }
+                }
+            }
+
+            if (empty($questionIds) === false) {
+                $answers = array_intersect_key($answers, array_flip($questionIds));
+            }
+
+            // Enforce per-answer scalar-value caps to prevent nested-blob injection.
+            foreach ($answers as $key => $value) {
+                if (is_array($value) === true) {
+                    // Allow flat arrays (multi-select) but forbid nested objects.
+                    foreach ($value as $item) {
+                        if (is_array($item) === true || is_object($item) === true) {
+                            return new JSONResponse(['error' => 'Invalid answer value for question '.$key], Http::STATUS_BAD_REQUEST);
+                        }
+                    }
+                } else if (is_string($value) === true && strlen($value) > 4096) {
+                    return new JSONResponse(['error' => 'Answer value too long for question '.$key], Http::STATUS_BAD_REQUEST);
+                }
+            }
+
             $settings         = $this->settingsService->getSettings();
             $registerId       = $settings['register'] ?? '';
             $responseSchemaId = $settings['surveyResponse_schema'] ?? '';

--- a/lib/Service/ContactmomentService.php
+++ b/lib/Service/ContactmomentService.php
@@ -138,10 +138,13 @@ class ContactmomentService
             );
         }
 
-        $objectArray = $object->getObject();
-        $agent       = $objectArray['agent'] ?? '';
-        $isCreator   = ($agent === $currentUserId);
-        $isAdmin     = $this->groupManager->isAdmin($currentUserId);
+        // Use the OR-immutable createdBy field (set by the platform on every
+        // saveObject/createObject call) rather than the user-mutable `agent` field.
+        // Any caller with OR write-access can stamp `agent: victim_uid`; `createdBy`
+        // is protected by the platform and cannot be overwritten via the public API.
+        $createdBy = $object->getCreatedBy() ?? '';
+        $isCreator = ($createdBy !== '' && $createdBy === $currentUserId);
+        $isAdmin   = $this->groupManager->isAdmin($currentUserId);
 
         if ($isCreator === false && $isAdmin === false) {
             throw new NotPermittedException(

--- a/lib/Service/ScheduledTaskService.php
+++ b/lib/Service/ScheduledTaskService.php
@@ -65,6 +65,30 @@ class ScheduledTaskService
     ];
 
     /**
+     * Task fields that any authenticated user may modify.
+     *
+     * All other incoming keys are silently stripped before the merge to
+     * prevent mass-assignment of admin-only or system fields.
+     * Admin-only fields (status, assigneeUserId, assigneeGroupId, attempts,
+     * createdAt, completedAt) are handled separately in the controller.
+     *
+     * @var array<string>
+     */
+    public const MUTABLE_FIELDS = [
+        'type',
+        'subject',
+        'description',
+        'priority',
+        'deadline',
+        'clientId',
+        'requestId',
+        'contactMomentSummary',
+        'callbackPhoneNumber',
+        'preferredTimeSlot',
+        'resultText',
+    ];
+
+    /**
      * Maximum window in minutes for pending-task queries (24 hours).
      *
      * @var int
@@ -315,7 +339,12 @@ class ScheduledTaskService
     public function updateScheduledTask(string $id, array $data): array
     {
         $existing = $this->getScheduledTask(id: $id);
-        unset($data['createdBy']);
+
+        // Strip any fields not explicitly on the allowlist (MUTABLE_FIELDS +
+        // admin-only fields already filtered by the controller).  This prevents
+        // mass-assignment of system/immutable fields like createdBy, uuid, etc.
+        $allowedKeys  = array_merge(self::MUTABLE_FIELDS, ['status', 'assigneeUserId', 'assigneeGroupId', 'createdAt', 'completedAt', 'attempts']);
+        $data         = array_intersect_key($data, array_flip($allowedKeys));
 
         $merged       = array_merge($existing, $data);
         $merged['id'] = $id;

--- a/tests/Unit/Controller/NotesControllerTest.php
+++ b/tests/Unit/Controller/NotesControllerTest.php
@@ -22,6 +22,7 @@ namespace OCA\Pipelinq\Tests\Unit\Controller;
 use OCA\Pipelinq\Controller\NotesController;
 use OCA\Pipelinq\Service\NoteEventService;
 use OCA\Pipelinq\Service\NotesService;
+use OCA\Pipelinq\Service\SettingsService;
 use OCP\IGroupManager;
 use OCP\IL10N;
 use OCP\IRequest;
@@ -67,9 +68,32 @@ class NotesControllerTest extends TestCase
         $l10n->method('t')->willReturnArgument(0);
         $logger             = $this->createMock(\Psr\Log\LoggerInterface::class);
 
-        // Container returns null for OR object lookups (fail-open in objectExists).
-        $container    = $this->createMock(ContainerInterface::class);
-        $container->method('get')->willThrowException(new \RuntimeException('OR unavailable'));
+        // Provide a settings service that returns valid register + schema IDs
+        // so objectExists() can scope the OR lookup to the correct entity.
+        $settingsService = $this->createMock(SettingsService::class);
+        $settingsService->method('getSettings')->willReturn([
+            'register'       => 'reg-123',
+            'client_schema'  => 'schema-client',
+            'contact_schema' => 'schema-contact',
+            'lead_schema'    => 'schema-lead',
+            'request_schema' => 'schema-request',
+        ]);
+
+        // Build a minimal OR ObjectEntity stub that objectExists() can return.
+        $mockObject = $this->getMockBuilder(\stdClass::class)
+            ->addMethods(['getUuid'])
+            ->getMock();
+        $mockObject->method('getUuid')->willReturn('object-uuid');
+
+        // Object service stub: find() returns a non-null object for any scoped lookup.
+        $objectServiceStub = $this->getMockBuilder(\stdClass::class)
+            ->addMethods(['find'])
+            ->getMock();
+        $objectServiceStub->method('find')->willReturn($mockObject);
+
+        $container = $this->createMock(ContainerInterface::class);
+        $container->method('get')->willReturn($objectServiceStub);
+
         $groupManager = $this->createMock(IGroupManager::class);
         $groupManager->method('isAdmin')->willReturn(true);
 
@@ -82,6 +106,7 @@ class NotesControllerTest extends TestCase
             $logger,
             $container,
             $groupManager,
+            $settingsService,
         );
     }//end setUp()
 


### PR DESCRIPTION
## Summary

Fixes all verified-REAL CRITICAL findings from wave-3 deep review (triage at `/tmp/triage-pipelinq.md`, source report `a91cf8d12457eba00.output`).

- **C1** FALSE-POSITIVE — not touched
- **C2** `ScheduledTaskService::updateScheduledTask` mass-assignment — added `MUTABLE_FIELDS` const; `updateScheduledTask` now intersects incoming data against an explicit allowlist (user-mutable + admin-controlled fields), stripping anything else before merge
- **C3** `PublicSurveyController::submit` DOS / data pollution — added 64 KiB payload cap, validated each answer key against the survey's declared question IDs (unknown keys stripped silently), per-answer 4 KiB value cap, and flat-array guard against nested-blob injection
- **C4** `NotesController` IDOR — `objectExists()` now scopes the OR `find()` call to the app's own `register` + schema derived from the `objectType` via `OBJECT_TYPE_TO_SCHEMA_KEY` map; fails closed on unexpected errors and missing config rather than fail-open; injected `SettingsService` into constructor
- **C5** `ContactmomentService::delete` mutable-field ownership check — replaced `$objectArray['agent']` lookup with `$object->getCreatedBy()` (OR-immutable platform-set field) to prevent framing attacks where any write-capable caller stamps `agent: victim_uid`

## Test plan

- [ ] CI phpcs / phpstan / phpunit gates green
- [ ] `NotesControllerTest` updated: constructor now passes `SettingsService` mock with valid settings; object service mock returns non-null for scoped lookups
- [ ] C2: verify `updateScheduledTask` strips unknown/system fields (e.g. `uuid`, `createdBy`) from incoming payload
- [ ] C3: verify submitting a >64 KiB answers blob returns 413; answers with keys not in `questions[].id` are stripped
- [ ] C4: verify notes on a UUID from a different app/register returns 404 for authenticated users
- [ ] C5: verify deleting a contactmoment as a non-creator who stamped `agent: their_uid` returns 403