### PR TITLE
i18n(schema): author pipelinq schema-level titles in English + NL l10n

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -52,7 +52,7 @@ Vrij en open source onder de EUPL-1.2-licentie.
 
 **Ondersteuning:** Voor ondersteuning, neem contact op via support@conduction.nl. Voor een Service Level Agreement (SLA), neem contact op via sales@conduction.nl.
     ]]></description>
-    <version>0.5.63</version>
+    <version>0.5.64</version>
     <licence>EUPL-1.2</licence>
     <author mail="info@conduction.nl" homepage="https://www.conduction.nl/">Conduction</author>
     <namespace>Pipelinq</namespace>

--- a/l10n/en.js
+++ b/l10n/en.js
@@ -2384,7 +2384,9 @@ OC.L10N.register(
     "Action" : "Action",
     "Timestamp" : "Timestamp",
     "Opt-out / Confidentiality Flag" : "Opt-out / Confidentiality Flag",
-    "Effective Date" : "Effective Date"
+    "Effective Date" : "Effective Date",
+    "Customer Loyalty Account" : "Customer Loyalty Account",
+    "NRC Subscription" : "NRC Subscription"
 },
 "nplurals=2; plural=(n != 1);"
 );

--- a/l10n/en.json
+++ b/l10n/en.json
@@ -2383,7 +2383,9 @@
                 "Action": "Action",
                 "Timestamp": "Timestamp",
                 "Opt-out / Confidentiality Flag": "Opt-out / Confidentiality Flag",
-                "Effective Date": "Effective Date"
+                "Effective Date": "Effective Date",
+                "Customer Loyalty Account": "Customer Loyalty Account",
+                "NRC Subscription": "NRC Subscription"
         },
         "plurals": null
 }

--- a/l10n/nl.js
+++ b/l10n/nl.js
@@ -2460,7 +2460,9 @@ OC.L10N.register(
     "Action" : "Actie",
     "Timestamp" : "Tijdstip",
     "Opt-out / Confidentiality Flag" : "Opt-out / Geheimhouding-vlag",
-    "Effective Date" : "Ingangsdatum"
+    "Effective Date" : "Ingangsdatum",
+    "Customer Loyalty Account" : "Klant Loyalty Account",
+    "NRC Subscription" : "NRC Abonnement"
 },
 "nplurals=2; plural=(n != 1);"
 );

--- a/l10n/nl.json
+++ b/l10n/nl.json
@@ -2459,7 +2459,9 @@
                 "Action": "Actie",
                 "Timestamp": "Tijdstip",
                 "Opt-out / Confidentiality Flag": "Opt-out / Geheimhouding-vlag",
-                "Effective Date": "Ingangsdatum"
+                "Effective Date": "Ingangsdatum",
+                "Customer Loyalty Account": "Klant Loyalty Account",
+                "NRC Subscription": "NRC Abonnement"
         },
         "plurals": null
 }

--- a/lib/Settings/pipelinq_register.json
+++ b/lib/Settings/pipelinq_register.json
@@ -3,8 +3,8 @@
   "info": {
     "title": "Pipelinq CRM Register",
     "description": "Client Relationship Management register for the Pipelinq Nextcloud app. Manages clients, contacts, leads, requests, and pipelines.",
-    "version": "1.2.1",
-    "x-changelog": "1.2.1: Re-authored 38 Dutch schema property titles to English (contact.geheimhouding plus the bsnValidatie, brpLookupVerzoek, brpPersoon, bsnAuditRecord, and optOutVlag schemas); Dutch labels now live in l10n/nl.json + nl.js. No property keys, enums, or other fields changed."
+    "version": "1.2.2",
+    "x-changelog": "1.2.2: Re-authored 2 Dutch schema-level titles to English (klantLoyaltyAccount \"Klant Loyalty Account\"->\"Customer Loyalty Account\", nrcAbonnement \"NRC Abonnement\"->\"NRC Subscription\"); Dutch labels now live in l10n/nl.json + nl.js. VNG Klantinteracties and Kassakoppeling schema titles kept as-is (formal standard / established domain terms). No property titles, keys, enums, or other fields changed. 1.2.1: Re-authored 38 Dutch schema property titles to English (contact.geheimhouding plus the bsnValidatie, brpLookupVerzoek, brpPersoon, bsnAuditRecord, and optOutVlag schemas); Dutch labels now live in l10n/nl.json + nl.js. No property keys, enums, or other fields changed."
   },
   "x-openregister": {
     "type": "application",

--- a/lib/Settings/register.d/70-loyalty-program.json
+++ b/lib/Settings/register.d/70-loyalty-program.json
@@ -341,7 +341,7 @@
       },
       "klantLoyaltyAccount": {
         "slug": "klantLoyaltyAccount",
-        "title": "Klant Loyalty Account",
+        "title": "Customer Loyalty Account",
         "version": "1.0.0",
         "summary": "A customer's enrollment in a loyalty programme; tracks balances, tier, and opt-in.",
         "description": "KlantLoyaltyAccount links one customer (klantId, references a Nextcloud contact UID) to one LoyaltyProgramme. currentBalance and lifetimePoints are denormalised for query performance; the immutable PointsLedgerEntry collection is the source of truth (REQ-LOY-002, REQ-LOY-005). Composite uniqueness on (klantId, programmeId).",

--- a/lib/Settings/register.d/80-zgw-api-bridge.json
+++ b/lib/Settings/register.d/80-zgw-api-bridge.json
@@ -182,7 +182,7 @@
       },
       "nrcAbonnement": {
         "slug": "nrcAbonnement",
-        "title": "NRC Abonnement",
+        "title": "NRC Subscription",
         "icon": "BellRing",
         "version": "1.0.0",
         "summary": "Subscription state for one NRC endpoint per ZgwEndpoint (callback URL, bearer secret ref, active kanalen).",


### PR DESCRIPTION
## Summary
- Rewrote 2 Dutch schema-level titles (register.d fragments) to English:
  - `klantLoyaltyAccount`: "Klant Loyalty Account" -> "Customer Loyalty Account"
  - `nrcAbonnement`: "NRC Abonnement" -> "NRC Subscription" (kept "NRC" — formal abbreviation for Notificaties Routerings Component)
- All other schema-level titles in the register were already English (scanned all 27 base schemas + 30 register.d fragments).
- Left `vngKlantinteractieBinding` ("VNG Klantinteracties Binding") and `kassakoppelingAuditLog` ("POS Kassakoppeling Audit Entry") titles unchanged — "VNG Klantinteracties" is the formal name of the external Dutch government API standard, and "Kassakoppeling" is an established domain term used verbatim throughout the codebase (routes, class names, openspec docs) — same judgment call as keeping BRP/BSN.
- Added 2 missing l10n keys (en identity + nl Dutch value) to `l10n/en.json`, `en.js`, `nl.json`, `nl.js`.
- Bumped register `info.version` 1.2.1 -> 1.2.2 and `appinfo/info.xml` 0.5.63 -> 0.5.64.

## Test plan
- [x] `git diff` of the register shows only the two schema-level `"title":` value changes + the version/changelog line
- [x] Property-key set per touched schema verified identical to `origin/development` merge-base (scripted check)
- [x] Register + l10n JSON valid (`python3 -m json.load`); `node -c` on l10n `.js` files
- [x] No npm build run, no live instance touched