### PR TITLE
chore(deps): upgrade @conduction/nextcloud-vue to 3.0.0-vue3.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
 			"version": "0.1.0",
 			"license": "EUPL-1.2",
 			"dependencies": {
-				"@conduction/nextcloud-vue": "3.0.0-vue3.2",
+				"@conduction/nextcloud-vue": "3.0.0-vue3.4",
 				"@nextcloud/axios": "~2.5.2",
 				"@nextcloud/capabilities": "^1.2.1",
 				"@nextcloud/dialogs": "^7.4.1",
@@ -1816,9 +1816,9 @@
 			}
 		},
 		"node_modules/@conduction/nextcloud-vue": {
-			"version": "3.0.0-vue3.2",
-			"resolved": "https://registry.npmjs.org/@conduction/nextcloud-vue/-/nextcloud-vue-3.0.0-vue3.2.tgz",
-			"integrity": "sha512-Ge6uW0lJHAdZ/mlWgrfGTrSIeh2waSCOS4n8m2SSCDv9rpw1lHw8hPK5VdvYym+5+sj8OUU+xP9f5bSmclF7Yg==",
+			"version": "3.0.0-vue3.4",
+			"resolved": "https://registry.npmjs.org/@conduction/nextcloud-vue/-/nextcloud-vue-3.0.0-vue3.4.tgz",
+			"integrity": "sha512-+x6lUVhpoZsozAW5S20C9Y3KHhLo5+0MIqKi00lJlK+yOHuJxBoZlra7ijaY0Wk0TOs6iBdhmbGNYptJa1Pkwg==",
 			"license": "EUPL-1.2",
 			"dependencies": {
 				"@ckpack/vue-color": "^1.6.0",
@@ -8263,9 +8263,9 @@
 			"optional": true
 		},
 		"node_modules/electron-to-chromium": {
-			"version": "1.5.399",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.399.tgz",
-			"integrity": "sha512-lEcqhErbHjXRvd41rnWLpzbyU/IXfIYo7QwaFWmxGeLiLyY2TBCdHnWY88vB+p3ubnihRypDm66panXl7TylLA==",
+			"version": "1.5.400",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.400.tgz",
+			"integrity": "sha512-96EWDNjM59SYflgeV5Ylsf4EMiq1a25YjCnJH7cxn/AF2H3pILRweaUnoLax0yKHWdpOzY6JKEu45e8irqZIHA==",
 			"dev": true,
 			"license": "ISC"
 		},

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
 			"version": "0.1.0",
 			"license": "EUPL-1.2",
 			"dependencies": {
-				"@conduction/nextcloud-vue": "2.1.0-vue3.17",
+				"@conduction/nextcloud-vue": "3.0.0-vue3.2",
 				"@nextcloud/axios": "~2.5.2",
 				"@nextcloud/capabilities": "^1.2.1",
 				"@nextcloud/dialogs": "^7.4.1",
@@ -1816,9 +1816,9 @@
 			}
 		},
 		"node_modules/@conduction/nextcloud-vue": {
-			"version": "2.1.0-vue3.17",
-			"resolved": "https://registry.npmjs.org/@conduction/nextcloud-vue/-/nextcloud-vue-2.1.0-vue3.17.tgz",
-			"integrity": "sha512-EcKb/Gf1WEWlkjdt7HFTzjZYxNIMiOZqyGdYK69rJPYhFLIRWKdOK7b+OTEgxk37thznnDaRJRvH3Pb8fAXXpA==",
+			"version": "3.0.0-vue3.2",
+			"resolved": "https://registry.npmjs.org/@conduction/nextcloud-vue/-/nextcloud-vue-3.0.0-vue3.2.tgz",
+			"integrity": "sha512-Ge6uW0lJHAdZ/mlWgrfGTrSIeh2waSCOS4n8m2SSCDv9rpw1lHw8hPK5VdvYym+5+sj8OUU+xP9f5bSmclF7Yg==",
 			"license": "EUPL-1.2",
 			"dependencies": {
 				"@ckpack/vue-color": "^1.6.0",
@@ -6693,9 +6693,9 @@
 			"license": "MIT"
 		},
 		"node_modules/baseline-browser-mapping": {
-			"version": "2.11.11",
-			"resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.11.tgz",
-			"integrity": "sha512-/yImnXwyTvgMkhgekLHok/Rx5vO6E0BmStWlSqKWMVm2a2ITuZ1Tn+9bgLS+gZRdZmWtd8nxuhHpdmCUOWsTQQ==",
+			"version": "2.11.12",
+			"resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.12.tgz",
+			"integrity": "sha512-r7WnVImvVCeFpf2DOXfy41aPWzeNg3H/A2X4dKmy1QL0MSyyk/e7z8ihJ3N6Nn2PsdhkVlqnEfnUE4a05P2aTA==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"bin": {
@@ -7164,6 +7164,19 @@
 			},
 			"engines": {
 				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/camelcase-keys/node_modules/type-fest": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.4.0.tgz",
+			"integrity": "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==",
+			"dev": true,
+			"license": "(MIT OR CC0-1.0)",
+			"engines": {
+				"node": ">=10"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
@@ -8204,9 +8217,9 @@
 			}
 		},
 		"node_modules/dompurify": {
-			"version": "3.4.12",
-			"resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.12.tgz",
-			"integrity": "sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==",
+			"version": "3.4.13",
+			"resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.13.tgz",
+			"integrity": "sha512-2vmYIoqjze2d+kakP8S/nS5shfsl587kzwEjcGlTdiksUVgFHnFCsLYDVj/JNqJVOQZGSYBTmuycv0PodwmnMQ==",
 			"license": "(MPL-2.0 OR Apache-2.0)",
 			"optionalDependencies": {
 				"@types/trusted-types": "^2.0.7"
@@ -10761,6 +10774,75 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/import-local/node_modules/find-up": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+			"integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"locate-path": "^5.0.0",
+				"path-exists": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/import-local/node_modules/locate-path": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+			"integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"p-locate": "^4.1.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/import-local/node_modules/p-limit": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+			"integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"p-try": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/import-local/node_modules/p-locate": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+			"integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"p-limit": "^2.2.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/import-local/node_modules/pkg-dir": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
+			"integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"find-up": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
 		"node_modules/imurmurhash": {
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
@@ -12261,6 +12343,19 @@
 				"node": ">=10"
 			}
 		},
+		"node_modules/meow/node_modules/type-fest": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.4.0.tgz",
+			"integrity": "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==",
+			"dev": true,
+			"license": "(MIT OR CC0-1.0)",
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/meow/node_modules/yallist": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
@@ -13140,9 +13235,9 @@
 			"optional": true
 		},
 		"node_modules/nanoid": {
-			"version": "3.3.16",
-			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-			"integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+			"version": "3.3.17",
+			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
+			"integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
 			"funding": [
 				{
 					"type": "github",
@@ -13421,18 +13516,6 @@
 				"webpack": ">=5"
 			}
 		},
-		"node_modules/node-polyfill-webpack-plugin/node_modules/type-fest": {
-			"version": "4.41.0",
-			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
-			"integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
-			"license": "(MIT OR CC0-1.0)",
-			"engines": {
-				"node": ">=16"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
 		"node_modules/node-releases": {
 			"version": "2.0.51",
 			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.51.tgz",
@@ -13476,18 +13559,6 @@
 				"url": "^0.11.4",
 				"util": "^0.12.4",
 				"vm-browserify": "^1.0.1"
-			},
-			"engines": {
-				"node": ">=10"
-			}
-		},
-		"node_modules/node-stdlib-browser/node_modules/pkg-dir": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-5.0.0.tgz",
-			"integrity": "sha512-NPE8TDbzl/3YQYY7CSS228s3g2ollTFnc+Qi3tqmqJp9Vg2ovUpixcJEo2HJScN2Ez+kEaal6y70c0ehqJBJeA==",
-			"license": "MIT",
-			"dependencies": {
-				"find-up": "^5.0.0"
 			},
 			"engines": {
 				"node": ">=10"
@@ -14159,72 +14230,15 @@
 			}
 		},
 		"node_modules/pkg-dir": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
-			"integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"find-up": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/pkg-dir/node_modules/find-up": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
-			"integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"locate-path": "^5.0.0",
-				"path-exists": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/pkg-dir/node_modules/locate-path": {
 			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
-			"integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
-			"dev": true,
+			"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-5.0.0.tgz",
+			"integrity": "sha512-NPE8TDbzl/3YQYY7CSS228s3g2ollTFnc+Qi3tqmqJp9Vg2ovUpixcJEo2HJScN2Ez+kEaal6y70c0ehqJBJeA==",
 			"license": "MIT",
 			"dependencies": {
-				"p-locate": "^4.1.0"
+				"find-up": "^5.0.0"
 			},
 			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/pkg-dir/node_modules/p-limit": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-			"integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"p-try": "^2.0.0"
-			},
-			"engines": {
-				"node": ">=6"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/pkg-dir/node_modules/p-locate": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
-			"integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"p-limit": "^2.2.0"
-			},
-			"engines": {
-				"node": ">=8"
+				"node": ">=10"
 			}
 		},
 		"node_modules/pkg-types": {
@@ -14952,6 +14966,19 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/read-pkg-up/node_modules/type-fest": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.4.0.tgz",
+			"integrity": "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==",
+			"dev": true,
+			"license": "(MIT OR CC0-1.0)",
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/read-pkg/node_modules/hosted-git-info": {
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.1.0.tgz",
@@ -15005,6 +15032,19 @@
 			},
 			"engines": {
 				"node": ">=10"
+			}
+		},
+		"node_modules/read-pkg/node_modules/type-fest": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.4.0.tgz",
+			"integrity": "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==",
+			"dev": true,
+			"license": "(MIT OR CC0-1.0)",
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/read-pkg/node_modules/yallist": {
@@ -17402,13 +17442,12 @@
 			}
 		},
 		"node_modules/type-fest": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.4.0.tgz",
-			"integrity": "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==",
-			"dev": true,
+			"version": "4.41.0",
+			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+			"integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
 			"license": "(MIT OR CC0-1.0)",
 			"engines": {
-				"node": ">=10"
+				"node": ">=16"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
 		"extends @nextcloud/browserslist-config"
 	],
 	"dependencies": {
-		"@conduction/nextcloud-vue": "3.0.0-vue3.2",
+		"@conduction/nextcloud-vue": "3.0.0-vue3.4",
 		"@nextcloud/axios": "~2.5.2",
 		"@nextcloud/capabilities": "^1.2.1",
 		"@nextcloud/dialogs": "^7.4.1",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
 		"extends @nextcloud/browserslist-config"
 	],
 	"dependencies": {
-		"@conduction/nextcloud-vue": "2.1.0-vue3.17",
+		"@conduction/nextcloud-vue": "3.0.0-vue3.2",
 		"@nextcloud/axios": "~2.5.2",
 		"@nextcloud/capabilities": "^1.2.1",
 		"@nextcloud/dialogs": "^7.4.1",


### PR DESCRIPTION
## What

Upgrades `@conduction/nextcloud-vue` from `2.1.0-vue3.17` to **`3.0.0-vue3.4`**, pinned exactly (no caret, no tilde).

> **Note on the branch name:** this branch is called `chore/ncvue-3.0.0-vue3.2` because it originally targeted `3.0.0-vue3.2`. It now ships **`3.0.0-vue3.4`**. The branch was deliberately not renamed — renaming would close and recreate this PR.

## Version shipped

| | |
|---|---|
| `package.json` pin | `"@conduction/nextcloud-vue": "3.0.0-vue3.4"` |
| Lockfile resolved | `https://registry.npmjs.org/@conduction/nextcloud-vue/-/nextcloud-vue-3.0.0-vue3.4.tgz` |
| Installed on disk | `node_modules/@conduction/nextcloud-vue/package.json` → `"version": "3.0.0-vue3.4"` |

## Lockfile verification

Regenerated from scratch (`rm -rf package-lock.json node_modules`), then npm 11 `npm install` → npm 10 `npm install --package-lock-only` → npm 10 `npm ci`.

- `@conduction/nextcloud-vue` resolves to the `3.0.0-vue3.4` tarball — exact, no range.
- **`vue3-apexcharts` stays at `1.8.0` (MIT)** — below the `1.9.0` proprietary relicense that forbids sublicensing and would conflict with this app's EUPL-1.2. No override was needed to hold it there; the constraint `~1.8.0` does it.
- Lockfile size sane: 19,538 lines / 644 KB, **1,384** `node_modules/` entries, 792 top-level dirs installed. No `"//"` key anywhere in `package.json` or `package-lock.json` (a `//` key inside `overrides` makes npm resolve zero deps while still reporting "up to date").
- `.npmrc` in this repo already carries `min-release-age=0` (committed in `bd77f6cc`), so no `--min-release-age` override was needed and `.npmrc` is untouched.

## Breaking surface — the three removed components

`3.0.0` removed exactly `CnFlowCanvas`, `CnEditFlowsModal` and `CnFlowCanvasModal`. pipelinq is flow-oriented, so this was checked carefully rather than assumed.

**Result: ZERO references in `src/` and ZERO in the built `js/`.**

Both greps were positive-controlled, because an absence claim is exactly what a broken grep manufactures for free:

1. **Control over `src/`** — the same `grep -rlF` invocation that returns nothing for the three removed names returns **11 files** for `CnDetailPage` and hits for `CnDashboardPage`. A broader sweep for any `CnFlow` / `CnEditFlows` substring in `src/` also returns nothing (grep's own exit code `1`).
2. **Control over `js/`** — the same invocation over the 41 built bundles (41 MB) returns nothing for the three removed names, but returns 2 files for `CnDetailPage` and 4 for `CnDashboardPage`.
3. **Removed-vs-retained checked against the installed library** — in `node_modules/@conduction/nextcloud-vue/dist/esm/index.js`: `CnFlowCanvas` 0, `CnEditFlowsModal` 0, `CnFlowCanvasModal` 0, while `CnFlowEditModal` 1, `CnDashboardPage` 1, `CnDetailPage` 1. So the three names are genuinely gone from the library and the retained siblings are genuinely present — the grep distinguishes them.

**One clarification worth recording:** `CnFlowEditModal` (a *retained* component) **does** appear in `js/pipelinq-shared-nc-vue.js`. That is not evidence the app imports flow components. `src/` imports nc-vue through the **barrel** (`from '@conduction/nextcloud-vue'`) and `webpack.config.js` puts the whole nc-vue package into a dedicated `shared-nc-vue` cacheGroup, so the entire library surface lands in that chunk regardless of what the app names. `src/` contains no reference to `CnFlowEditModal` either.

## Local gates

| Gate | Command | Result |
|---|---|---|
| Build | `USE_LOCAL_LIB=false npm run build` | **pass** — webpack 5.109.2 compiled with 6 warnings, 0 errors |
| Lint | `npm run lint` | **pass** — 341 problems, **0 errors**, 341 warnings (all pre-existing: jsdoc + `OC.currentUser` deprecations) |
| Unit tests | `npm run test:unit` | **pass** — 6 files, **45/45 tests passed** |

Toolchain: npm 11.13.0 / node v22.22.0 for resolution; npm 10.9.8 / node v20.20.2 for `--package-lock-only`, `ci`, build, lint and tests.

## Why this PR was `BLOCKED`

For the record, since it was not a failing check:

- Org ruleset `14128349` applies a `pull_request` rule with `required_approving_review_count: 1` → `reviewDecision: REVIEW_REQUIRED`.
- The legacy branch protection on `development` additionally requires the status contexts `PHP Quality`, `Frontend Quality` and `Branch Policy Check`. No workflow reports those context names — the actual checks are named `quality / PHP Quality (phpcs)` and so on — so the combined status sits permanently at `state: pending` with an empty `statuses` array. Those three contexts can never turn green as configured.

The branch was already based on the current `development` tip (`6a693a1a`), so being out of date was not a factor and no rebase was required.
