### PR TITLE
feat(icons): extend ADR-077 to page, widget and action icons

### DIFF
--- a/lib/Settings/register.d/96-contract-renewal.json
+++ b/lib/Settings/register.d/96-contract-renewal.json
@@ -4,7 +4,7 @@
       "contract": {
         "slug": "contract",
         "title": "Contract",
-        "icon": "icon-category-organization",
+        "icon": "Domain",
         "summary": "Recurring-revenue contract with renewal lifecycle",
         "description": "A recurring or one-off contract between the organization and a client. Drives MRR/ARR, renewal-window detection, renewal-lead automation and churn metrics. References an existing client object (identity is never duplicated). Field names contractNumber/startDate/endDate/value/status are read by the customer-portal contract reader without mapping.",
         "@type": "object",


### PR DESCRIPTION
## Why

The first ADR-077 pass migrated `menu[]` — the cross-app chrome users meet in every app. Everything else kept its legacy `icon-*` classes: page and tab icons, widget headers, and the `actions[]` / `headerActions[]` entries.

Those render through the same CnIcon registry and carry the same hazard: a legacy name with no `CSS_ICON_TO_MDI` bridge entry falls through to the raw Nextcloud class, and on NC34+ light themes several of those ship a baked white `background-image` — **an invisible glyph, wherever it appears**, not just in the nav.

## What

Every icon field now uses the shared vocabulary — MDI PascalCase, one concept to one icon.

Action icons name a **verb** rather than a domain noun, so the vocabulary gained an actions family (view / create / edit / delete / run / test / publish / upload / download / refresh / …). Where a label named no concept, the conversion used the **CSS bridge target** — exactly the glyph already on screen — so those entries change dialect, not appearance.

`src/icons.js` is regenerated so every name the manifests reference is registered.

## Verification

- hydra **gate-60** clean (0 failures, 0 warnings), with the gate now walking **every** icon field rather than menu entries only
- every icon import resolves against this app’s own `node_modules`
- eslint clean

Spec: ADR-077 — ConductionNL/hydra#416.