### PR TITLE
fix(deps): nc-vue 2.1.0-vue3.17 — stop the setup wizard parking over the app

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
 			"version": "0.1.0",
 			"license": "EUPL-1.2",
 			"dependencies": {
-				"@conduction/nextcloud-vue": "2.1.0-vue3.16",
+				"@conduction/nextcloud-vue": "2.1.0-vue3.17",
 				"@nextcloud/axios": "~2.5.2",
 				"@nextcloud/capabilities": "^1.2.1",
 				"@nextcloud/dialogs": "^7.4.1",
@@ -1816,9 +1816,9 @@
 			}
 		},
 		"node_modules/@conduction/nextcloud-vue": {
-			"version": "2.1.0-vue3.16",
-			"resolved": "https://registry.npmjs.org/@conduction/nextcloud-vue/-/nextcloud-vue-2.1.0-vue3.16.tgz",
-			"integrity": "sha512-YPGG5iIdBHRydqwnYbjrSVqriBmdTmjxp5HZiSmT+Ab1eLZ1D5Sv1OAq32kVNJ6ax/SmPjQK+ujMU2bb+wJxOA==",
+			"version": "2.1.0-vue3.17",
+			"resolved": "https://registry.npmjs.org/@conduction/nextcloud-vue/-/nextcloud-vue-2.1.0-vue3.17.tgz",
+			"integrity": "sha512-EcKb/Gf1WEWlkjdt7HFTzjZYxNIMiOZqyGdYK69rJPYhFLIRWKdOK7b+OTEgxk37thznnDaRJRvH3Pb8fAXXpA==",
 			"license": "EUPL-1.2",
 			"dependencies": {
 				"@ckpack/vue-color": "^1.6.0",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
 		"extends @nextcloud/browserslist-config"
 	],
 	"dependencies": {
-		"@conduction/nextcloud-vue": "2.1.0-vue3.16",
+		"@conduction/nextcloud-vue": "2.1.0-vue3.17",
 		"@nextcloud/axios": "~2.5.2",
 		"@nextcloud/capabilities": "^1.2.1",
 		"@nextcloud/dialogs": "^7.4.1",


### PR DESCRIPTION
Unblocks the e2e suite. Consumes the upstream fix in ConductionNL/nextcloud-vue#579.

## Why the suite was failing

pipelinq declares **7** first-time-setup steps; `SetupController::status()` reports a status key for **4**. The optional `demo-data` run-action is reported **nowhere**.

nc-vue mapped a missing key to `done: false`, so an *unreported* step was indistinguishable from an *undone* one and `optionalUnmet` never emptied. `CnAppRoot`'s auto-open watcher consulted only that list and **never the server's own `completed` flag**, so `CnSetupWizard` — a `CnWizardDialog`, i.e. a modal with a focus trap — mounted over the app on every mount without a localStorage dismissal.

Playwright always starts from a clean profile, so e2e hit it **every run**. The app rendered underneath but was inert behind the dialog: that is the ~98 selector timeouts.

`/api/setup/status` answering `200 {completed:true}` throughout is what made this look impossible. The endpoint was never wrong — the consumer just wasn't reading its answer.

(This is also why it reproduced identically on the Vue 2 and Vue 3 bundles: the logic, not the framework, was at fault. And it hits this suite specifically because `tests/e2e/helpers/auth.ts` logs in as **admin** — the separate 403-for-non-admins path, fixed earlier in #574-#577, never applied here.)

## Verified end to end, not by version number

| stage | check |
|---|---|
| published tarball `2.1.0-vue3.17` | guard present in `src/` **and** both dist builds (3685 files extracted — positive control) |
| `node_modules/@conduction/nextcloud-vue` after `npm ci` | 3/3 files carrying `optionalSetupGating` have the guard |
| emitted `js/pipelinq-shared-nc-vue.js` (minified) | `optionalSetupGating(){...Be.completed.value===!0?!1:...}` |
| `npm run build` | **exit 0**, webpack 5.109.2 |
| `npx vitest run` | **45 passed (45)** |

## Licence

`vue3-apexcharts` stays pinned at **1.8.0 / MIT** in the lockfile. 1.9.0+ is proprietary and forbids sublicensing in our EUPL-1.2 apps — confirmed unchanged by this bump.

## Note on `E2E Tests (Playwright)`

That job already fails on the base SHA (`1629d2116`, run 30792660780, jobs `quality / E2E Tests (Playwright)` + `quality / Quality Report`), so a red there pre-dates this change. This PR is the upstream half of the fix; whether the job goes green also depends on the runner having a working instance.