### PR TITLE
ci: rename branch-protection caller job id to `branch-protection`

### DIFF
--- a/.github/workflows/branch-protection.yml
+++ b/.github/workflows/branch-protection.yml
@@ -5,5 +5,10 @@ on:
     branches: [main, beta]
 
 jobs:
-  check:
+  # Job id must stay `branch-protection` so the check reports as
+  # `branch-protection / check-branch`, which is the context name the org
+  # ruleset requires. GitHub names a reusable-workflow context
+  # `<caller-job-id> / <called-job-name>`, so renaming this job silently
+  # detaches the required status check and leaves PRs permanently pending.
+  branch-protection:
     uses: ConductionNL/.github/.github/workflows/branch-protection.yml@main


### PR DESCRIPTION
GitHub names a reusable-workflow status context `<caller-job-id> / <called-job-name>`.

`development` is the head branch of the `development -> beta` release PRs, so **development's
tip is what decides the context name on those PRs** — not beta's. With a caller job id other
than `branch-protection`, the org ruleset requirement `branch-protection / check-branch` never
reported on any release PR, leaving them permanently `BLOCKED`.

This renames the caller job id so the context matches. It does **not** change what is required and
does **not** touch any ruleset or branch protection.