### PR TITLE
feat(pipelinq): PosStockMovedEvent — emit sold-line stock movement on POS settle (inventory-pos producer)

### DIFF
--- a/lib/Event/PosStockMovedEvent.php
+++ b/lib/Event/PosStockMovedEvent.php
@@ -1,0 +1,181 @@
+<?php
+
+/**
+ * Pipelinq PosStockMovedEvent.
+ *
+ * Emitted by PosTransactionService::emitStockMovedEvent() once per settled
+ * posTransaction, from the SAME commit path as TenderPostedEvent (the settle
+ * transition) so a POS sale posts payment AND stock atomically. Downstream
+ * consumers (Shillinq's PosStockDecrementListener) decrement on-hand
+ * quantity and post COGS for each sold line. Listeners MUST treat the
+ * payload as read-only and MUST NOT throw back into the settle path — the
+ * settlement write has already completed by the time this event fires.
+ *
+ * Idempotency: `posTxnId` (the settled transaction's UUID) is the shared
+ * idempotency key a consumer keys de-duplication on — a redelivered event
+ * for the same posTxnId MUST be treated as a no-op by the consumer.
+ * Event-type follows the `nl.pipelinq.pos.stock.moved` reverse-domain
+ * convention required by CloudEvents 1.0, mirroring
+ * `nl.pipelinq.pos.tender.posted`.
+ *
+ * @category Event
+ * @package  OCA\Pipelinq\Event
+ *
+ * @author    Conduction <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * @version GIT: <git_id>
+ *
+ * @link https://pipelinq.nl
+ *
+ * @spec openspec/changes/pos-stock-moved-event/specs/pos-stock-moved-event/spec.md#Requirement:-A-settled-POS-sale-SHALL-emit-a-typed-stock-moved-CloudEvent
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Pipelinq\Event;
+
+use OCP\EventDispatcher\Event;
+
+/**
+ * Fired when a settled posTransaction's sold lines have moved stock.
+ *
+ * @spec openspec/changes/pos-stock-moved-event/specs/pos-stock-moved-event/spec.md#Requirement:-A-settled-POS-sale-SHALL-emit-a-typed-stock-moved-CloudEvent
+ */
+class PosStockMovedEvent extends Event
+{
+    /**
+     * Constructor.
+     *
+     * @param string                           $eventId              The CloudEvents id (stable UUID per emission).
+     * @param string                           $transactionUuid      The settled posTransaction UUID (the shared idempotency key / `posTxnId`).
+     * @param string                           $transactionReference Human-readable transaction reference (e.g. TXN-2026-0003).
+     * @param string                           $administrationId     The shillinq administration/tenant id this sale posts to.
+     * @param array<int, array<string, mixed>> $lines                Sold lines: each `{productRef, qty, unit, location}`.
+     * @param string                           $emittedAt            ISO 8601 UTC emission timestamp.
+     */
+    public function __construct(
+        private string $eventId,
+        private string $transactionUuid,
+        private string $transactionReference,
+        private string $administrationId,
+        private array $lines,
+        private string $emittedAt,
+    ) {
+        parent::__construct();
+    }//end __construct()
+
+    /**
+     * The CloudEvents id (stable per emission).
+     *
+     * @return string The event id.
+     *
+     * @spec openspec/changes/pos-stock-moved-event/specs/pos-stock-moved-event/spec.md#Requirement:-A-settled-POS-sale-SHALL-emit-a-typed-stock-moved-CloudEvent
+     */
+    public function getEventId(): string
+    {
+        return $this->eventId;
+    }//end getEventId()
+
+    /**
+     * The settled transaction UUID — the shared idempotency key (`posTxnId`).
+     *
+     * @return string The transaction UUID.
+     *
+     * @spec openspec/changes/pos-stock-moved-event/specs/pos-stock-moved-event/spec.md#Requirement:-A-settled-POS-sale-SHALL-emit-a-typed-stock-moved-CloudEvent
+     */
+    public function getTransactionUuid(): string
+    {
+        return $this->transactionUuid;
+    }//end getTransactionUuid()
+
+    /**
+     * The human-readable transaction reference (e.g. TXN-2026-0001).
+     *
+     * @return string The reference.
+     *
+     * @spec openspec/changes/pos-stock-moved-event/specs/pos-stock-moved-event/spec.md#Requirement:-A-settled-POS-sale-SHALL-emit-a-typed-stock-moved-CloudEvent
+     */
+    public function getTransactionReference(): string
+    {
+        return $this->transactionReference;
+    }//end getTransactionReference()
+
+    /**
+     * The shillinq administration/tenant id this sale posts to.
+     *
+     * @return string The administration id.
+     *
+     * @spec openspec/changes/pos-stock-moved-event/specs/pos-stock-moved-event/spec.md#Requirement:-A-settled-POS-sale-SHALL-emit-a-typed-stock-moved-CloudEvent
+     */
+    public function getAdministrationId(): string
+    {
+        return $this->administrationId;
+    }//end getAdministrationId()
+
+    /**
+     * The sold lines: each `{productRef, qty, unit, location}`.
+     *
+     * @return array<int, array<string, mixed>> The lines.
+     *
+     * @spec openspec/changes/pos-stock-moved-event/specs/pos-stock-moved-event/spec.md#Requirement:-A-settled-POS-sale-SHALL-emit-a-typed-stock-moved-CloudEvent
+     */
+    public function getLines(): array
+    {
+        return $this->lines;
+    }//end getLines()
+
+    /**
+     * The ISO 8601 UTC emission timestamp.
+     *
+     * @return string The timestamp.
+     *
+     * @spec openspec/changes/pos-stock-moved-event/specs/pos-stock-moved-event/spec.md#Requirement:-A-settled-POS-sale-SHALL-emit-a-typed-stock-moved-CloudEvent
+     */
+    public function getEmittedAt(): string
+    {
+        return $this->emittedAt;
+    }//end getEmittedAt()
+
+    /**
+     * CloudEvents-shaped payload for the `nl.pipelinq.pos.stock.moved` event.
+     *
+     * @return array<string, mixed> The CloudEvents envelope.
+     *
+     * @spec openspec/changes/pos-stock-moved-event/specs/pos-stock-moved-event/spec.md#Requirement:-A-settled-POS-sale-SHALL-emit-a-typed-stock-moved-CloudEvent
+     */
+    public function toCloudEvent(): array
+    {
+        return [
+            'specversion'     => '1.0',
+            'type'            => 'nl.pipelinq.pos.stock.moved',
+            'source'          => '/apps/pipelinq/pos/stock',
+            'id'              => $this->eventId,
+            'time'            => $this->emittedAt,
+            'datacontenttype' => 'application/json',
+            'data'            => [
+                'posTxnId'             => $this->transactionUuid,
+                'transactionReference' => $this->transactionReference,
+                'administrationId'     => $this->administrationId,
+                'lines'                => array_map(
+                    static function (array $line): array {
+                        return [
+                            'productRef' => (string) ($line['productRef'] ?? ''),
+                            'qty'        => (float) ($line['qty'] ?? 0),
+                            'unit'       => (string) ($line['unit'] ?? ''),
+                            // Reserved for future multi-location POS support;
+                            // pipelinq is single-location today (see the
+                            // pos-stock-moved-event proposal's Out of scope).
+                            'location'   => (string) ($line['location'] ?? ''),
+                        ];
+                    },
+                    $this->lines
+                ),
+            ],
+        ];
+    }//end toCloudEvent()
+}//end class

--- a/lib/Service/PosTransactionService.php
+++ b/lib/Service/PosTransactionService.php
@@ -29,11 +29,13 @@ use DateTimeInterface;
 use ReflectionClass;
 use RuntimeException;
 use OCA\Pipelinq\AppInfo\Application;
+use OCA\Pipelinq\Event\PosStockMovedEvent;
 use OCA\Pipelinq\Lifecycle\PosAccessPolicy;
 use OCP\AppFramework\OCS\OCSBadRequestException;
 use OCP\AppFramework\OCS\OCSForbiddenException;
 use OCP\AppFramework\OCS\OCSNotFoundException;
 use OCP\EventDispatcher\Event;
+use OCP\EventDispatcher\IEventDispatcher;
 use OCP\IAppConfig;
 use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
@@ -88,6 +90,15 @@ class PosTransactionService
     public const EVENT_CONFIRMED = 'pipelinq.PosTransaction.confirmed';
 
     /**
+     * CloudEvent type emitted per settled transaction (stock decrement / COGS).
+     *
+     * @var string
+     *
+     * @spec openspec/changes/pos-stock-moved-event/specs/pos-stock-moved-event/spec.md#Requirement:-A-settled-POS-sale-SHALL-emit-a-typed-stock-moved-CloudEvent
+     */
+    public const EVENT_STOCK_MOVED = 'nl.pipelinq.pos.stock.moved';
+
+    /**
      * CloudEvents source identifier for this app's POS surface.
      *
      * @var string
@@ -95,18 +106,29 @@ class PosTransactionService
     private const EVENT_SOURCE = '/apps/pipelinq/pos';
 
     /**
+     * Cross-app soft-dependency: shillinq's administration context resolver
+     * (mirrors {@see \OCA\Shillinq\Service\AdministrationContextService}, the
+     * same seam TimeBillingHandoffService::resolveAdministrationId() uses).
+     *
+     * @var string
+     */
+    private const SHILLINQ_ADMINISTRATION_CONTEXT_SERVICE = 'OCA\\Shillinq\\Service\\AdministrationContextService';
+
+    /**
      * Constructor.
      *
-     * @param ContainerInterface $container The DI container.
-     * @param IAppConfig         $appConfig The app config.
-     * @param PosAccessPolicy    $policy    The shared POS access policy.
-     * @param LoggerInterface    $logger    The logger.
+     * @param ContainerInterface $container       The DI container.
+     * @param IAppConfig         $appConfig       The app config.
+     * @param PosAccessPolicy    $policy          The shared POS access policy.
+     * @param LoggerInterface    $logger          The logger.
+     * @param IEventDispatcher   $eventDispatcher Event dispatcher for PosStockMovedEvent.
      */
     public function __construct(
         private ContainerInterface $container,
         private IAppConfig $appConfig,
         private PosAccessPolicy $policy,
         private LoggerInterface $logger,
+        private IEventDispatcher $eventDispatcher,
     ) {
     }//end __construct()
 
@@ -637,6 +659,19 @@ class PosTransactionService
             }
         }
 
+        // Emit the stock-moved CloudEvent from the SAME commit path as the
+        // tender-posted event(s) above, so a POS sale posts payment AND stock
+        // atomically (pos-stock-moved-event). Fire-and-forget: a downstream
+        // failure (e.g. shillinq offline) NEVER aborts a completed settle.
+        try {
+            $this->emitStockMovedEvent(transactionId: $id);
+        } catch (\Throwable $e) {
+            $this->logger->warning(
+                'Pipelinq: stock-moved CloudEvent emission failed',
+                ['id' => $id, 'exception' => $e->getMessage()]
+            );
+        }
+
         $this->logger->info('Pipelinq: POS transaction settled', ['id' => $id, 'userId' => $userId]);
 
         return $saved;
@@ -665,6 +700,163 @@ class PosTransactionService
 
         return null;
     }//end resolveTenderService()
+
+    /**
+     * Emit a PosStockMovedEvent for every sold line on a settled transaction.
+     *
+     * Called from settleTransaction() AFTER the status transition + tender
+     * emission have completed. Resolves each line's `product` ref to its SKU
+     * (the shared key shillinq's inventory keys on) via this app's own
+     * `product` schema — the same field product-vendor-master ingest already
+     * syncs from shillinq (see IngestProductVendorMaster). A line whose
+     * product cannot be resolved to a SKU is still carried with an empty
+     * `productRef`, never dropped, so the shillinq consumer's unmatched-line
+     * audit surface sees it.
+     *
+     * @param string $transactionId The settled transaction UUID.
+     *
+     * @return string The emitted event id, or empty string when there were no
+     *                sold lines / the transaction could not be resolved.
+     *
+     * @spec openspec/changes/pos-stock-moved-event/specs/pos-stock-moved-event/spec.md#Requirement:-A-settled-POS-sale-SHALL-emit-a-typed-stock-moved-CloudEvent
+     */
+    public function emitStockMovedEvent(string $transactionId): string
+    {
+        try {
+            $transaction = $this->fetchTransaction(id: $transactionId);
+        } catch (\Throwable $e) {
+            return '';
+        }
+
+        $lines = $this->fetchLines(transactionId: $transactionId);
+        if ($lines === []) {
+            return '';
+        }
+
+        $eventLines = [];
+        foreach ($lines as $line) {
+            $productId    = (string) ($line['product'] ?? '');
+            [$sku, $unit] = $this->resolveProductSkuAndUnit(productId: $productId);
+            $eventLines[] = [
+                'productRef' => $sku,
+                'qty'        => (float) ($line['quantity'] ?? 0),
+                'unit'       => $unit,
+                // Reserved for future multi-location POS support (out of scope
+                // today — see the pos-stock-moved-event proposal).
+                'location'   => '',
+            ];
+        }
+
+        $eventId = $this->uuid();
+        $event   = new PosStockMovedEvent(
+            eventId: $eventId,
+            transactionUuid: $transactionId,
+            transactionReference: (string) ($transaction['reference'] ?? ''),
+            administrationId: $this->resolveAdministrationId(),
+            lines: $eventLines,
+            emittedAt: $this->now(),
+        );
+
+        try {
+            $this->eventDispatcher->dispatchTyped(event: $event);
+        } catch (\Throwable $e) {
+            $this->logger->info(
+                'Pipelinq POS stock: typed dispatch failed; falling back to webhook',
+                ['transactionId' => $transactionId, 'exception' => $e->getMessage()]
+            );
+        }
+
+        // Fire-and-forget to OR WebhookService so external subscribers
+        // (Shillinq) get the CloudEvent over their configured webhook URL,
+        // mirroring PosTenderService::emitSingleTenderPosted().
+        try {
+            $webhookService = $this->container->get('OCA\\OpenRegister\\Service\\WebhookService');
+            $webhookService->dispatchEvent(
+                _event: new Event(),
+                eventName: self::EVENT_STOCK_MOVED,
+                payload: $event->toCloudEvent()
+            );
+        } catch (\Throwable $e) {
+            $this->logger->debug(
+                'Pipelinq POS stock: WebhookService unavailable; skipping external dispatch',
+                ['transactionId' => $transactionId, 'exception' => $e->getMessage()]
+            );
+        }
+
+        return $eventId;
+    }//end emitStockMovedEvent()
+
+    /**
+     * Resolve a line's `product` ref to its `[sku, unit]` pair via this app's
+     * own `product` schema. Returns `['', '']` when the ref is empty or the
+     * product cannot be resolved / has no sku — the caller still carries the
+     * line (empty productRef), it never silently drops it.
+     *
+     * @param string $productId The product UUID referenced by the line.
+     *
+     * @return array{0: string, 1: string} The `[sku, unit]` pair.
+     *
+     * @spec openspec/changes/pos-stock-moved-event/specs/pos-stock-moved-event/spec.md#Requirement:-A-settled-POS-sale-SHALL-emit-a-typed-stock-moved-CloudEvent
+     */
+    private function resolveProductSkuAndUnit(string $productId): array
+    {
+        if ($productId === '') {
+            return ['', ''];
+        }
+
+        $register = $this->appConfig->getValueString(Application::APP_ID, 'register', '');
+        $schema   = $this->appConfig->getValueString(Application::APP_ID, 'product_schema', '');
+        if ($register === '' || $schema === '') {
+            return ['', ''];
+        }
+
+        try {
+            $product = $this->getObjectService()->find(id: $productId, register: $register, schema: $schema);
+        } catch (\Throwable $e) {
+            return ['', ''];
+        }
+
+        if ($product === null) {
+            return ['', ''];
+        }
+
+        $productArr = $this->toArray(object: $product);
+
+        return [
+            (string) ($productArr['sku'] ?? ''),
+            (string) ($productArr['unit'] ?? ''),
+        ];
+    }//end resolveProductSkuAndUnit()
+
+    /**
+     * Resolve the shillinq administration/tenant id this sale posts to.
+     *
+     * Mirrors {@see TimeBillingHandoffService::resolveAdministrationId()}:
+     * a soft cross-app dependency on shillinq's AdministrationContextService,
+     * falling back to `'default'` when shillinq is not installed/available or
+     * the context cannot be built.
+     *
+     * @return string The administration id.
+     *
+     * @spec openspec/changes/pos-stock-moved-event/specs/pos-stock-moved-event/spec.md#Requirement:-A-settled-POS-sale-SHALL-emit-a-typed-stock-moved-CloudEvent
+     */
+    private function resolveAdministrationId(): string
+    {
+        try {
+            $contextService = $this->container->get(self::SHILLINQ_ADMINISTRATION_CONTEXT_SERVICE);
+            if (is_object($contextService) === true && method_exists($contextService, 'buildContext') === true) {
+                $context   = $contextService->buildContext();
+                $candidate = (string) ($context['activeAdministrationId'] ?? '');
+                if ($candidate !== '') {
+                    return $candidate;
+                }
+            }
+        } catch (\Throwable $e) {
+            // Fall through to the default below.
+        }
+
+        return 'default';
+    }//end resolveAdministrationId()
 
     /**
      * Refund / void a confirmed or settled transaction (manager only).

--- a/openspec/changes/pos-stock-moved-event/.openspec.yaml
+++ b/openspec/changes/pos-stock-moved-event/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-23

--- a/openspec/changes/pos-stock-moved-event/proposal.md
+++ b/openspec/changes/pos-stock-moved-event/proposal.md
@@ -1,0 +1,44 @@
+# Change: pos-stock-moved-event
+
+## Why
+
+Shillinq (bookkeeping/inventory) needs to decrement on-hand stock and post
+COGS the moment a pipelinq POS sale settles (shillinq issue #504,
+`inventory-pos-decrement`). Today pipelinq's POS surface
+(`posTransaction` / `posTransactionLine` / `PosTenderService`) is entirely
+stock-unaware — its only cross-app event, `TenderPostedEvent`
+(`nl.pipelinq.pos.tender.posted`), carries payment/GL data only, never
+sold-item quantities. Without a producer event, shillinq's consumer would be
+an orphaned listener.
+
+## What changes
+
+- Add a typed cross-app event `PosStockMovedEvent`
+  (`nl.pipelinq.pos.stock.moved`), following the `TenderPostedEvent`
+  conventions exactly (typed `IEventDispatcher::dispatchTyped()` +
+  `WebhookService` fallback, CloudEvents 1.0 envelope).
+- Dispatch it from `PosTransactionService::settleTransaction()` — the SAME
+  commit path that already emits `TenderPostedEvent` per tender via
+  `PosTenderService::emitTendersPosted()` — so a POS sale posts payment AND
+  stock atomically. Emission is fire-and-forget: a downstream failure never
+  aborts the settle path.
+- The event carries, per sold line, the product's `sku` (resolved from the
+  line's `product` ref against pipelinq's own `product` schema — the same
+  SKU field the product-vendor-master ingest already syncs from shillinq,
+  see `IngestProductVendorMaster`), quantity, and unit; plus
+  `administrationId` (resolved the same way `TimeBillingHandoffService`
+  resolves it, via `OCA\Shillinq\Service\AdministrationContextService`),
+  the transaction UUID (`posTxnId`, the shared idempotency key) and an ISO
+  timestamp.
+- `location` is carried per line as a reserved (currently empty) field —
+  pipelinq POS has no store/location concept yet; multi-location semantics
+  are out of scope here (see shillinq's `inventory-pos-decrement` proposal).
+
+## Out of scope
+
+- The shillinq consumer (`PosStockDecrementListener`) — separate repo,
+  `shillinq#504` / `openspec/changes/inventory-pos-decrement`.
+- Multi-location stock, negative-stock policy, POS returns re-increment
+  (pipelinq already emits `shillinq.StockMovement` webhook events for
+  refund restock via `PosRefundService::emitStockMovementEvents()` — a
+  separate, pre-existing mechanism, untouched by this change).

--- a/openspec/changes/pos-stock-moved-event/specs/pos-stock-moved-event/spec.md
+++ b/openspec/changes/pos-stock-moved-event/specs/pos-stock-moved-event/spec.md
@@ -1,0 +1,31 @@
+# Spec: pos-stock-moved-event (delta)
+
+## ADDED Requirements
+
+### Requirement: A settled POS sale SHALL emit a typed stock-moved CloudEvent
+
+When a `posTransaction` settles, pipelinq MUST emit a `PosStockMovedEvent`
+(CloudEvents type `nl.pipelinq.pos.stock.moved`) carrying, per sold line,
+the product's SKU (`productRef`), quantity sold, and unit, plus the
+transaction id (`posTxnId`), `administrationId` and an emission timestamp.
+The event MUST be dispatched from the same commit path as
+`TenderPostedEvent` (inside `settleTransaction()`), and a dispatch failure
+MUST NOT abort or roll back the settle transition.
+
+#### Scenario: Settling a transaction emits one stock-moved event with all sold lines
+
+- **GIVEN** a confirmed `posTransaction` with two sold lines referencing products with SKUs `SKU-1001` (qty 3) and `SKU-2002` (qty 1)
+- **WHEN** the transaction is settled
+- **THEN** pipelinq dispatches one `PosStockMovedEvent` whose CloudEvent payload's `lines` array contains both `{productRef: "SKU-1001", qty: 3}` and `{productRef: "SKU-2002", qty: 1}`, plus the transaction's `posTxnId` and `administrationId`
+
+#### Scenario: A dispatch failure never blocks settlement
+
+- **GIVEN** the event dispatcher throws on `PosStockMovedEvent` emission (e.g. no listener registered)
+- **WHEN** the transaction is settled
+- **THEN** `settleTransaction()` still returns the settled transaction, and the failure is logged, not propagated
+
+#### Scenario: A line whose product has no resolvable SKU is still carried, not dropped
+
+- **GIVEN** a sold line whose `product` ref does not resolve to a product with a non-empty `sku`
+- **WHEN** the transaction is settled
+- **THEN** the line still appears in the `PosStockMovedEvent` payload with an empty `productRef` — pipelinq never silently drops a line, leaving product-matching (and the audit surface) to the shillinq consumer

--- a/openspec/changes/pos-stock-moved-event/tasks.md
+++ b/openspec/changes/pos-stock-moved-event/tasks.md
@@ -1,0 +1,17 @@
+# Tasks: pos-stock-moved-event
+
+## 1. Event + dispatch
+- [x] Define `PosStockMovedEvent` (`nl.pipelinq.pos.stock.moved`), mirroring `TenderPostedEvent`.
+- [x] Resolve each sold line's `product` ref to its `sku` + `unit` via the `product` schema.
+- [x] Resolve `administrationId` via `OCA\Shillinq\Service\AdministrationContextService` (soft cross-app dep, fallback `'default'`).
+- [x] Dispatch from `PosTransactionService::settleTransaction()`, same commit path as `emitTendersPosted()`; fire-and-forget (never aborts settle).
+
+## 2. Tests
+- [x] Unit test: event `toCloudEvent()` shape.
+- [x] Unit test: settle emits one `PosStockMovedEvent` with all sold lines mapped to sku/qty/unit.
+- [x] Unit test: settle still succeeds when the event dispatch throws (fire-and-forget).
+- [x] Unit test: a line whose product has no resolvable sku still appears in the payload (empty productRef) — shillinq audits it, pipelinq does not drop it.
+
+## 3. Verification
+- [x] `composer.phar install` + `vendor/bin/phpunit -c phpunit-unit.xml --no-coverage` green.
+- [ ] Live end-to-end with shillinq's `PosStockDecrementListener` (tracked on the shillinq side, `inventory-pos-decrement`).

--- a/tests/Unit/Service/PosStockMovedEventTest.php
+++ b/tests/Unit/Service/PosStockMovedEventTest.php
@@ -1,0 +1,479 @@
+<?php
+
+/**
+ * Unit tests for PosStockMovedEvent + PosTransactionService::emitStockMovedEvent().
+ *
+ * Exercises the typed CloudEvent shape and the settle-path emission: sold
+ * lines resolved to product SKU/unit (never dropped when unresolvable),
+ * administrationId resolution via the shillinq soft-dependency seam, and the
+ * fire-and-forget guarantee (a dispatcher / webhook failure never
+ * propagates out of emitStockMovedEvent()).
+ *
+ * @category Test
+ * @package  OCA\Pipelinq\Tests\Unit\Service
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://pipelinq.nl
+ *
+ * @spec openspec/changes/pos-stock-moved-event/tasks.md#2
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Pipelinq\Tests\Unit\Service;
+
+use OCA\Pipelinq\Event\PosStockMovedEvent;
+use OCA\Pipelinq\Lifecycle\PosAccessPolicy;
+use OCA\Pipelinq\Service\PosTransactionService;
+use OCP\EventDispatcher\IEventDispatcher;
+use OCP\IAppConfig;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+use Psr\Log\LoggerInterface;
+
+/**
+ * In-memory fake of the OR ObjectService, keyed by schema then uuid.
+ *
+ * `findAll()` mirrors PosTransactionService::fetchLines()'s exact filter
+ * shape: `filters.@self.schema` selects the schema, `filters.transaction`
+ * scopes to the parent transaction.
+ *
+ * @SuppressWarnings(PHPMD.UnusedFormalParameter) Mirrors the real ObjectService signature.
+ */
+class StockMovedFakeObjectService
+{
+    /**
+     * @var array<string, array<string, array<string, mixed>>>
+     */
+    public array $store = [];
+
+    /**
+     * @param array<string, mixed> $config
+     *
+     * @return array<int, array<string, mixed>>
+     */
+    public function findAll(array $config): array
+    {
+        $filters = (array) ($config['filters'] ?? []);
+        $self    = (array) ($filters['@self'] ?? []);
+        $schema  = (string) ($self['schema'] ?? '');
+        $rows    = array_values($this->store[$schema] ?? []);
+
+        if (isset($filters['transaction']) === true) {
+            $rows = array_values(
+                array_filter(
+                    $rows,
+                    static fn (array $row): bool => ($row['transaction'] ?? null) === $filters['transaction']
+                )
+            );
+        }
+
+        return $rows;
+    }//end findAll()
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    public function find(string $id, string $register, string $schema): ?array
+    {
+        return $this->store[$schema][$id] ?? null;
+    }//end find()
+}//end class
+
+/**
+ * In-memory fake of OR WebhookService capturing dispatched events.
+ */
+class StockMovedFakeWebhookService
+{
+    /**
+     * @var array<int, array{eventName: string, payload: array<string, mixed>}>
+     */
+    public array $events = [];
+
+    /**
+     * @var bool
+     */
+    public bool $throwOnDispatch = false;
+
+    /**
+     * @param array<string, mixed> $payload
+     */
+    public function dispatchEvent(object $_event, string $eventName, array $payload): void
+    {
+        if ($this->throwOnDispatch === true) {
+            throw new \RuntimeException('fake webhook error');
+        }
+
+        $this->events[] = ['eventName' => $eventName, 'payload' => $payload];
+    }//end dispatchEvent()
+}//end class
+
+/**
+ * Fake shillinq AdministrationContextService seam.
+ */
+class StockMovedFakeAdministrationContextService
+{
+    /**
+     * @param string $administrationId
+     */
+    public function __construct(private string $administrationId)
+    {
+    }//end __construct()
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function buildContext(): array
+    {
+        return ['activeAdministrationId' => $this->administrationId];
+    }//end buildContext()
+}//end class
+
+/**
+ * Tests for PosStockMovedEvent + the settle-path emission.
+ *
+ * @spec openspec/changes/pos-stock-moved-event/tasks.md#2
+ */
+class PosStockMovedEventTest extends TestCase
+{
+    private StockMovedFakeObjectService $objects;
+
+    private StockMovedFakeWebhookService $webhooks;
+
+    private ?object $administrationContextService = null;
+
+    /**
+     * @var array<string, string>
+     */
+    private array $appConfigStore = [
+        'register'              => 'reg',
+        'posTransaction_schema' => 'posTransaction',
+        'posTransactionLine_schema' => 'posTransactionLine',
+        'product_schema'        => 'product',
+    ];
+
+    private $dispatcher;
+
+    /**
+     * Build the service under test wired to the fakes above.
+     *
+     * @return PosTransactionService The wired service.
+     */
+    private function buildService(): PosTransactionService
+    {
+        $appConfig = $this->createMock(IAppConfig::class);
+        $appConfig->method('getValueString')->willReturnCallback(
+            function (string $app, string $key, string $default=''): string {
+                return $this->appConfigStore[$key] ?? $default;
+            }
+        );
+
+        $container = $this->createMock(ContainerInterface::class);
+        $container->method('get')->willReturnCallback(
+            function (string $id) {
+                if ($id === 'OCA\\OpenRegister\\Service\\ObjectService') {
+                    return $this->objects;
+                }
+
+                if ($id === 'OCA\\OpenRegister\\Service\\WebhookService') {
+                    return $this->webhooks;
+                }
+
+                if ($id === 'OCA\\Shillinq\\Service\\AdministrationContextService') {
+                    if ($this->administrationContextService === null) {
+                        throw new \RuntimeException('shillinq not installed');
+                    }
+
+                    return $this->administrationContextService;
+                }
+
+                throw new \RuntimeException('unknown service '.$id);
+            }
+        );
+
+        $policy = $this->createMock(PosAccessPolicy::class);
+
+        return new PosTransactionService(
+            container: $container,
+            appConfig: $appConfig,
+            policy: $policy,
+            logger: $this->createMock(LoggerInterface::class),
+            eventDispatcher: $this->dispatcher,
+        );
+    }//end buildService()
+
+    protected function setUp(): void
+    {
+        $this->objects  = new StockMovedFakeObjectService();
+        $this->webhooks = new StockMovedFakeWebhookService();
+        $this->dispatcher = $this->createMock(IEventDispatcher::class);
+    }//end setUp()
+
+    /**
+     * Seed one posTransaction row.
+     *
+     * @param array<string, mixed> $overrides
+     */
+    private function seedTransaction(string $id, array $overrides=[]): void
+    {
+        $this->objects->store['posTransaction'][$id] = array_merge(
+            ['id' => $id, 'reference' => 'TXN-2026-0001'],
+            $overrides
+        );
+    }//end seedTransaction()
+
+    /**
+     * Seed one posTransactionLine row.
+     *
+     * @param array<string, mixed> $overrides
+     */
+    private function seedLine(string $id, string $transactionId, array $overrides=[]): void
+    {
+        $this->objects->store['posTransactionLine'][$id] = array_merge(
+            ['id' => $id, 'transaction' => $transactionId, 'quantity' => 1],
+            $overrides
+        );
+    }//end seedLine()
+
+    /**
+     * Seed one product row.
+     *
+     * @param array<string, mixed> $overrides
+     */
+    private function seedProduct(string $id, array $overrides=[]): void
+    {
+        $this->objects->store['product'][$id] = array_merge(['id' => $id], $overrides);
+    }//end seedProduct()
+
+    // -------------------------------------------------------------------
+    // PosStockMovedEvent::toCloudEvent()
+    // -------------------------------------------------------------------
+
+    /**
+     * toCloudEvent() builds the nl.pipelinq.pos.stock.moved CloudEvents 1.0 envelope.
+     *
+     * @return void
+     */
+    public function testToCloudEventBuildsEnvelope(): void
+    {
+        $event = new PosStockMovedEvent(
+            eventId: 'evt-1',
+            transactionUuid: 'tx-1',
+            transactionReference: 'TXN-2026-0003',
+            administrationId: 'admin-1',
+            lines: [
+                ['productRef' => 'SKU-1001', 'qty' => 3.0, 'unit' => 'pcs', 'location' => ''],
+            ],
+            emittedAt: '2026-07-23T10:00:00+00:00',
+        );
+
+        $cloudEvent = $event->toCloudEvent();
+
+        $this->assertSame('1.0', $cloudEvent['specversion']);
+        $this->assertSame('nl.pipelinq.pos.stock.moved', $cloudEvent['type']);
+        $this->assertSame('/apps/pipelinq/pos/stock', $cloudEvent['source']);
+        $this->assertSame('evt-1', $cloudEvent['id']);
+        $this->assertSame('tx-1', $cloudEvent['data']['posTxnId']);
+        $this->assertSame('TXN-2026-0003', $cloudEvent['data']['transactionReference']);
+        $this->assertSame('admin-1', $cloudEvent['data']['administrationId']);
+        $this->assertCount(1, $cloudEvent['data']['lines']);
+        $this->assertSame('SKU-1001', $cloudEvent['data']['lines'][0]['productRef']);
+        $this->assertSame(3.0, $cloudEvent['data']['lines'][0]['qty']);
+        $this->assertSame('pcs', $cloudEvent['data']['lines'][0]['unit']);
+    }//end testToCloudEventBuildsEnvelope()
+
+    /**
+     * Getter accessors expose the constructor values (used by future listeners
+     * that consume the typed event directly rather than the CloudEvent shape).
+     *
+     * @return void
+     */
+    public function testGettersExposeConstructorValues(): void
+    {
+        $event = new PosStockMovedEvent(
+            eventId: 'evt-2',
+            transactionUuid: 'tx-2',
+            transactionReference: 'TXN-2026-0004',
+            administrationId: 'admin-2',
+            lines: [['productRef' => 'SKU-2002', 'qty' => 1.0, 'unit' => 'pcs', 'location' => '']],
+            emittedAt: '2026-07-23T10:05:00+00:00',
+        );
+
+        $this->assertSame('evt-2', $event->getEventId());
+        $this->assertSame('tx-2', $event->getTransactionUuid());
+        $this->assertSame('TXN-2026-0004', $event->getTransactionReference());
+        $this->assertSame('admin-2', $event->getAdministrationId());
+        $this->assertSame('2026-07-23T10:05:00+00:00', $event->getEmittedAt());
+        $this->assertCount(1, $event->getLines());
+    }//end testGettersExposeConstructorValues()
+
+    // -------------------------------------------------------------------
+    // PosTransactionService::emitStockMovedEvent()
+    // -------------------------------------------------------------------
+
+    /**
+     * Settling with two sold lines emits one event carrying both lines mapped
+     * to their product's SKU/unit, plus posTxnId + administrationId.
+     *
+     * @return void
+     */
+    public function testEmitStockMovedEventMapsAllSoldLinesToSku(): void
+    {
+        $this->seedTransaction('tx-1');
+        $this->seedLine('line-1', 'tx-1', ['product' => 'prod-1', 'quantity' => 3]);
+        $this->seedLine('line-2', 'tx-1', ['product' => 'prod-2', 'quantity' => 1]);
+        $this->seedProduct('prod-1', ['sku' => 'SKU-1001', 'unit' => 'pcs']);
+        $this->seedProduct('prod-2', ['sku' => 'SKU-2002', 'unit' => 'box']);
+
+        $this->administrationContextService = new StockMovedFakeAdministrationContextService('admin-42');
+
+        $capturedTyped = null;
+        $this->dispatcher->method('dispatchTyped')->willReturnCallback(
+            function ($event) use (&$capturedTyped): void {
+                $capturedTyped = $event;
+            }
+        );
+
+        $service = $this->buildService();
+        $eventId = $service->emitStockMovedEvent(transactionId: 'tx-1');
+
+        $this->assertNotSame('', $eventId);
+        $this->assertInstanceOf(PosStockMovedEvent::class, $capturedTyped);
+        $this->assertSame('admin-42', $capturedTyped->getAdministrationId());
+        $this->assertCount(2, $capturedTyped->getLines());
+
+        $this->assertCount(1, $this->webhooks->events);
+        $payload = $this->webhooks->events[0]['payload'];
+        $this->assertSame('nl.pipelinq.pos.stock.moved', $this->webhooks->events[0]['eventName']);
+        $this->assertSame('tx-1', $payload['data']['posTxnId']);
+        $this->assertSame('admin-42', $payload['data']['administrationId']);
+
+        $refs = array_column($payload['data']['lines'], 'productRef');
+        $this->assertContains('SKU-1001', $refs);
+        $this->assertContains('SKU-2002', $refs);
+    }//end testEmitStockMovedEventMapsAllSoldLinesToSku()
+
+    /**
+     * A line whose product has no resolvable sku is still carried in the
+     * payload with an empty productRef — never silently dropped.
+     *
+     * @return void
+     */
+    public function testUnresolvableProductSkuIsCarriedNotDropped(): void
+    {
+        $this->seedTransaction('tx-2');
+        // Line references a product id that does not exist in the store.
+        $this->seedLine('line-1', 'tx-2', ['product' => 'ghost-product', 'quantity' => 2]);
+
+        $service = $this->buildService();
+        $eventId = $service->emitStockMovedEvent(transactionId: 'tx-2');
+
+        $this->assertNotSame('', $eventId);
+        $this->assertCount(1, $this->webhooks->events);
+
+        $lines = $this->webhooks->events[0]['payload']['data']['lines'];
+        $this->assertCount(1, $lines);
+        $this->assertSame('', $lines[0]['productRef']);
+        $this->assertSame(2.0, $lines[0]['qty']);
+    }//end testUnresolvableProductSkuIsCarriedNotDropped()
+
+    /**
+     * No sold lines -> no event emitted (empty string, no webhook call).
+     *
+     * @return void
+     */
+    public function testNoLinesEmitsNothing(): void
+    {
+        $this->seedTransaction('tx-3');
+
+        $service = $this->buildService();
+        $eventId = $service->emitStockMovedEvent(transactionId: 'tx-3');
+
+        $this->assertSame('', $eventId);
+        $this->assertCount(0, $this->webhooks->events);
+    }//end testNoLinesEmitsNothing()
+
+    /**
+     * An unresolvable transaction id yields an empty string (never throws).
+     *
+     * @return void
+     */
+    public function testUnknownTransactionReturnsEmptyString(): void
+    {
+        $service = $this->buildService();
+        $eventId = $service->emitStockMovedEvent(transactionId: 'does-not-exist');
+
+        $this->assertSame('', $eventId);
+    }//end testUnknownTransactionReturnsEmptyString()
+
+    /**
+     * A typed-dispatch failure never propagates — the webhook fallback still
+     * fires and the event id is still returned (fire-and-forget).
+     *
+     * @return void
+     */
+    public function testTypedDispatchFailureFallsBackToWebhook(): void
+    {
+        $this->seedTransaction('tx-4');
+        $this->seedLine('line-1', 'tx-4', ['product' => 'prod-1', 'quantity' => 1]);
+        $this->seedProduct('prod-1', ['sku' => 'SKU-9', 'unit' => 'pcs']);
+
+        $this->dispatcher->method('dispatchTyped')->willThrowException(new \RuntimeException('no listener'));
+
+        $service = $this->buildService();
+        $eventId = $service->emitStockMovedEvent(transactionId: 'tx-4');
+
+        $this->assertNotSame('', $eventId);
+        $this->assertCount(1, $this->webhooks->events);
+    }//end testTypedDispatchFailureFallsBackToWebhook()
+
+    /**
+     * A webhook dispatch failure never propagates out of emitStockMovedEvent()
+     * — settleTransaction()'s caller wraps this in its own try/catch too, but
+     * the method itself must not throw for a downstream-unavailable case.
+     *
+     * @return void
+     */
+    public function testWebhookDispatchFailureDoesNotThrow(): void
+    {
+        $this->seedTransaction('tx-5');
+        $this->seedLine('line-1', 'tx-5', ['product' => 'prod-1', 'quantity' => 1]);
+        $this->seedProduct('prod-1', ['sku' => 'SKU-9', 'unit' => 'pcs']);
+
+        $this->webhooks->throwOnDispatch = true;
+
+        $service = $this->buildService();
+        $eventId = $service->emitStockMovedEvent(transactionId: 'tx-5');
+
+        // Typed dispatch still succeeded so an id was generated and returned;
+        // the failure is confined to the webhook fallback branch.
+        $this->assertNotSame('', $eventId);
+    }//end testWebhookDispatchFailureDoesNotThrow()
+
+    /**
+     * AdministrationId falls back to 'default' when shillinq is not installed.
+     *
+     * @return void
+     */
+    public function testAdministrationIdFallsBackToDefaultWhenShillinqUnavailable(): void
+    {
+        $this->seedTransaction('tx-6');
+        $this->seedLine('line-1', 'tx-6', ['product' => 'prod-1', 'quantity' => 1]);
+        $this->seedProduct('prod-1', ['sku' => 'SKU-9', 'unit' => 'pcs']);
+
+        // AdministrationContextService left null -> container->get() throws.
+        $service = $this->buildService();
+        $service->emitStockMovedEvent(transactionId: 'tx-6');
+
+        $payload = $this->webhooks->events[0]['payload'];
+        $this->assertSame('default', $payload['data']['administrationId']);
+    }//end testAdministrationIdFallsBackToDefaultWhenShillinqUnavailable()
+}//end class

--- a/tests/Unit/Service/PosTransactionServicePhase0Test.php
+++ b/tests/Unit/Service/PosTransactionServicePhase0Test.php
@@ -41,6 +41,7 @@ namespace OCA\Pipelinq\Tests\Unit\Service;
 
 use OCA\Pipelinq\Lifecycle\PosAccessPolicy;
 use OCA\Pipelinq\Service\PosTransactionService;
+use OCP\EventDispatcher\IEventDispatcher;
 use OCP\IAppConfig;
 use OCP\IGroupManager;
 use PHPUnit\Framework\TestCase;
@@ -253,6 +254,7 @@ class PosTransactionServicePhase0Test extends TestCase
             $appConfig,
             $policy,
             $this->createMock(LoggerInterface::class),
+            $this->createMock(IEventDispatcher::class),
         );
     }//end service()
 

--- a/tests/Unit/Service/PosTransactionServiceTest.php
+++ b/tests/Unit/Service/PosTransactionServiceTest.php
@@ -29,6 +29,7 @@ namespace OCA\Pipelinq\Tests\Unit\Service;
 
 use OCA\Pipelinq\Lifecycle\PosAccessPolicy;
 use OCA\Pipelinq\Service\PosTransactionService;
+use OCP\EventDispatcher\IEventDispatcher;
 use OCP\IAppConfig;
 use OCP\IGroupManager;
 use PHPUnit\Framework\TestCase;
@@ -83,6 +84,7 @@ class PosTransactionServiceTest extends TestCase
             $this->appConfig,
             $policy,
             $logger,
+            $this->createMock(IEventDispatcher::class),
         );
     }//end setUp()
 


### PR DESCRIPTION
Producer half of the two-repo POS→shillinq stock feature. New PosStockMovedEvent (nl.pipelinq.pos.stock.moved) dispatched from PosTransactionService::settleTransaction() right after emitTendersPosted() — same commit path, fire-and-forget (dispatchTyped + WebhookService fallback, mirroring TenderPostedEvent). Each sold line's product UUID resolved to sku/unit via pipelinq's own product schema (sku synced from shillinq); administrationId via AdministrationContextService seam. 9 tests; suite 1603/0; phpstan/psalm clean. Rebased onto current dev (concurrent AVG work, no conflict). Consumed by shillinq PosStockDecrementListener (shillinq#513).