### PR TITLE
fix: move cross-app stub namespaces out of autoload-dev (openregister#2036)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,13 +14,6 @@
 			"OCA\\Pipelinq\\": "lib/"
 		}
 	},
-	"autoload-dev": {
-		"psr-4": {
-			"OCA\\OpenRegister\\": "tests/Stubs/",
-			"Doctrine\\DBAL\\": "tests/Stubs/DBAL/",
-			"OC\\": "tests/Stubs/OC/"
-		}
-	},
 	"require": {
 		"php": "^8.3",
 		"nextcloud/ocp": "^31.0"

--- a/tests/bootstrap-bare.php
+++ b/tests/bootstrap-bare.php
@@ -27,6 +27,22 @@ define('OC_CONSOLE', true);
 
 $autoloader = require __DIR__ . '/../vendor/autoload.php';
 
+// Register the test-only stub namespaces on the composer loader at test time.
+// These previously lived in composer.json "autoload-dev" (mapping the real
+// cross-app / framework namespaces OCA\OpenRegister\, Doctrine\DBAL\ and OC\ to
+// tests/Stubs/). When vendor/ is built WITH dev dependencies — as the shared dev
+// instance does — that mapping enters the RUNTIME classmap and the stubs SHADOW the
+// real classes instance-wide, producing 500s everywhere (openregister#2036). The
+// mapping is therefore removed from composer.json and re-registered here, at
+// test-time only, so the unit suite still resolves the stubs while no runtime
+// autoloader is ever polluted. Loading is lazy, so ordering relative to the
+// OCP/NC registration below is irrelevant.
+if ($autoloader instanceof \Composer\Autoload\ClassLoader) {
+    $autoloader->addPsr4('OCA\\OpenRegister\\', __DIR__ . '/Stubs/');
+    $autoloader->addPsr4('Doctrine\\DBAL\\', __DIR__ . '/Stubs/DBAL/');
+    $autoloader->addPsr4('OC\\', __DIR__ . '/Stubs/OC/');
+}
+
 if ($autoloader instanceof \Composer\Autoload\ClassLoader) {
     if (is_dir(__DIR__ . '/../vendor/nextcloud/ocp/OCP') === true) {
         $autoloader->addPsr4('OCP\\', __DIR__ . '/../vendor/nextcloud/ocp/OCP/');

--- a/tests/bootstrap-unit.php
+++ b/tests/bootstrap-unit.php
@@ -27,6 +27,22 @@ define('PHPUNIT_RUN', 1);
 // Include Composer's autoloader.
 $autoloader = require __DIR__ . '/../vendor/autoload.php';
 
+// Register the test-only stub namespaces on the composer loader at test time.
+// These previously lived in composer.json "autoload-dev" (mapping the real
+// cross-app / framework namespaces OCA\OpenRegister\, Doctrine\DBAL\ and OC\ to
+// tests/Stubs/). When vendor/ is built WITH dev dependencies — as the shared dev
+// instance does — that mapping enters the RUNTIME classmap and the stubs SHADOW the
+// real classes instance-wide, producing 500s everywhere (openregister#2036). The
+// mapping is therefore removed from composer.json and re-registered here, at
+// test-time only, so the unit suite still resolves the stubs while no runtime
+// autoloader is ever polluted. Loading is lazy, so ordering relative to the
+// OCP/NC registration below is irrelevant.
+if ($autoloader instanceof \Composer\Autoload\ClassLoader) {
+    $autoloader->addPsr4('OCA\\OpenRegister\\', __DIR__ . '/Stubs/');
+    $autoloader->addPsr4('Doctrine\\DBAL\\', __DIR__ . '/Stubs/DBAL/');
+    $autoloader->addPsr4('OC\\', __DIR__ . '/Stubs/OC/');
+}
+
 // Register OCP\ and NCU\ namespaces.
 // vendor/nextcloud/ocp/OCP is a symlink to the live NC server (/var/www/html/lib/public)
 // that resolves on a deployed instance but is broken in the bare php:8.3-cli CI container.

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -24,6 +24,22 @@ define('PHPUNIT_RUN', 1);
 // ClassLoader instance is returned even when PHPUnit has already pulled it in.
 $autoloader = require __DIR__ . '/../vendor/autoload.php';
 
+// Register the test-only stub namespaces on the composer loader at test time.
+// These previously lived in composer.json "autoload-dev" (mapping the real
+// cross-app / framework namespaces OCA\OpenRegister\, Doctrine\DBAL\ and OC\ to
+// tests/Stubs/). When vendor/ is built WITH dev dependencies — as the shared dev
+// instance does — that mapping enters the RUNTIME classmap and the stubs SHADOW the
+// real classes instance-wide, producing 500s everywhere (openregister#2036). The
+// mapping is therefore removed from composer.json and re-registered here, at
+// test-time only, so the unit suite still resolves the stubs while no runtime
+// autoloader is ever polluted. Loading is lazy, so ordering relative to the
+// OCP/NC registration below is irrelevant.
+if ($autoloader instanceof \Composer\Autoload\ClassLoader) {
+    $autoloader->addPsr4('OCA\\OpenRegister\\', __DIR__ . '/Stubs/');
+    $autoloader->addPsr4('Doctrine\\DBAL\\', __DIR__ . '/Stubs/DBAL/');
+    $autoloader->addPsr4('OC\\', __DIR__ . '/Stubs/OC/');
+}
+
 // Register the OCP/NCU namespaces from the nextcloud/ocp dev dependency so that
 // unit tests can run in a bare environment (no installed Nextcloud server). When
 // NC is present its own autoloader provides these and these mappings are inert.


### PR DESCRIPTION
## The bug

`composer.json` `autoload-dev` mapped three **real** cross-app / framework namespaces to `tests/Stubs/`:

| namespace | mapped to |
|---|---|
| `OCA\OpenRegister\` | `tests/Stubs/` |
| `Doctrine\DBAL\` | `tests/Stubs/DBAL/` |
| `OC\` | `tests/Stubs/OC/` |

When `vendor/` is built **with** dev dependencies — as the shared dev instance does — those PSR-4 entries enter the **runtime** autoloader and the stubs **shadow the real classes instance-wide**, producing 500s across the whole Nextcloud (openregister#2036 / hermiq#21). Releases built `--no-dev` are unaffected.

## The fix

- Removed the entire `autoload-dev` block from `composer.json` (it held only these three shadowing entries).
- Re-registered the same three namespaces on the composer `ClassLoader` **at test time**, in every phpunit bootstrap that is actually used — `tests/bootstrap.php` (phpunit.xml), `tests/bootstrap-unit.php` (phpunit-unit.xml), `tests/bootstrap-bare.php` (phpunit-bare.xml) — right after the `vendor/autoload.php` require. Loading is lazy so ordering vs the OCP/NC registration is irrelevant. Existing guarded `require_once` stub preloads left intact.

Same shape as the proven decidesk fix (#349).

## Verification (nextcloud container, PHP 8.4)

**PROOF 1 — shadow gone.** A dev `composer dump-autoload` (5767 classes) now emits **0** stub-namespace entries:
- `autoload_psr4.php`: 0 refs to `OCA\OpenRegister\` / `Doctrine\DBAL\` / stub-`OC\` (only `OCA\Pipelinq\ => lib/` remains)
- `autoload_classmap.php`: 0 entries resolving into `tests/Stubs`, 0 `OCA\OpenRegister` classes

**PROOF 2 — tests still load stubs.** Unit suite green against the modified app:
`Tests: 1586, Assertions: 4933, Warnings: 3, Skipped: 11` — **0 failures, 0 errors**. (The 3 warnings + 11 skips are pre-existing benign harness conditions, unrelated to this change.)