### PR TITLE
ci: point the reusable workflows at the org and branch that exist

### DIFF
--- a/.github/workflows/branch-protection.yml
+++ b/.github/workflows/branch-protection.yml
@@ -6,4 +6,4 @@ on:
 
 jobs:
   check:
-    uses: Conduction/.github/.github/workflows/branch-protection.yml@main
+    uses: ConductionNL/.github/.github/workflows/branch-protection.yml@main

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -16,7 +16,7 @@ on:
 
 jobs:
   quality:
-    uses: Conduction/.github/.github/workflows/quality.yml@main
+    uses: ConductionNL/.github/.github/workflows/quality.yml@main
     with:
       app-name: pipelinq
       # Strict static-analysis gate suite (composer check:strict equivalent).

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -8,6 +8,6 @@ on:
 
 jobs:
   deploy:
-    uses: Conduction/.github/.github/workflows/documentation.yml@main
+    uses: ConductionNL/.github/.github/workflows/documentation.yml@main
     with:
       cname: pipelinq.conduction.nl

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   triage:
-    uses: Conduction/.github/.github/workflows/issue-triage.yml@feature/openspec-project-sync
+    uses: ConductionNL/.github/.github/workflows/issue-triage.yml@main
     with:
       app-name: pipelinq
       backlog-existing: ${{ github.event_name == 'workflow_dispatch' && inputs.backlog-existing || false }}

--- a/.github/workflows/openspec-sync.yml
+++ b/.github/workflows/openspec-sync.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   sync:
-    uses: Conduction/.github/.github/workflows/openspec-sync.yml@feature/openspec-project-sync
+    uses: ConductionNL/.github/.github/workflows/openspec-sync.yml@main
     with:
       app-name: pipelinq
     secrets:

--- a/.github/workflows/release-beta.yml
+++ b/.github/workflows/release-beta.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   release:
-    uses: Conduction/.github/.github/workflows/release-beta.yml@main
+    uses: ConductionNL/.github/.github/workflows/release-beta.yml@main
     with:
       app-name: pipelinq
     secrets: inherit

--- a/.github/workflows/release-stable.yml
+++ b/.github/workflows/release-stable.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   release:
-    uses: Conduction/.github/.github/workflows/release-stable.yml@main
+    uses: ConductionNL/.github/.github/workflows/release-stable.yml@main
     with:
       app-name: pipelinq
     secrets: inherit

--- a/.github/workflows/sync-to-beta.yml
+++ b/.github/workflows/sync-to-beta.yml
@@ -6,4 +6,4 @@ on:
 
 jobs:
   sync:
-    uses: Conduction/.github/.github/workflows/sync-to-beta.yml@main
+    uses: ConductionNL/.github/.github/workflows/sync-to-beta.yml@main


### PR DESCRIPTION
## What

Every callable workflow in this repo referenced the org `Conduction/.github`. That org does not exist.

```
GET /repos/Conduction/.github    -> 404
GET /repos/ConductionNL/.github  -> 200 (default branch: main)
```

`ConductionNL/.github` on `main` carries every workflow named here: `branch-protection.yml`, `documentation.yml`, `issue-triage.yml`, `openspec-sync.yml`, `quality.yml`, `release-beta.yml`, `release-stable.yml`, `sync-to-beta.yml`.

## Why it was invisible

An unresolvable `uses:` does not fail loudly — it fails as **absence**, and a gate's failure and its absence look identical from the outside.

The tell is in `gh run list`: when a reusable workflow never resolves, the run `name` is the **raw path** rather than the workflow's declared name, because the caller never got far enough to read it.

Before this PR:

```
.github/workflows/code-quality.yml       || name=.github/workflows/code-quality.yml       || failure
.github/workflows/branch-protection.yml  || name=.github/workflows/branch-protection.yml  || failure
.github/workflows/sync-to-beta.yml       || name=.github/workflows/sync-to-beta.yml       || failure
l10n                                     || name=l10n                                     || success
CodeQL                                   || name=Push on development                      || success
```

`l10n` and `CodeQL` reference nothing external, resolve normally and pass. Everything routed through the missing org does not.

So this repo has effectively had **no Code Quality, no branch protection, no release-beta, no release-stable, no sync-to-beta, no openspec-sync and no issue-triage**.

## Verification

The correct ref was confirmed against repos whose CI demonstrably works, not assumed: `openbuild` and `openregister` both call `ConductionNL/.github/.github/workflows/quality.yml@main`, and their Code Quality runs resolve and succeed.

## Expect this to surface real failures

Code Quality has never run here. Turning it on is likely to go red, and that is the point — the findings were always there, just unreported.
