### PR TITLE
fix(routes): align 4 API endpoints with Newman test paths

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -9,18 +9,18 @@ return [
         ['name' => 'settings#reimport', 'url' => '/api/settings/reimport', 'verb' => 'POST'],
 
         // User settings
-        ['name' => 'settings#getUserSettings', 'url' => '/api/user/settings', 'verb' => 'GET'],
-        ['name' => 'settings#updateUserSettings', 'url' => '/api/user/settings', 'verb' => 'PUT'],
+        ['name' => 'settings#getUserSettings', 'url' => '/api/settings/user', 'verb' => 'GET'],
+        ['name' => 'settings#updateUserSettings', 'url' => '/api/settings/user', 'verb' => 'PUT'],
 
         // Generic per-user preferences (used by shared nextcloud-vue widgets, e.g. CnSupportDialog)
         ['name' => 'preferences#getPreference', 'url' => '/api/preferences/{key}', 'verb' => 'GET'],
         ['name' => 'preferences#setPreference', 'url' => '/api/preferences/{key}', 'verb' => 'PUT'],
 
         // Lead sources (camelCase slug matches LeadSourceController class name)
-        ['name' => 'leadSource#index', 'url' => '/api/settings/lead-sources', 'verb' => 'GET'],
-        ['name' => 'leadSource#create', 'url' => '/api/settings/lead-sources', 'verb' => 'POST'],
-        ['name' => 'leadSource#update', 'url' => '/api/settings/lead-sources/{id}', 'verb' => 'PUT'],
-        ['name' => 'leadSource#destroy', 'url' => '/api/settings/lead-sources/{id}', 'verb' => 'DELETE'],
+        ['name' => 'leadSource#index', 'url' => '/api/lead-sources', 'verb' => 'GET'],
+        ['name' => 'leadSource#create', 'url' => '/api/lead-sources', 'verb' => 'POST'],
+        ['name' => 'leadSource#update', 'url' => '/api/lead-sources/{id}', 'verb' => 'PUT'],
+        ['name' => 'leadSource#destroy', 'url' => '/api/lead-sources/{id}', 'verb' => 'DELETE'],
 
         // Contacts sync (camelCase slug matches ContactSyncController class name)
         ['name' => 'contactSync#search', 'url' => '/api/contacts-sync/search', 'verb' => 'GET'],
@@ -34,18 +34,18 @@ return [
         ['name' => 'notes#deleteSingle', 'url' => '/api/notes/single/{noteId}', 'verb' => 'DELETE'],
 
         // Request channels (camelCase slug matches RequestChannelController class name)
-        ['name' => 'requestChannel#index', 'url' => '/api/settings/request-channels', 'verb' => 'GET'],
-        ['name' => 'requestChannel#create', 'url' => '/api/settings/request-channels', 'verb' => 'POST'],
-        ['name' => 'requestChannel#update', 'url' => '/api/settings/request-channels/{id}', 'verb' => 'PUT'],
-        ['name' => 'requestChannel#destroy', 'url' => '/api/settings/request-channels/{id}', 'verb' => 'DELETE'],
+        ['name' => 'requestChannel#index', 'url' => '/api/request-channels', 'verb' => 'GET'],
+        ['name' => 'requestChannel#create', 'url' => '/api/request-channels', 'verb' => 'POST'],
+        ['name' => 'requestChannel#update', 'url' => '/api/request-channels/{id}', 'verb' => 'PUT'],
+        ['name' => 'requestChannel#destroy', 'url' => '/api/request-channels/{id}', 'verb' => 'DELETE'],
 
         // Prospect discovery
         ['name' => 'prospect#index', 'url' => '/api/prospects', 'verb' => 'GET'],
         ['name' => 'prospect#createLead', 'url' => '/api/prospects/create-lead', 'verb' => 'POST'],
 
         // Prospect settings (admin only; camelCase slug matches ProspectSettingsController class name)
-        ['name' => 'prospectSettings#index', 'url' => '/api/prospects/settings', 'verb' => 'GET'],
-        ['name' => 'prospectSettings#update', 'url' => '/api/prospects/settings', 'verb' => 'PUT'],
+        ['name' => 'prospectSettings#index', 'url' => '/api/prospect-settings', 'verb' => 'GET'],
+        ['name' => 'prospectSettings#update', 'url' => '/api/prospect-settings', 'verb' => 'PUT'],
 
         // Public intake forms (no auth; camelCase slug matches PublicFormController class name)
         ['name' => 'publicForm#show', 'url' => '/api/public/forms/{id}', 'verb' => 'GET'],

--- a/lib/Controller/NotesController.php
+++ b/lib/Controller/NotesController.php
@@ -131,7 +131,7 @@ class NotesController extends Controller
             // Unexpected error — fail closed and log.
             $this->logger->error('NotesController: objectExists check failed', ['objectId' => $objectId, 'exception' => $e->getMessage()]);
             return false;
-        }
+        }//end try
     }//end objectExists()
 
     /**

--- a/lib/Controller/PublicSurveyController.php
+++ b/lib/Controller/PublicSurveyController.php
@@ -241,8 +241,8 @@ class PublicSurveyController extends PublicShareController
             // permissively (allowlist skipped) to preserve backward compatibility.
             // Any survey that has at least one question with an 'id' engages the
             // allowlist — answers keyed by unknown IDs are dropped.
-            $questions    = $data['questions'] ?? [];
-            $questionIds  = [];
+            $questions       = $data['questions'] ?? [];
+            $questionIds     = [];
             $questionsWithId = 0;
             $totalQuestions  = 0;
             if (is_array($questions) === true) {
@@ -345,7 +345,7 @@ class PublicSurveyController extends PublicShareController
                 'limit'   => 1,
             ]
         );
-        $items   = $results['results'] ?? $results ?? [];
+        $items   = $results['results'] ?? [];
         if (empty($items) === true) {
             return null;
         }

--- a/lib/Controller/SettingsController.php
+++ b/lib/Controller/SettingsController.php
@@ -30,6 +30,7 @@ use OCP\App\IAppManager;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\Attribute\AuthorizedAdminSetting;
+use OCP\AppFramework\Http\Attribute\NoAdminRequired;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\IGroupManager;
 use OCP\IL10N;
@@ -120,10 +121,9 @@ class SettingsController extends Controller
      *
      * @return JSONResponse The settings response.
      *
-     * @NoAdminRequired
-     *
      * @spec openspec/changes/retrofit-2026-05-24-annotate-pipelinq/tasks.md#task-3
      */
+    #[NoAdminRequired]
     public function index(): JSONResponse
     {
         $user    = $this->userSession->getUser();
@@ -204,9 +204,9 @@ class SettingsController extends Controller
      *
      * @return JSONResponse The user settings response.
      *
-     * @NoAdminRequired
-     * @spec            openspec/changes/reverse-2026-05-26-be-settings/tasks.md#task-7
+     * @spec openspec/changes/reverse-2026-05-26-be-settings/tasks.md#task-7
      */
+    #[NoAdminRequired]
     public function getUserSettings(): JSONResponse
     {
         $user = $this->userSession->getUser();
@@ -224,9 +224,9 @@ class SettingsController extends Controller
      *
      * @return JSONResponse The updated user settings response.
      *
-     * @NoAdminRequired
-     * @spec            openspec/changes/reverse-2026-05-26-be-settings/tasks.md#task-8
+     * @spec openspec/changes/reverse-2026-05-26-be-settings/tasks.md#task-8
      */
+    #[NoAdminRequired]
     public function updateUserSettings(): JSONResponse
     {
         $user = $this->userSession->getUser();

--- a/lib/Service/ContactmomentService.php
+++ b/lib/Service/ContactmomentService.php
@@ -142,7 +142,12 @@ class ContactmomentService
         // saveObject/createObject call) rather than the user-mutable `agent` field.
         // Any caller with OR write-access can stamp `agent: victim_uid`; `createdBy`
         // is protected by the platform and cannot be overwritten via the public API.
-        $createdBy = $object->getCreatedBy() ?? '';
+        if (is_array($object) === true) {
+            $createdBy = ($object['createdBy'] ?? '');
+        } else {
+            $createdBy = ($object->getCreatedBy() ?? '');
+        }//end if
+
         $isCreator = ($createdBy !== '' && $createdBy === $currentUserId);
         $isAdmin   = $this->groupManager->isAdmin($currentUserId);
 

--- a/lib/Service/ScheduledTaskService.php
+++ b/lib/Service/ScheduledTaskService.php
@@ -343,8 +343,8 @@ class ScheduledTaskService
         // Strip any fields not explicitly on the allowlist (MUTABLE_FIELDS +
         // admin-only fields already filtered by the controller).  This prevents
         // mass-assignment of system/immutable fields like createdBy, uuid, etc.
-        $allowedKeys  = array_merge(self::MUTABLE_FIELDS, ['status', 'assigneeUserId', 'assigneeGroupId', 'createdAt', 'completedAt', 'attempts']);
-        $data         = array_intersect_key($data, array_flip($allowedKeys));
+        $allowedKeys = array_merge(self::MUTABLE_FIELDS, ['status', 'assigneeUserId', 'assigneeGroupId', 'createdAt', 'completedAt', 'attempts']);
+        $data        = array_intersect_key($data, array_flip($allowedKeys));
 
         $merged       = array_merge($existing, $data);
         $merged['id'] = $id;

--- a/tests/Stubs/Service/ObjectService.php
+++ b/tests/Stubs/Service/ObjectService.php
@@ -83,5 +83,43 @@ if (class_exists(ObjectService::class) === false) {
             return [];
         }//end saveObject()
 
+        /**
+         * Set the active register for subsequent calls (fluent API).
+         *
+         * @param string|int $register Register slug or ID.
+         *
+         * @return static
+         */
+        public function setRegister(string|int $register): static
+        {
+            return $this;
+        }//end setRegister()
+
+        /**
+         * Set the active schema for subsequent calls (fluent API).
+         *
+         * @param string|int $schema Schema slug or ID.
+         *
+         * @return static
+         */
+        public function setSchema(string|int $schema): static
+        {
+            return $this;
+        }//end setSchema()
+
+        /**
+         * Delete an object by UUID.
+         *
+         * @param string      $uuid     The object UUID.
+         * @param string|null $register Register slug or ID (optional, overrides setRegister).
+         * @param string|null $schema   Schema slug or ID (optional, overrides setSchema).
+         *
+         * @return bool
+         */
+        public function deleteObject(string $uuid, string|int|null $register=null, string|int|null $schema=null): bool
+        {
+            return true;
+        }//end deleteObject()
+
     }//end class
 }//end if


### PR DESCRIPTION
## Root cause

Four API routes were registered under paths that did not match what Newman tests and the frontend expected. The SPA catch-all absorbed every request that missed a registered route, returning the full ~17 KB HTML dashboard page with HTTP 200 instead of JSON.

| Endpoint tested by Newman | Route in routes.php (before) | Fix |
|---|---|---|
| GET /api/lead-sources | /api/settings/lead-sources | Moved to /api/lead-sources |
| GET /api/request-channels | /api/settings/request-channels | Moved to /api/request-channels |
| GET /api/prospect-settings | /api/prospects/settings | Moved to /api/prospect-settings |
| GET /api/settings/user | /api/user/settings | Moved to /api/settings/user |

All four controllers and their methods existed and returned JSONResponse correctly -- the problem was purely the registered URL path.

## Additional fixes

- SettingsController: replaced legacy @NoAdminRequired docblock with PHP 8 attribute on index(), getUserSettings(), updateUserSettings()
- Pre-existing quality fixes: NotesController missing end-try comment, PublicSurveyController alignment + PHPStan redundant null-coalesce, ScheduledTaskService alignment, ContactmomentService PHPStan array|object duality on getCreatedBy(), ObjectService stub extended with setRegister/setSchema/deleteObject

## Test plan

- [ ] composer check:strict exits 0
- [ ] Newman GET /api/lead-sources returns JSON
- [ ] Newman GET /api/request-channels returns JSON
- [ ] Newman GET /api/prospect-settings returns JSON (admin auth)
- [ ] Newman GET /api/settings/user returns JSON user settings