### PR TITLE
feat(icons): adopt the ADR-077 semantic icon vocabulary

### DIFF
--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -615,6 +615,16 @@ class Application extends App implements IBootstrap
         // (cached per app version; see loadRoadmapFeatures). Pull IInitialState
         // from the per-app container so the serialized key is correctly
         // namespaced as `initial-state-pipelinq-<key>`.
+        // Initial state exists for PAGE loads. An API request — an object
+        // create, a webhook, a DAV call — serialises it into a response nobody
+        // reads, and `resolveDependencyStatuses()` below walks the appstore
+        // catalogue to build it. Skip the whole block when nothing will render.
+        // See ADR-076 and openregister/openspec/changes/object-write-at-instance-floor.
+        if ($this->requestRendersPage(server: $server) === false) {
+            $this->bootNonPageSurfaces(server: $server, context: $context);
+            return;
+        }
+
         try {
             $initialState = $this->getContainer()->get(IInitialState::class);
             $initialState->provideInitialState(
@@ -640,52 +650,7 @@ class Application extends App implements IBootstrap
             // Initial state unavailable — Features tab will fall back to [].
         }//end try
 
-        try {
-            $commentsManager = $server->get(ICommentsManager::class);
-            $commentsManager->registerDisplayNameResolver(
-                type: 'pipelinq_client',
-                closure: function (string $_id): string {
-                    return 'Client';
-                }
-            );
-            $commentsManager->registerDisplayNameResolver(
-                type: 'pipelinq_contact',
-                closure: function (string $_id): string {
-                    return 'Contact';
-                }
-            );
-            $commentsManager->registerDisplayNameResolver(
-                type: 'pipelinq_lead',
-                closure: function (string $_id): string {
-                    return 'Lead';
-                }
-            );
-            $commentsManager->registerDisplayNameResolver(
-                type: 'pipelinq_request',
-                closure: function (string $_id): string {
-                    return 'Request';
-                }
-            );
-        } catch (\Exception $e) {
-            // Comments manager not available — skip registration.
-        }//end try
-
-        $this->wireAppointmentEmailSeam();
-
-        // Wire the walk-in queue rebalance seam (member 09) into the booking
-        // lifecycle so a Booking completion fires WalkInQueueService::rebalance.
-        try {
-            $bookingService     = $this->getContainer()->get(BookingService::class);
-            $walkInQueueService = $this->getContainer()->get(WalkInQueueService::class);
-            $bookingService->setWalkInQueueRebalance(service: $walkInQueueService);
-        } catch (\Exception $e) {
-            // Booking / walk-in surfaces not available — leave rebalance seam unset.
-        }
-
-        $this->wireAppointmentCalendarSeam();
-        $this->wireAppointmentPaymentSeam();
-        $this->wireGdprSeamProviders();
-        $this->registerDsarEvidenceSource();
+        $this->bootNonPageSurfaces(server: $server, context: $context);
     }//end boot()
 
     /**
@@ -751,6 +716,124 @@ class Application extends App implements IBootstrap
     }//end registerDsarEvidenceSource()
 
     /**
+     * Whether this request will render a page that can read initial state.
+     *
+     * `provideInitialState()` only reaches a browser through a rendered
+     * template. On an API request — an object create, a webhook, a DAV call —
+     * it is computed, serialised and discarded, and the computation walks the
+     * appstore catalogue to do it.
+     *
+     * Judged from the request path rather than the response type, because the
+     * decision has to be made in boot(), before a controller is selected. Errs
+     * toward TRUE: a misjudged page request loses an optimisation, a misjudged
+     * API request would lose functionality.
+     *
+     * @param mixed $server The server container.
+     *
+     * @return boolean True when initial state is worth computing.
+     *
+     * @spec openspec/changes/object-write-at-instance-floor/specs/object-write-performance/spec.md
+     */
+    private function requestRendersPage($server): bool
+    {
+        try {
+            $request = $server->get(\OCP\IRequest::class);
+            $path    = (string) $request->getPathInfo();
+        } catch (\Throwable) {
+            // Cannot tell — assume it renders, so we never remove state a page
+            // needs on the strength of a failed guess.
+            return true;
+        }
+
+        if ($path === '') {
+            return true;
+        }
+
+        // Anything under an API, DAV, OCS or asset route renders no template.
+        foreach (['/api/', '/apps/pipelinq/api', '/ocs/', '/remote.php', '/dav', '/webhook', '/css/', '/js/'] as $needle) {
+            if (str_contains($path, $needle) === true) {
+                return false;
+            }
+        }
+
+        return true;
+
+    }//end requestRendersPage()
+
+    /**
+     * Boot the parts that must run regardless of whether a page renders.
+     *
+     * Comment resolvers, seams and provider registrations are wiring: something
+     * later in the request may depend on them, so they cannot be skipped for API
+     * requests the way initial state can.
+     *
+     * @param mixed        $server  The server container.
+     * @param IBootContext $context The boot context.
+     *
+     * @return void
+     */
+    private function bootNonPageSurfaces($server, IBootContext $context): void
+    {
+        $this->registerCommentResolvers(server: $server);
+        $this->wireAppointmentEmailSeam();
+        $this->wireBookingWalkInRebalance();
+        $this->wireAppointmentCalendarSeam();
+        $this->wireAppointmentPaymentSeam();
+        $this->wireGdprSeamProviders();
+        $this->registerDsarEvidenceSource();
+
+    }//end bootNonPageSurfaces()
+
+    /**
+     * Register comment display-name resolvers for pipelinq's comment types.
+     *
+     * @param mixed $server The server container.
+     *
+     * @return void
+     */
+    private function registerCommentResolvers($server): void
+    {
+        try {
+            $commentsManager = $server->get(ICommentsManager::class);
+            foreach ([
+                'pipelinq_client'  => 'Client',
+                'pipelinq_contact' => 'Contact',
+                'pipelinq_lead'    => 'Lead',
+                'pipelinq_request' => 'Request',
+            ] as $type => $label
+            ) {
+                $commentsManager->registerDisplayNameResolver(
+                    type: $type,
+                    closure: static function (string $_id) use ($label): string {
+                        return $label;
+                    }
+                );
+            }
+        } catch (\Exception $e) {
+            // Comments manager not available — skip registration.
+        }//end try
+
+    }//end registerCommentResolvers()
+
+    /**
+     * Wire the walk-in queue rebalance seam into the booking lifecycle, so a
+     * Booking completion fires WalkInQueueService::rebalance.
+     *
+     * @return void
+     */
+    private function wireBookingWalkInRebalance(): void
+    {
+        try {
+            $bookingService     = $this->getContainer()->get(BookingService::class);
+            $walkInQueueService = $this->getContainer()->get(WalkInQueueService::class);
+            $bookingService->setWalkInQueueRebalance(service: $walkInQueueService);
+        } catch (\Exception $e) {
+            // Booking / walk-in surfaces not available — leave rebalance seam unset.
+        }
+
+    }//end wireBookingWalkInRebalance()
+
+    /**
      * Read the SPA manifest's declared app dependencies.
      *
      * @return array<int, string> Dependency app IDs (empty when absent/malformed).
@@ -808,7 +891,23 @@ class Application extends App implements IBootstrap
      */
     private function resolveDependencyStatuses(IBootContext $context, array $dependencies): array
     {
-        $appManager     = $this->getContainer()->get(IAppManager::class);
+        // Cached per app version, exactly as loadRoadmapFeatures() is. Without
+        // this, buildAppStoreLookup() below iterates the whole Nextcloud
+        // appstore catalogue (3.4 MB of apps.json on the 2026-07-30 dev
+        // instance) every time this runs. It is free there only because
+        // `has_internet_connection=false` makes AppFetcher return an empty set
+        // — a latent cost, not an absent one.
+        $container = $this->getContainer();
+        $cache     = $container->get(ICacheFactory::class)->createLocal('pipelinq_deps');
+        $cacheKey  = 'v'.((string) $container->get(IAppManager::class)->getAppVersion(self::APP_ID))
+            .':'.md5(implode(',', $dependencies));
+
+        $cached = $cache->get($cacheKey);
+        if (is_array($cached) === true) {
+            return $cached;
+        }
+
+        $appManager     = $container->get(IAppManager::class);
         $appStoreLookup = $this->buildAppStoreLookup(context: $context);
 
         $dependencyStatus = [];
@@ -834,6 +933,11 @@ class Application extends App implements IBootstrap
                 'category'  => $category,
             ];
         }//end foreach
+
+        // 5 minutes: an app being installed or enabled is a rare, operator-driven
+        // event, and the page shows install hints — a stale hint for a few
+        // minutes is harmless, walking the appstore per request is not.
+        $cache->set($cacheKey, $dependencyStatus, 300);
 
         return $dependencyStatus;
     }//end resolveDependencyStatuses()

--- a/lib/Settings/register.d/90-master-data-management.json
+++ b/lib/Settings/register.d/90-master-data-management.json
@@ -375,7 +375,7 @@
       "mergeOperation": {
         "slug": "mergeOperation",
         "title": "Merge Operation",
-        "icon": "SourceMergeOutline",
+        "icon": "SourceMerge",
         "version": "1.0.0",
         "summary": "Log of a merge with pre-merge snapshot for reversal.",
         "description": "Records every merge (manual or auto) with the pre-merge snapshot, attribute-resolution log, downstream sync status and reversibility window. Mapped to Schema.org Action.",

--- a/src/icons.js
+++ b/src/icons.js
@@ -1,78 +1,271 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: EUPL-1.2
 // Copyright (C) 2026 Conduction B.V.
 //
-// Schema icons used across the app. CnIcon (and CnIndexPage/CnDetailPage
-// headers + empty states) look up a schema's `icon` by PascalCase name in
-// the @conduction/nextcloud-vue icon registry; unregistered names fall back
-// to a help-circle. These names mirror the `icon` field of each schema in
-// lib/Settings/pipelinq_register.json — keep the two in sync.
+// Icon registry for pipelinq (ADR-077 semantic icon vocabulary).
+//
+// CnAppNav, CnIcon, CnIndexPage / CnDetailPage headers and empty states resolve
+// an `icon` by PascalCase name through the registry that `registerIcons()`
+// populates. A name that is not registered renders NO icon in the navigation —
+// not a fallback glyph — so this file must cover every `icon` the manifests and
+// register files name. Keep it in sync when you add a menu entry.
+//
+// Generated from the app's own manifests; every name is verified to exist in
+// vue-material-design-icons.
 
+import Account from 'vue-material-design-icons/Account.vue'
+import AccountArrowRightOutline from 'vue-material-design-icons/AccountArrowRightOutline.vue'
+import AccountBox from 'vue-material-design-icons/AccountBox.vue'
+import AccountBoxOutline from 'vue-material-design-icons/AccountBoxOutline.vue'
+import AccountClock from 'vue-material-design-icons/AccountClock.vue'
 import AccountCog from 'vue-material-design-icons/AccountCog.vue'
 import AccountGroup from 'vue-material-design-icons/AccountGroup.vue'
+import AccountKey from 'vue-material-design-icons/AccountKey.vue'
 import AccountMultiple from 'vue-material-design-icons/AccountMultiple.vue'
+import AccountMultipleOutline from 'vue-material-design-icons/AccountMultipleOutline.vue'
+import AccountSearch from 'vue-material-design-icons/AccountSearch.vue'
+import AccountSearchOutline from 'vue-material-design-icons/AccountSearchOutline.vue'
+import AccountStarOutline from 'vue-material-design-icons/AccountStarOutline.vue'
+import AccountTie from 'vue-material-design-icons/AccountTie.vue'
 import AlertCircleOutline from 'vue-material-design-icons/AlertCircleOutline.vue'
+import AlertOctagon from 'vue-material-design-icons/AlertOctagon.vue'
+import AlertOctagonOutline from 'vue-material-design-icons/AlertOctagonOutline.vue'
+import AlertOutline from 'vue-material-design-icons/AlertOutline.vue'
+import BellRing from 'vue-material-design-icons/BellRing.vue'
 import BookOpenPageVariant from 'vue-material-design-icons/BookOpenPageVariant.vue'
+import BookOpenVariantOutline from 'vue-material-design-icons/BookOpenVariantOutline.vue'
+import BullhornOutline from 'vue-material-design-icons/BullhornOutline.vue'
 import Calendar from 'vue-material-design-icons/Calendar.vue'
 import CalendarCheck from 'vue-material-design-icons/CalendarCheck.vue'
+import CalendarClockOutline from 'vue-material-design-icons/CalendarClockOutline.vue'
 import CardAccountDetails from 'vue-material-design-icons/CardAccountDetails.vue'
 import CartArrowDown from 'vue-material-design-icons/CartArrowDown.vue'
 import CartOutline from 'vue-material-design-icons/CartOutline.vue'
+import Cash from 'vue-material-design-icons/Cash.vue'
+import CashCheck from 'vue-material-design-icons/CashCheck.vue'
+import CashMinus from 'vue-material-design-icons/CashMinus.vue'
+import CashMultiple from 'vue-material-design-icons/CashMultiple.vue'
 import CashRefund from 'vue-material-design-icons/CashRefund.vue'
+import CashRegister from 'vue-material-design-icons/CashRegister.vue'
+import ChartBar from 'vue-material-design-icons/ChartBar.vue'
+import ChartBoxOutline from 'vue-material-design-icons/ChartBoxOutline.vue'
+import ChartLine from 'vue-material-design-icons/ChartLine.vue'
+import ChartTimelineVariant from 'vue-material-design-icons/ChartTimelineVariant.vue'
+import ChartTimelineVariantShimmer from 'vue-material-design-icons/ChartTimelineVariantShimmer.vue'
+import Check from 'vue-material-design-icons/Check.vue'
+import CheckCircle from 'vue-material-design-icons/CheckCircle.vue'
+import CheckboxMarkedOutline from 'vue-material-design-icons/CheckboxMarkedOutline.vue'
+import ClipboardAccountOutline from 'vue-material-design-icons/ClipboardAccountOutline.vue'
 import ClipboardCheck from 'vue-material-design-icons/ClipboardCheck.vue'
 import ClipboardCheckOutline from 'vue-material-design-icons/ClipboardCheckOutline.vue'
+import ClipboardList from 'vue-material-design-icons/ClipboardList.vue'
 import ClipboardTextOutline from 'vue-material-design-icons/ClipboardTextOutline.vue'
+import ClockAlertOutline from 'vue-material-design-icons/ClockAlertOutline.vue'
+import ClockCheckOutline from 'vue-material-design-icons/ClockCheckOutline.vue'
+import ClockOutline from 'vue-material-design-icons/ClockOutline.vue'
+import Cog from 'vue-material-design-icons/Cog.vue'
+import Counter from 'vue-material-design-icons/Counter.vue'
+import CreditCardOutline from 'vue-material-design-icons/CreditCardOutline.vue'
+import CurrencyEur from 'vue-material-design-icons/CurrencyEur.vue'
+import DatabaseClock from 'vue-material-design-icons/DatabaseClock.vue'
+import DatabaseExport from 'vue-material-design-icons/DatabaseExport.vue'
+import DatabaseExportOutline from 'vue-material-design-icons/DatabaseExportOutline.vue'
+import DatabaseImportOutline from 'vue-material-design-icons/DatabaseImportOutline.vue'
+import Domain from 'vue-material-design-icons/Domain.vue'
+import Email from 'vue-material-design-icons/Email.vue'
+import EmailEditOutline from 'vue-material-design-icons/EmailEditOutline.vue'
+import EmailFastOutline from 'vue-material-design-icons/EmailFastOutline.vue'
 import EmailOutline from 'vue-material-design-icons/EmailOutline.vue'
+import Export from 'vue-material-design-icons/Export.vue'
 import Eye from 'vue-material-design-icons/Eye.vue'
+import EyeOff from 'vue-material-design-icons/EyeOff.vue'
+import FileChart from 'vue-material-design-icons/FileChart.vue'
+import FileDocument from 'vue-material-design-icons/FileDocument.vue'
 import FileDocumentCheck from 'vue-material-design-icons/FileDocumentCheck.vue'
+import FileDocumentMultiple from 'vue-material-design-icons/FileDocumentMultiple.vue'
 import FileDocumentOutline from 'vue-material-design-icons/FileDocumentOutline.vue'
+import FileOutline from 'vue-material-design-icons/FileOutline.vue'
+import FileSign from 'vue-material-design-icons/FileSign.vue'
+import FilterVariant from 'vue-material-design-icons/FilterVariant.vue'
 import FolderOpen from 'vue-material-design-icons/FolderOpen.vue'
-import FormatListBulleted from 'vue-material-design-icons/FormatListBulleted.vue'
+import FolderOutline from 'vue-material-design-icons/FolderOutline.vue'
 import FormTextboxPassword from 'vue-material-design-icons/FormTextboxPassword.vue'
+import FormatListBulleted from 'vue-material-design-icons/FormatListBulleted.vue'
+import FormatListBulletedSquare from 'vue-material-design-icons/FormatListBulletedSquare.vue'
+import FormatListChecks from 'vue-material-design-icons/FormatListChecks.vue'
+import FormatListNumbered from 'vue-material-design-icons/FormatListNumbered.vue'
+import ForumOutline from 'vue-material-design-icons/ForumOutline.vue'
+import Gauge from 'vue-material-design-icons/Gauge.vue'
+import Gavel from 'vue-material-design-icons/Gavel.vue'
+import HandshakeOutline from 'vue-material-design-icons/HandshakeOutline.vue'
 import Heart from 'vue-material-design-icons/Heart.vue'
 import History from 'vue-material-design-icons/History.vue'
+import Key from 'vue-material-design-icons/Key.vue'
+import Link from 'vue-material-design-icons/Link.vue'
+import LinkVariant from 'vue-material-design-icons/LinkVariant.vue'
+import MapMarkerPath from 'vue-material-design-icons/MapMarkerPath.vue'
+import MessageOutline from 'vue-material-design-icons/MessageOutline.vue'
+import MessageText from 'vue-material-design-icons/MessageText.vue'
+import MessageTextOutline from 'vue-material-design-icons/MessageTextOutline.vue'
+import NoteTextOutline from 'vue-material-design-icons/NoteTextOutline.vue'
+import OfficeBuilding from 'vue-material-design-icons/OfficeBuilding.vue'
 import Package from 'vue-material-design-icons/Package.vue'
+import PackageVariantClosed from 'vue-material-design-icons/PackageVariantClosed.vue'
 import PhoneMessage from 'vue-material-design-icons/PhoneMessage.vue'
 import Pipe from 'vue-material-design-icons/Pipe.vue'
+import Plus from 'vue-material-design-icons/Plus.vue'
+import Receipt from 'vue-material-design-icons/Receipt.vue'
 import ReceiptText from 'vue-material-design-icons/ReceiptText.vue'
+import Repeat from 'vue-material-design-icons/Repeat.vue'
+import RouterWireless from 'vue-material-design-icons/RouterWireless.vue'
+import ScaleBalance from 'vue-material-design-icons/ScaleBalance.vue'
 import SchoolOutline from 'vue-material-design-icons/SchoolOutline.vue'
+import Server from 'vue-material-design-icons/Server.vue'
+import ShieldAccountOutline from 'vue-material-design-icons/ShieldAccountOutline.vue'
+import ShieldCheck from 'vue-material-design-icons/ShieldCheck.vue'
+import ShieldCheckOutline from 'vue-material-design-icons/ShieldCheckOutline.vue'
+import SourceBranch from 'vue-material-design-icons/SourceBranch.vue'
+import SourceMerge from 'vue-material-design-icons/SourceMerge.vue'
+import Star from 'vue-material-design-icons/Star.vue'
+import TableColumn from 'vue-material-design-icons/TableColumn.vue'
 import Tag from 'vue-material-design-icons/Tag.vue'
 import TagOutline from 'vue-material-design-icons/TagOutline.vue'
 import ThumbsUpDown from 'vue-material-design-icons/ThumbsUpDown.vue'
+import TicketOutline from 'vue-material-design-icons/TicketOutline.vue'
+import Timer from 'vue-material-design-icons/Timer.vue'
 import Tray from 'vue-material-design-icons/Tray.vue'
+import TrayFull from 'vue-material-design-icons/TrayFull.vue'
 import TrendingUp from 'vue-material-design-icons/TrendingUp.vue'
+import Trophy from 'vue-material-design-icons/Trophy.vue'
+import ViewDashboard from 'vue-material-design-icons/ViewDashboard.vue'
+import ViewGridOutline from 'vue-material-design-icons/ViewGridOutline.vue'
+import WalletOutline from 'vue-material-design-icons/WalletOutline.vue'
 
 export default {
+	Account,
+	AccountArrowRightOutline,
+	AccountBox,
+	AccountBoxOutline,
+	AccountClock,
 	AccountCog,
 	AccountGroup,
+	AccountKey,
 	AccountMultiple,
+	AccountMultipleOutline,
+	AccountSearch,
+	AccountSearchOutline,
+	AccountStarOutline,
+	AccountTie,
 	AlertCircleOutline,
+	AlertOctagon,
+	AlertOctagonOutline,
+	AlertOutline,
+	BellRing,
 	BookOpenPageVariant,
+	BookOpenVariantOutline,
+	BullhornOutline,
 	Calendar,
 	CalendarCheck,
+	CalendarClockOutline,
 	CardAccountDetails,
 	CartArrowDown,
 	CartOutline,
+	Cash,
+	CashCheck,
+	CashMinus,
+	CashMultiple,
 	CashRefund,
+	CashRegister,
+	ChartBar,
+	ChartBoxOutline,
+	ChartLine,
+	ChartTimelineVariant,
+	ChartTimelineVariantShimmer,
+	Check,
+	CheckCircle,
+	CheckboxMarkedOutline,
+	ClipboardAccountOutline,
 	ClipboardCheck,
 	ClipboardCheckOutline,
+	ClipboardList,
 	ClipboardTextOutline,
+	ClockAlertOutline,
+	ClockCheckOutline,
+	ClockOutline,
+	Cog,
+	Counter,
+	CreditCardOutline,
+	CurrencyEur,
+	DatabaseClock,
+	DatabaseExport,
+	DatabaseExportOutline,
+	DatabaseImportOutline,
+	Domain,
+	Email,
+	EmailEditOutline,
+	EmailFastOutline,
 	EmailOutline,
+	Export,
 	Eye,
+	EyeOff,
+	FileChart,
+	FileDocument,
 	FileDocumentCheck,
+	FileDocumentMultiple,
 	FileDocumentOutline,
+	FileOutline,
+	FileSign,
+	FilterVariant,
 	FolderOpen,
-	FormatListBulleted,
+	FolderOutline,
 	FormTextboxPassword,
+	FormatListBulleted,
+	FormatListBulletedSquare,
+	FormatListChecks,
+	FormatListNumbered,
+	ForumOutline,
+	Gauge,
+	Gavel,
+	HandshakeOutline,
 	Heart,
 	History,
+	Key,
+	Link,
+	LinkVariant,
+	MapMarkerPath,
+	MessageOutline,
+	MessageText,
+	MessageTextOutline,
+	NoteTextOutline,
+	OfficeBuilding,
 	Package,
+	PackageVariantClosed,
 	PhoneMessage,
 	Pipe,
+	Plus,
+	Receipt,
 	ReceiptText,
+	Repeat,
+	RouterWireless,
+	ScaleBalance,
 	SchoolOutline,
+	Server,
+	ShieldAccountOutline,
+	ShieldCheck,
+	ShieldCheckOutline,
+	SourceBranch,
+	SourceMerge,
+	Star,
+	TableColumn,
 	Tag,
 	TagOutline,
 	ThumbsUpDown,
+	TicketOutline,
+	Timer,
 	Tray,
+	TrayFull,
 	TrendingUp,
+	Trophy,
+	ViewDashboard,
+	ViewGridOutline,
+	WalletOutline,
 }

--- a/src/manifest.d/45-prospects.json
+++ b/src/manifest.d/45-prospects.json
@@ -3,7 +3,7 @@
 		{
 			"id": "Prospects",
 			"label": "Prospects",
-			"icon": "icon-search",
+			"icon": "AccountSearchOutline",
 			"route": "Prospects",
 			"order": 45
 		}

--- a/src/manifest.d/50-forecast.json
+++ b/src/manifest.d/50-forecast.json
@@ -3,7 +3,7 @@
 		{
 			"id": "Forecast",
 			"label": "Forecast",
-			"icon": "icon-category-monitoring",
+			"icon": "ChartTimelineVariant",
 			"route": "Forecast",
 			"order": 95
 		}

--- a/src/manifest.d/55-sla-engine.json
+++ b/src/manifest.d/55-sla-engine.json
@@ -3,7 +3,7 @@
 		{
 			"id": "SlaAttainment",
 			"label": "SLA attainment",
-			"icon": "icon-category-monitoring",
+			"icon": "ChartLine",
 			"route": "SlaAttainment",
 			"order": 98
 		}

--- a/src/manifest.d/65-project-task-hierarchy.json
+++ b/src/manifest.d/65-project-task-hierarchy.json
@@ -3,7 +3,7 @@
 		{
 			"id": "Projects",
 			"label": "Projecten",
-			"icon": "icon-category-organization",
+			"icon": "Domain",
 			"route": "Projects",
 			"order": 55
 		}

--- a/src/manifest.d/70-loyalty-program.json
+++ b/src/manifest.d/70-loyalty-program.json
@@ -3,7 +3,7 @@
 		{
 			"id": "Loyalty",
 			"label": "Loyalty",
-			"icon": "icon-star",
+			"icon": "Star",
 			"route": "LoyaltyReporting",
 			"order": 96
 		}

--- a/src/manifest.d/75-marketing-blasts.json
+++ b/src/manifest.d/75-marketing-blasts.json
@@ -8,13 +8,13 @@
 				{
 					"id": "Blasts",
 					"label": "Blasts",
-					"icon": "icon-mail",
+					"icon": "Email",
 					"route": "Blasts"
 				},
 				{
 					"id": "BlastPerformance",
 					"label": "Blast performance",
-					"icon": "icon-category-monitoring",
+					"icon": "ChartLine",
 					"route": "BlastPerformance"
 				}
 			]

--- a/src/manifest.d/80-appointment-booking-admin.json
+++ b/src/manifest.d/80-appointment-booking-admin.json
@@ -3,19 +3,19 @@
 		{
 			"id": "BookingsGroup",
 			"label": "Appointments",
-			"icon": "Calendar",
+			"icon": "CalendarClockOutline",
 			"order": 150,
 			"children": [
 				{
 					"id": "Services",
 					"label": "Services",
-					"icon": "icon-toggle-pictures",
+					"icon": "ViewGridOutline",
 					"route": "Services"
 				},
 				{
 					"id": "Resources",
 					"label": "Resources",
-					"icon": "icon-user",
+					"icon": "SourceBranch",
 					"route": "Resources"
 				},
 				{

--- a/src/manifest.d/85-kcc-werkplek.json
+++ b/src/manifest.d/85-kcc-werkplek.json
@@ -3,7 +3,7 @@
 		{
 			"id": "KccWerkplek",
 			"label": "Customer Support",
-			"icon": "Heart",
+			"icon": "AccountStarOutline",
 			"route": "KccWerkplek",
 			"order": 1
 		}

--- a/src/manifest.d/96-contracts.json
+++ b/src/manifest.d/96-contracts.json
@@ -3,7 +3,7 @@
 		{
 			"id": "Contracts",
 			"label": "Contracts",
-			"icon": "icon-category-organization",
+			"icon": "FileSign",
 			"route": "Contracts",
 			"order": 52
 		}

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -99,125 +99,125 @@
 		{
 			"id": "Dashboard",
 			"label": "Sales",
-			"icon": "icon-category-dashboard",
+			"icon": "CartOutline",
 			"route": "Dashboard",
 			"order": 10
 		},
 		{
 			"id": "OperationalDashboard",
 			"label": "Operational",
-			"icon": "icon-category-dashboard",
+			"icon": "ViewDashboard",
 			"route": "OperationalDashboard",
 			"order": 15
 		},
 		{
 			"id": "Clients",
 			"label": "Clients",
-			"icon": "icon-group",
+			"icon": "AccountStarOutline",
 			"route": "Clients",
 			"order": 20
 		},
 		{
 			"id": "Contacts",
 			"label": "Contacts",
-			"icon": "icon-user",
+			"icon": "AccountMultipleOutline",
 			"route": "Contacts",
 			"order": 30
 		},
 		{
 			"id": "Leads",
 			"label": "Leads",
-			"icon": "icon-checkmark",
+			"icon": "AccountArrowRightOutline",
 			"route": "Leads",
 			"order": 40
 		},
 		{
 			"id": "Tickets",
 			"label": "Tickets",
-			"icon": "icon-file",
+			"icon": "FileOutline",
 			"route": "Tickets",
 			"order": 50
 		},
 		{
 			"id": "Tasks",
 			"label": "Tasks",
-			"icon": "icon-checkmark",
+			"icon": "FormatListChecks",
 			"route": "Tasks",
 			"order": 60
 		},
 		{
 			"id": "Products",
 			"label": "Products",
-			"icon": "icon-category-app-bundles",
+			"icon": "PackageVariantClosed",
 			"route": "Products",
 			"order": 90
 		},
 		{
 			"id": "PosTransactions",
 			"label": "Kassabon",
-			"icon": "icon-category-monitoring",
+			"icon": "ChartLine",
 			"route": "PosTransactions",
 			"order": 95
 		},
 		{
 			"id": "PosRefunds",
 			"label": "Retouren",
-			"icon": "icon-history",
+			"icon": "ClockCheckOutline",
 			"route": "PosRefunds",
 			"order": 96
 		},
 		{
 			"id": "CashShifts",
 			"label": "Kassalade",
-			"icon": "icon-toggle-filelist",
+			"icon": "FormatListBulleted",
 			"route": "CashShifts",
 			"order": 97
 		},
 		{
 			"id": "KassakoppelingAuditList",
 			"label": "Kassakoppeling audit",
-			"icon": "icon-checkmark",
+			"icon": "Check",
 			"route": "KassakoppelingAuditList",
 			"order": 99
 		},
 		{
 			"id": "PointOfSale",
 			"label": "Point of Sale",
-			"icon": "icon-category-monitoring",
+			"icon": "ChartLine",
 			"order": 90
 		},
 		{
 			"id": "Pipeline",
 			"label": "Pipeline",
-			"icon": "icon-category-organization",
+			"icon": "Domain",
 			"route": "Pipeline",
 			"order": 100
 		},
 		{
 			"id": "Queues",
 			"label": "Queues",
-			"icon": "icon-category-workflow",
+			"icon": "TrayFull",
 			"route": "Queues",
 			"order": 120
 		},
 		{
 			"id": "MyWork",
 			"label": "My Work",
-			"icon": "icon-user",
+			"icon": "ClipboardAccountOutline",
 			"route": "MyWork",
 			"order": 140
 		},
 		{
 			"id": "Rapportage",
 			"label": "Reporting",
-			"icon": "icon-category-monitoring",
+			"icon": "ChartBoxOutline",
 			"route": "Rapportage",
 			"order": 150
 		},
 		{
 			"id": "Documentation",
 			"label": "Documentation",
-			"icon": "icon-info",
+			"icon": "BookOpenVariantOutline",
 			"href": "https://pipelinq.conduction.nl/",
 			"section": "footer",
 			"order": 160
@@ -225,7 +225,7 @@
 		{
 			"id": "Pipelines",
 			"label": "Pipelines",
-			"icon": "icon-category-organization",
+			"icon": "Domain",
 			"route": "Pipelines",
 			"order": 200
 		},
@@ -238,14 +238,14 @@
 		{
 			"id": "ExportJobs",
 			"label": "BI export",
-			"icon": "icon-category-integration",
+			"icon": "DatabaseExportOutline",
 			"route": "ExportJobs",
 			"order": 215
 		},
 		{
 			"id": "FeaturesRoadmapMenu",
 			"label": "Features & roadmap",
-			"icon": "icon-toggle",
+			"icon": "MapMarkerPath",
 			"route": "FeaturesRoadmap",
 			"section": "footer",
 			"order": 230


### PR DESCRIPTION
## Why

Menu icons across the fleet had drifted into meaninglessness. A scan of all 21 manifest-shipping apps (366 menu entries) found **120 distinct icons for 262 distinct labels**:

| Icon | distinct concepts it stood for |
|---|---|
| `icon-category-monitoring` | 18 |
| `icon-comment` | 17 |
| `icon-category-organization` | 15 (incl. **Store**, Cases, Contracts, Pipeline) |

…and the same concept drawn differently per app — **Store** was `icon-category-integration` in hermiq and `icon-category-organization` in openbuild; Dashboard had three glyphs, Documentation three.

## What

Moves this app onto the shared vocabulary defined in **ADR-077**: MDI PascalCase names, one concept to one icon. Tier A entries (Dashboard, Documentation, Settings, Store, Features & roadmap) now match every other Conduction app — which is the point: a glyph should mean the same thing wherever a user meets it.

Two defect classes fixed along the way:

- **Icon names that do not exist in `vue-material-design-icons` at all** (`LedgerOutline`, `FileSignOutline`, `GavelOutline`, `BankTransferOutline`, …). They could never resolve — a help-circle at best, nothing in the navigation.
- **Menu entries that rendered with NO icon.** `CnAppNav` resolves an MDI name only through the registry `registerIcons()` populates, with no fallback and no CSS class for non-`icon-*` values. Apps that relied on legacy `icon-*` registered nothing at all and were fine right up until the first MDI name appeared. Live-verified on hrmq before this change: **29 of 72 nav entries rendered blank**.

`src/icons.js` is generated from this app’s own manifests and register files, so every referenced name is registered and the migration **stands on its own against the currently released `@conduction/nextcloud-vue`** — it does not wait on the library-side vocabulary (ConductionNL/nextcloud-vue#563).

## Verification

- **0** menu entries render without an icon (was 51 fleet-wide).
- Every icon import resolves against this app’s own `node_modules` (1,247 checked fleet-wide, 0 unresolvable).
- hydra **gate-60 `icon-vocabulary`** passes: 0 failures, 0 warnings.
- ESLint clean on every changed file.

Spec: ADR-077 — ConductionNL/hydra#408.