### PR TITLE
fix(ui): NcButton `native-type` is inert on @nextcloud/vue 9 — two forms never submitted

### DIFF
--- a/src/views/dashboard/widgets/NaviAnalyticsWidget.vue
+++ b/src/views/dashboard/widgets/NaviAnalyticsWidget.vue
@@ -81,7 +81,7 @@
 				class="navi-widget__input" />
 			<NcButton
 				variant="primary"
-				native-type="submit"
+				type="submit"
 				:disabled="loading || !query.trim()">
 				{{ t('pipelinq', 'Send') }}
 			</NcButton>

--- a/src/views/loyalty/LoyaltyAccountCreation.vue
+++ b/src/views/loyalty/LoyaltyAccountCreation.vue
@@ -39,7 +39,7 @@
 				</a>
 			</p>
 
-			<NcButton variant="primary" native-type="submit" :disabled="!canSubmit">
+			<NcButton variant="primary" type="submit" :disabled="!canSubmit">
 				{{ t('pipelinq', 'Create loyalty account') }}
 			</NcButton>
 		</form>


### PR DESCRIPTION
## The defect

`@nextcloud/vue` 9 renamed `NcButton`'s visual prop `type` → `variant` and **repurposed `type` as the native button type**, with `default: "button"`. `nativeType` was removed outright — it was the v8 name.

So `native-type="submit"` on v9 is an **undeclared prop**: it falls through to the DOM as an inert attribute while the button keeps `type="button"`. A `type="button"` inside a `<form>` raises no submit event, so `@submit.prevent` never runs.

**No console warning, no lint error, no failed request** — it looks exactly like a backend that was never called.

This repo is on `@nextcloud/vue` `^9.9.0`, lockfile-resolved to **9.9.0** (checked in the lockfile, not the caret).

## The two sites

Both already used `variant=` (the v9 visual prop), so these were **half-finished v8→v9 migrations** where only the button type was missed. Each verified per-site to sit inside a form with a submit handler:

| site | enclosing form |
|---|---|
| `src/views/dashboard/widgets/NaviAnalyticsWidget.vue:84` | `<form class="navi-widget__form" @submit.prevent="submitQuery">` |
| `src/views/loyalty/LoyaltyAccountCreation.vue:42` | `<form @submit.prevent="enroll">` |

Both are `native-type="submit"` → `type="submit"`. `git grep native-type -- src` now returns nothing.

User-facing impact: the Navi analytics widget's **Send** button and the **Create loyalty account** button did nothing when clicked.

## Evidence

Behaviour is proven in **ConductionNL/openconnector#1140**, which mounts the *real* `NcButton` from the installed 9.9.0 and asserts DOM behaviour, with negative controls:

| spelling | renders | submit handler |
|---|---|---|
| `type="submit"` (the fix) | `type=submit` | **fires** |
| `native-type="submit"` (the bug) | `type=button` | **never fires** |

That test is mutation-checked — flipping the fix assertion back to the broken spelling makes it fail, so the assertion is shown capable of failing rather than merely passing.

The component-level mechanism is shared by both sites here. What is verified by reading rather than execution is that each of these *specific* forms wraps its button — the table above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)