### PR TITLE
ci: rename branch-protection caller job id to `branch-protection`

### DIFF
--- a/.github/workflows/branch-protection.yml
+++ b/.github/workflows/branch-protection.yml
@@ -5,5 +5,10 @@ on:
     branches: [main, beta]
 
 jobs:
-  check:
+  # Job id must stay `branch-protection` so the check reports as
+  # `branch-protection / check-branch`, which is the context name the org
+  # ruleset requires. GitHub names a reusable-workflow context
+  # `<caller-job-id> / <called-job-name>`, so renaming this job silently
+  # detaches the required status check and leaves PRs permanently pending.
+  branch-protection:
     uses: ConductionNL/.github/.github/workflows/branch-protection.yml@main


### PR DESCRIPTION
GitHub names a reusable-workflow status context `<caller-job-id> / <called-job-name>`.

This repo's caller job id was **not** `branch-protection`, so the shared branch-protection
workflow reported under the wrong context name. The org rulesets (`Main Branch Protection`
id 14128365, `Beta Branch Protection` id 14128357) require exactly:

```
branch-protection / check-branch
quality / Quality Report
```

No name match means the required context never reported **at all** — not as a failure, as
*nothing*. The PR sits at `BLOCKED` forever, and the absence of the check is visually identical to
the check merely not having finished yet. That is the whole defect: a check's absence looks
exactly like its success is still pending.

This renames the caller job id so the context matches. It does **not** change what is required and
does **not** touch any ruleset or branch protection — that is a governance decision, not a code
one.

Irony worth recording: this PR itself has to be admin-merged, because the defect it fixes is
precisely what makes the required context unreportable on the current tip.