### PR TITLE
i18n(l10n): n() plural coverage

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -52,7 +52,7 @@ Vrij en open source onder de EUPL-1.2-licentie.
 
 **Ondersteuning:** Voor ondersteuning, neem contact op via support@conduction.nl. Voor een Service Level Agreement (SLA), neem contact op via sales@conduction.nl.
     ]]></description>
-    <version>0.5.67</version>
+    <version>0.5.68</version>
     <licence>EUPL-1.2</licence>
     <author mail="info@conduction.nl" homepage="https://www.conduction.nl/">Conduction</author>
     <namespace>Pipelinq</namespace>

--- a/l10n/en.json
+++ b/l10n/en.json
@@ -3064,7 +3064,37 @@
         "Save the job before running a test": "Save the job before running a test",
         "Target kind": "Target kind",
         "Worklog": "Worklog",
-        "{n} of {max} items": "{n} of {max} items"
+        "{n} of {max} items": "{n} of {max} items",
+        "%n stage": [
+            "%n stage",
+            "%n stages"
+        ],
+        "%n stages": "%n stages",
+        "%n minute": [
+            "%n minute",
+            "%n minutes"
+        ],
+        "%n minutes": "%n minutes",
+        "%n more contact not shown": [
+            "%n more contact not shown",
+            "%n more contacts not shown"
+        ],
+        "%n more contacts not shown": "%n more contacts not shown",
+        "%n contact in this segment is missing {channel} consent. Choose how to proceed.": [
+            "%n contact in this segment is missing {channel} consent. Choose how to proceed.",
+            "%n contacts in this segment are missing {channel} consent. Choose how to proceed."
+        ],
+        "%n contacts in this segment are missing {channel} consent. Choose how to proceed.": "%n contacts in this segment are missing {channel} consent. Choose how to proceed.",
+        "%n minute ago": [
+            "%n minute ago",
+            "%n minutes ago"
+        ],
+        "%n minutes ago": "%n minutes ago",
+        "%n hour ago": [
+            "%n hour ago",
+            "%n hours ago"
+        ],
+        "%n hours ago": "%n hours ago"
     },
     "plurals": null
 }

--- a/l10n/nl.json
+++ b/l10n/nl.json
@@ -3059,7 +3059,31 @@
         "Revenue": "Omzet",
         "Target kind": "Doelsoort",
         "Worklog": "Urenregistratie",
-        "{n} of {max} items": "{n} van {max} items"
+        "{n} of {max} items": "{n} van {max} items",
+        "%n stage": [
+            "%n fase",
+            "%n fasen"
+        ],
+        "%n minute": [
+            "%n minuut",
+            "%n minuten"
+        ],
+        "%n more contact not shown": [
+            "Nog %n contact niet getoond",
+            "Nog %n contacten niet getoond"
+        ],
+        "%n contact in this segment is missing {channel} consent. Choose how to proceed.": [
+            "%n contact in dit segment mist toestemming voor {channel}. Kies hoe u verdergaat.",
+            "%n contacten in dit segment missen toestemming voor {channel}. Kies hoe u verdergaat."
+        ],
+        "%n minute ago": [
+            "%n minuut geleden",
+            "%n minuten geleden"
+        ],
+        "%n hour ago": [
+            "%n uur geleden",
+            "%n uur geleden"
+        ]
     },
     "plurals": null
 }


### PR DESCRIPTION
Adds the `n('pipelinq', singular, plural)` plural strings that were used in source but missing from `l10n/en.json`/`nl.json` — Dutch users were seeing the untranslated English plural. Format matches the fleet convention (singular key → `[sing, plural]` array for runtime plural resolution; English plural also added as an identity key to satisfy the en.json coverage guard). `npm run test:l10n` passes; diff is purely additive (0 changed, 0 removed). Version bumped.