### PR TITLE
ci(l10n): gate PRs on en.json translation coverage

### DIFF
--- a/.github/workflows/l10n.yml
+++ b/.github/workflows/l10n.yml
@@ -1,0 +1,23 @@
+name: l10n
+
+on:
+  push:
+    branches: [main, development]
+  pull_request:
+    branches: [main, beta, development]
+
+permissions:
+  contents: read
+
+jobs:
+  l10n:
+    name: l10n coverage (en.json)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+      # check-l10n.js uses only Node built-ins (fs/path) — no npm ci needed.
+      - name: Check l10n coverage
+        run: npm run test:l10n


### PR DESCRIPTION
Adds a standalone `l10n` CI workflow that runs `npm run test:l10n` (dependency-free node script) on every PR, gating on en.json translation coverage. New file only — no other files touched.