### PR TITLE
chore(deps): bump nextcloud-vue to beta.220 (OpenBuild glyph fix)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
 			"version": "0.1.0",
 			"license": "EUPL-1.2",
 			"dependencies": {
-				"@conduction/nextcloud-vue": "^1.0.0-beta.213",
+				"@conduction/nextcloud-vue": "^1.0.0-beta.220",
 				"@nextcloud/axios": "~2.5.2",
 				"@nextcloud/dialogs": "^6.4.2",
 				"@nextcloud/initial-state": "^2.2.0",
@@ -1794,9 +1794,9 @@
 			}
 		},
 		"node_modules/@conduction/nextcloud-vue": {
-			"version": "1.0.0-beta.213",
-			"resolved": "https://registry.npmjs.org/@conduction/nextcloud-vue/-/nextcloud-vue-1.0.0-beta.213.tgz",
-			"integrity": "sha512-L3E7kT3AvVb8HvxRWc2nSA6aYXbuMOj9f7HiGiJQOJ9om6ImCrdreMqACB4pEbHGy49FeRnmX5aHI1qt8o1SaQ==",
+			"version": "1.0.0-beta.220",
+			"resolved": "https://registry.npmjs.org/@conduction/nextcloud-vue/-/nextcloud-vue-1.0.0-beta.220.tgz",
+			"integrity": "sha512-2t+xmunaMu7szYjhERFyDcXMeGcQbwoJEsH+zLihXWBPYg+kgOtekUT3KWvCU9UzSZhmmNApyXbkb76na4nwwA==",
 			"license": "EUPL-1.2",
 			"dependencies": {
 				"@codemirror/autocomplete": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
 		"extends @nextcloud/browserslist-config"
 	],
 	"dependencies": {
-		"@conduction/nextcloud-vue": "^1.0.0-beta.213",
+		"@conduction/nextcloud-vue": "^1.0.0-beta.220",
 		"@nextcloud/axios": "~2.5.2",
 		"@nextcloud/dialogs": "^6.4.2",
 		"@nextcloud/initial-state": "^2.2.0",


### PR DESCRIPTION
Bumps `@conduction/nextcloud-vue` to `^1.0.0-beta.220`, picking up the OpenBuild edit-button glyph fix (package/cube → OpenBuild stacked-layers icon), shipped in beta.218.

This app's currently-shipped bundle binds the **old cube** glyph (confirmed by scanning the built `js/` for the path bound to `cn-openbuild-edit__glyph`), so it needs this bump for its next CI/release build to ship the correct icon.

Dependency-only change — no source edits.