### PR TITLE
chore(deps): bump @conduction/nextcloud-vue to ^1.0.0-beta.221

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -52,7 +52,7 @@ Vrij en open source onder de EUPL-1.2-licentie.
 
 **Ondersteuning:** Voor ondersteuning, neem contact op via support@conduction.nl. Voor een Service Level Agreement (SLA), neem contact op via sales@conduction.nl.
     ]]></description>
-    <version>0.5.62</version>
+    <version>0.5.63</version>
     <licence>EUPL-1.2</licence>
     <author mail="info@conduction.nl" homepage="https://www.conduction.nl/">Conduction</author>
     <namespace>Pipelinq</namespace>

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
 			"version": "0.1.0",
 			"license": "EUPL-1.2",
 			"dependencies": {
-				"@conduction/nextcloud-vue": "^1.0.0-beta.213",
+				"@conduction/nextcloud-vue": "^1.0.0-beta.221",
 				"@nextcloud/axios": "~2.5.2",
 				"@nextcloud/dialogs": "^6.4.2",
 				"@nextcloud/initial-state": "^2.2.0",
@@ -1794,9 +1794,9 @@
 			}
 		},
 		"node_modules/@conduction/nextcloud-vue": {
-			"version": "1.0.0-beta.213",
-			"resolved": "https://registry.npmjs.org/@conduction/nextcloud-vue/-/nextcloud-vue-1.0.0-beta.213.tgz",
-			"integrity": "sha512-L3E7kT3AvVb8HvxRWc2nSA6aYXbuMOj9f7HiGiJQOJ9om6ImCrdreMqACB4pEbHGy49FeRnmX5aHI1qt8o1SaQ==",
+			"version": "1.0.0-beta.221",
+			"resolved": "https://registry.npmjs.org/@conduction/nextcloud-vue/-/nextcloud-vue-1.0.0-beta.221.tgz",
+			"integrity": "sha512-2sNPtUYlQNrFg3yVqXHvOwOHeXiOHsjmWhHPc3WCsAq8hpJj1v/T+XeGKFBmUEi4mJ/9UtR+NrrT8Zke0FKcug==",
 			"license": "EUPL-1.2",
 			"dependencies": {
 				"@codemirror/autocomplete": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
 		"extends @nextcloud/browserslist-config"
 	],
 	"dependencies": {
-		"@conduction/nextcloud-vue": "^1.0.0-beta.213",
+		"@conduction/nextcloud-vue": "^1.0.0-beta.221",
 		"@nextcloud/axios": "~2.5.2",
 		"@nextcloud/dialogs": "^6.4.2",
 		"@nextcloud/initial-state": "^2.2.0",


### PR DESCRIPTION
## Summary
- Bumps `@conduction/nextcloud-vue` from `^1.0.0-beta.213` to `^1.0.0-beta.221`, activating the cnTranslate display-layer translation so schema property titles (already authored EN + EN/NL l10n) translate per user language.
- Patch-bumps `appinfo/info.xml` version (0.5.62 → 0.5.63) so Nextcloud's `?v=` cache-buster serves the new bundle once built by the release CI.
- `js/` is gitignored in this app and built during release CI (see `.github/workflows/beta-release.yaml`, `release-workflow.yaml`), so no bundle is committed here — verified locally that `USE_LOCAL_LIB=false npm run build` succeeds and the built `pipelinq-shared-nc-vue.js` contains `cnTranslate`.

## Test plan
- [x] `npm ci` clean install
- [x] `npm install @conduction/nextcloud-vue@1.0.0-beta.221` — package.json + package-lock.json updated to exact `1.0.0-beta.221`
- [x] `USE_LOCAL_LIB=false npm run build` exits 0 (only pre-existing asset-size warnings)
- [x] `grep -rl cnTranslate js/` confirms `pipelinq-shared-nc-vue.js` contains the translation helper