### PR TITLE
ci: dump the seed's actual outcome, to settle openregister#2291 with evidence

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -52,4 +52,10 @@ jobs:
       # NOT find this line, because the org name is embedded in a JSON input
       # rather than a `uses:`. (Fixed concurrently in #671; same value.)
       additional-apps: '[{"repo":"ConductionNL/openregister","app":"openregister","ref":"development"}]'
-      playwright-seed-command: 'php occ app:disable pipelinq && php occ app:enable pipelinq'
+      # TEMPORARY diagnostic for openregister#2291 — remove once settled.
+      # The E2E job reports 150 "relation oc_openregister_table_15_<schema>
+      # does not exist" errors, but a faithful local replication (same
+      # openregister commit, fresh NC + postgres) provisions every table and
+      # cannot reproduce it. This dumps the seed's actual outcome so the next
+      # run says which of the three cases holds instead of us guessing.
+      playwright-seed-command: 'php occ app:disable pipelinq && php occ app:enable pipelinq && php tests/ci/dump-seed-state.php'

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -58,4 +58,4 @@ jobs:
       # openregister commit, fresh NC + postgres) provisions every table and
       # cannot reproduce it. This dumps the seed's actual outcome so the next
       # run says which of the three cases holds instead of us guessing.
-      playwright-seed-command: 'php occ app:disable pipelinq && php occ app:enable pipelinq && php tests/ci/dump-seed-state.php'
+      playwright-seed-command: 'php occ app:disable pipelinq && php occ app:enable pipelinq && php apps/pipelinq/tests/ci/dump-seed-state.php || php custom_apps/pipelinq/tests/ci/dump-seed-state.php || php tests/ci/dump-seed-state.php'

--- a/tests/ci/dump-seed-state.php
+++ b/tests/ci/dump-seed-state.php
@@ -1,0 +1,153 @@
+<?php
+
+/**
+ * CI diagnostic: report what seeding actually produced.
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
+ * TEMPORARY. Delete once openregister#2291 is settled.
+ *
+ * The E2E job fails with 150 `relation "oc_openregister_table_15_<schema>" does
+ * not exist` errors, but a faithful local replication of the same sequence — same
+ * openregister commit, same pipelinq, fresh Nextcloud + postgres — provisions
+ * every table and cannot reproduce it. So the evidence has to come from CI.
+ *
+ * This distinguishes the three possibilities that look identical from the outside:
+ *
+ *   1. the register/schemas were never created      -> registers empty
+ *   2. schemas exist but tables were never made     -> MISSING rows below
+ *   3. both existed and something dropped the table -> nothing missing here,
+ *                                                      but the run still errors
+ *
+ * It also prints the import markers, because OpenRegister tracks import state in
+ * BOTH the database and NC appconfig (`imported_config_<app>_version`/`_hash`).
+ * Truncating the tables alone does not reset it — that asymmetry manufactured a
+ * phantom "0 schemas created" while I was investigating locally, and it is
+ * exactly the kind of thing worth seeing rather than assuming.
+ *
+ * Read-only: this inspects, it never writes.
+ */
+
+require_once '/var/www/html/lib/base.php';
+
+\OC_App::loadApp('openregister');
+\OC_App::loadApp('pipelinq');
+
+/** @var \OCP\IDBConnection $db */
+$db = \OC::$server->get(\OCP\IDBConnection::class);
+
+echo PHP_EOL.'==================== SEED STATE DIAGNOSTIC ===================='.PHP_EOL;
+
+// ---- 1. Import markers (the state a table-truncation does NOT clear). --------
+$appConfig = \OC::$server->get(\OCP\IAppConfig::class);
+echo PHP_EOL.'-- import markers (appconfig) --'.PHP_EOL;
+$found = 0;
+foreach ($appConfig->getKeys('openregister') as $key) {
+    if (str_starts_with($key, 'imported_config_') === true) {
+        $found++;
+        echo sprintf("  %-56s = %s%s", $key, $appConfig->getValueString('openregister', $key), PHP_EOL);
+    }
+}
+
+if ($found === 0) {
+    echo '  (none)'.PHP_EOL;
+}
+
+// ---- 2. Configuration rows. -------------------------------------------------
+echo PHP_EOL.'-- oc_openregister_configurations --'.PHP_EOL;
+try {
+    $q = $db->getQueryBuilder();
+    $q->select('*')->from('openregister_configurations');
+    $rows = $q->executeQuery()->fetchAll();
+    if ($rows === []) {
+        echo '  (none)'.PHP_EOL;
+    }
+
+    foreach ($rows as $row) {
+        // Column is `app`, not `app_id` — verified against the live schema.
+        echo sprintf(
+            "  app=%-22s version=%-10s title=%s%s",
+            (string) ($row['app'] ?? '?'),
+            (string) ($row['version'] ?? '?'),
+            substr((string) ($row['title'] ?? ''), 0, 40),
+            PHP_EOL
+        );
+    }
+} catch (\Throwable $e) {
+    echo '  ERROR reading configurations: '.$e->getMessage().PHP_EOL;
+}
+
+// ---- 3. Registers, schemas, and whether each physical table exists. ----------
+echo PHP_EOL.'-- registers / schemas / tables --'.PHP_EOL;
+
+$missingTotal = 0;
+$schemaTotal  = 0;
+
+try {
+    $q = $db->getQueryBuilder();
+    $q->select('id', 'slug', 'schemas')->from('openregister_registers')->orderBy('id');
+    $registers = $q->executeQuery()->fetchAll();
+
+    if ($registers === []) {
+        echo '  !! NO REGISTERS AT ALL — the import never ran or created nothing'.PHP_EOL;
+    }
+
+    foreach ($registers as $register) {
+        $registerId = (int) $register['id'];
+        $rawSchemas = (string) ($register['schemas'] ?? '[]');
+        $schemaIds  = array_filter(array_map('trim', explode(',', trim($rawSchemas, '[]"'))));
+
+        $missing = [];
+        foreach ($schemaIds as $schemaId) {
+            $schemaId = (int) trim((string) $schemaId, '"\' ');
+            if ($schemaId === 0) {
+                continue;
+            }
+
+            $schemaTotal++;
+            $table = 'oc_openregister_table_'.$registerId.'_'.$schemaId;
+
+            // to_regclass returns NULL when the relation does not exist.
+            $exists = $db->executeQuery(
+                'SELECT to_regclass(?) IS NOT NULL AS present',
+                ['public.'.$table]
+            )->fetchOne();
+
+            if ((bool) $exists === false) {
+                $missing[]     = $schemaId;
+                $missingTotal++;
+            }
+        }
+
+        echo sprintf(
+            "  register %-4d %-24s schemas=%-4d missing_tables=%d%s",
+            $registerId,
+            (string) ($register['slug'] ?? '?'),
+            count($schemaIds),
+            count($missing),
+            PHP_EOL
+        );
+
+        if ($missing !== []) {
+            echo '      MISSING schema ids: '.implode(', ', array_slice($missing, 0, 40)).PHP_EOL;
+        }
+    }
+} catch (\Throwable $e) {
+    echo '  ERROR: '.$e->getMessage().PHP_EOL;
+}
+
+// ---- 4. Verdict. ------------------------------------------------------------
+echo PHP_EOL.'-- verdict --'.PHP_EOL;
+echo sprintf('  schemas checked: %d, tables missing: %d%s', $schemaTotal, $missingTotal, PHP_EOL);
+
+if ($schemaTotal === 0) {
+    echo '  => CASE 1: nothing was seeded (no registers/schemas).'.PHP_EOL;
+} elseif ($missingTotal > 0) {
+    echo '  => CASE 2: schemas exist but their tables were never provisioned.'.PHP_EOL;
+} else {
+    echo '  => CASE 3: every table exists at seed time; any later error is a'.PHP_EOL;
+    echo '             different fault (dropped/renamed later, or a stale id).'.PHP_EOL;
+}
+
+echo '=============================================================='.PHP_EOL.PHP_EOL;

--- a/tests/ci/dump-seed-state.php
+++ b/tests/ci/dump-seed-state.php
@@ -29,7 +29,25 @@
  * Read-only: this inspects, it never writes.
  */
 
-require_once '/var/www/html/lib/base.php';
+// Find the Nextcloud root by walking up from this file rather than hardcoding it.
+// The container puts it at /var/www/html; CI checks it out under
+// /home/runner/work/<repo>/<repo>/server. Hardcoding the container path made this
+// script fatal in CI, which is the one place it needed to run.
+$ncRoot = null;
+for ($dir = __DIR__, $i = 0; $i < 8; $i++) {
+    $dir = dirname($dir);
+    if (is_file($dir.'/lib/base.php') === true) {
+        $ncRoot = $dir;
+        break;
+    }
+}
+
+if ($ncRoot === null) {
+    fwrite(STDERR, 'dump-seed-state: could not locate lib/base.php above '.__DIR__.PHP_EOL);
+    exit(1);
+}
+
+require_once $ncRoot.'/lib/base.php';
 
 \OC_App::loadApp('openregister');
 \OC_App::loadApp('pipelinq');


### PR DESCRIPTION
**Temporary.** Delete once [openregister#2291](https://github.com/ConductionNL/openregister/issues/2291) is settled.

## Why

The E2E job reports 150 `relation "oc_openregister_table_15_<schema>" does not exist` errors across 30 schemas.

I built a disposable reproduction — fresh Nextcloud 34 + postgres 16, openregister at the **same** `development` commit, same pipelinq — and replicated CI's exact sequence (enable openregister, enable pipelinq, then the seed's `disable && enable`). It provisions **108 of 108 tables, twice, idempotently**. The failure does not reproduce locally.

I've already guessed twice and been wrong both times, so I'd rather have CI tell us.

## What it prints

Immediately after the seed, the three things that distinguish otherwise-identical symptoms:

| case | meaning |
|---|---|
| **1** — no registers/schemas | the import never ran |
| **2** — schemas exist, tables don't | provisioning is the fault |
| **3** — everything present | tables are lost *later*, or the failing reads use a stale id |

It also prints the import markers, because OpenRegister tracks import state in **both** the database and NC appconfig (`imported_config_<app>_version` / `_hash`). **Truncating the tables alone does not reset it.** That asymmetry manufactured a phantom "0 schemas created" during my investigation, which I believed for several steps before catching it — worth showing rather than assuming.

## Scope

- Hooked through `playwright-seed-command`, which pipelinq already owns — the shared workflow is untouched.
- **Read-only**: it inspects, never writes.
- Validated against the working disposable instance before shipping (correctly reports CASE 3 there, with the register/schema/table counts it should).
