### PR TITLE
ci: give every eligible job a measured timeout-minutes

### DIFF
--- a/.github/workflows/beta-release.yaml
+++ b/.github/workflows/beta-release.yaml
@@ -9,6 +9,9 @@ on:
 jobs:
   release-management:
     runs-on: ubuntu-latest
+    # Observed: n=26 runs, max 0.7 min. Bounded well above that because this job
+    # builds and uploads a release artifact — a slow upload must not be killed.
+    timeout-minutes: 45
     steps:
     
       # Stap 1: Code ophalen

--- a/.github/workflows/l10n.yml
+++ b/.github/workflows/l10n.yml
@@ -13,6 +13,9 @@ jobs:
   l10n:
     name: l10n coverage (en.json)
     runs-on: ubuntu-latest
+    # Observed: n=216 runs, median 0.1 min, max 1.1 min. Bounded loosely so
+    # normal runner contention can never trip it.
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/.github/workflows/release-workflow.yaml
+++ b/.github/workflows/release-workflow.yaml
@@ -15,6 +15,9 @@ on:
 jobs:
   release-management:
     runs-on: ubuntu-latest
+    # Observed: n=26 runs, max 0.7 min. Bounded well above that because this job
+    # builds and uploads a release artifact — a slow upload must not be killed.
+    timeout-minutes: 45
     steps:
     
       - name: Checkout Code
@@ -270,6 +273,8 @@ jobs:
 
   update-changelog:
     runs-on: ubuntu-latest
+    # Observed: ~0.2 min. Checkout + a commit; 15 min is pure headroom.
+    timeout-minutes: 15
     steps:
     
       - name: Checkout Code


### PR DESCRIPTION
Bounds every job in this repo that defines its own `steps:` — **4 jobs**.

| file | job | timeout | basis |
|---|---|---|---|
| `l10n.yml` | `l10n` | 15 | n=216, median 0.1 min, max 1.1 min |
| `beta-release.yaml` | `release-management` | 45 | n=26, max 0.7 min; builds + uploads a release artifact |
| `release-workflow.yaml` | `release-management` | 45 | as above |
| `release-workflow.yaml` | `update-changelog` | 15 | ~0.2 min; checkout + a commit |

## Why

An unbounded job that hangs burns a runner until GitHub's 6-hour ceiling. This gives every job in the repo that defines its own `steps:` a `timeout-minutes`, derived from observed run history, with the observation recorded inline next to the value.

Bounds are deliberately loose. A timeout that fires under normal runner contention is worse than no timeout at all, because it converts a merely slow run into a phantom defect.

## Reusable-workflow callers are deliberately untouched

Most CI in this repo is now delegated to `ConductionNL/.github`. A job that calls a reusable workflow via `uses:` **cannot** take `timeout-minutes` — GitHub rejects the whole file. Verified locally with `actionlint`:

```
when a reusable workflow is called with "uses", "timeout-minutes" is not available.
only following keys are allowed: "name", "uses", "with", "secrets", "needs", "if",
and "permissions" in job "deploy" [syntax-check]
```

Control (same file, unmodified) lints clean; the variant with `timeout-minutes` added fails. So those jobs are bounded inside `ConductionNL/.github` instead, not here — adding one here would take CI from "slow" to "does not start".

## Verification

- Every touched file re-parsed with `yaml.safe_load`; **job set unchanged**, each job carries exactly the intended value.
- Positive control: every job **not** targeted still reports `timeout-minutes: None`, and no `uses:` job carries one.
- `actionlint` run on base (`development`) vs head for the touched files: **identical finding counts**, so this change introduces zero new findings. (The pre-existing `actions/checkout@v2|v3` "runner too old" warnings are untouched and predate this PR.)
- Diff is workflow files only, additions only.
