### PR TITLE
sync: port the Codeberg-only shareable schema flag to GitHub

### DIFF
--- a/lib/Settings/pipelinq_register.json
+++ b/lib/Settings/pipelinq_register.json
@@ -851,10 +851,13 @@
         "slug": "pipeline",
         "title": "Pipeline",
         "icon": "Pipe",
-        "version": "3.0.0",
+        "version": "3.1.0",
         "summary": "A thin CRM pipeline config mapping stage rules onto a Deck board",
         "description": "Represents a CRM pipeline configuration — maps pipeline stages to a Deck board and its stacks, preserving CRM-specific semantics (probability, won/closed/default flags) that Deck itself does not model. Board mechanics (columns, cards, drag-and-drop) are provided by the OpenRegister deck leaf. Mapped to Schema.org ItemList.",
         "x-schema-org": "schema:ItemList",
+        "configuration": {
+          "x-openregister-shareable": true
+        },
         "required": [
           "title",
           "stages"


### PR DESCRIPTION
Codeberg is a **backup mirror**; GitHub is primary. This one commit landed only on Codeberg.

## What was missing

`feat(schema): mark pipeline shareable for federated config sharing` (Codeberg #409, 2026-07-26):

```json
"version": "3.0.0"  ->  "3.1.0"
"configuration": { "x-openregister-shareable": true }
```

Verified by searching both trees with git rather than the REST APIs:

| | files mentioning `shareable` |
|---|---|
| Codeberg | 4 — **including `lib/Settings/pipelinq_register.json`** |
| GitHub | 3 — the register file is **not** among them |

## Everything else on Codeberg is already here

- **0 files exist only on Codeberg** — nothing else would have been lost
- GitHub's head is 2026-08-02; Codeberg's is 2026-07-26, so GitHub is a week ahead
- The apparent 2153 "Codeberg-only commits" is a forked history, not missing work — content comparison is the only meaningful measure here

Cherry-pick applied cleanly; the register JSON parses.
