### PR TITLE
ci: enable the Hydra mechanical gate tier — it has never run in this repo

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -57,6 +57,36 @@ jobs:
       enable-frontend: true
       enable-eslint: true
       enable-sbom: true
+      # Run the Hydra mechanical quality gates against this PR's diff.
+      #
+      # This tier has never executed in this repository. `enable-hydra-gates`
+      # defaults to false, so `quality / Hydra Gates` has been SKIPPED on every
+      # run here — and a skipped job is neither a pass nor a failure in the
+      # Quality Report rollup, so its absence has been indistinguishable from
+      # its success.
+      #
+      # Measured before switching on, not assumed. Running the v1.0.1 package
+      # locally against this repo's most recent merged PR diff reported ALL
+      # GATES PASSED (58 of 61 reporting; 4, 24 and 33 have no prerequisite
+      # here). The whole-tree audit does show 8 gate-61 (listener-work-placement)
+      # registrations carrying inherited debt — that is a real work-list, but
+      # gate-61 is diff-scoped in both full and scoped runs, so it reports zero
+      # on untouched trees and will not block unrelated PRs.
+      #
+      # No count is written here on purpose: the number of gates depends on the
+      # pin below and the number that run depends on this repo's diff and
+      # toolchain. The package prints both (`COVERAGE: N of M`) in the job log.
+      # See https://github.com/ConductionNL/.github/tree/main/hydra-gates
+      #
+      # Pinned to a tag, not `main`, so a change to the gate package cannot
+      # alter this repository's verdict without a commit here to move the pin.
+      # v1.0.1 is the pin openbuild and openregister already run.
+      enable-hydra-gates: true
+      hydra-gates-ref: v1.0.1
+      # `enable-axe` deliberately NOT set: it produces the report gate-33
+      # consumes, and a vanilla Nextcloud already carries serious/critical axe
+      # violations, so enabling it here would mix "this repo has a defect" with
+      # "core does". Separate change. gate-33 reports SKIPPED meanwhile.
       enable-phpunit: true
       # Newman: tests/newman/pipelinq-api.postman_collection.json doesn't pass
       # against a freshly-installed NC yet — the CRM endpoints need the


### PR DESCRIPTION
## What this turns on

`quality / Hydra Gates` — the mechanical gate tier from `conduction/hydra-gates` — has **never executed in this repository**.

`enable-hydra-gates` defaults to `false` in the shared workflow, and this caller never set it. So the job has been **SKIPPED on every run this repo has ever had**. A skipped job is neither a pass nor a failure in the Quality Report rollup, which means the gate tier's *absence* has been indistinguishable from its *success*.

Across the 18 repositories that call the shared quality workflow, **openbuild was the only one with this tier on.**

## Measured before switching on, not assumed

The v1.0.1 gate package was run locally against this repository's most recent merged PR diff before this PR was opened:

```
[hydra-gates] COVERAGE: 58 of 61 declared gates reported a result.
[hydra-gates] GATES THAT DID NOT RUN: 4 24 33
[hydra-gates] RESULT: ALL GATES PASSED — EXCEPT GATES 4 24 33, WHICH DID NOT RUN.
```

Gates 4, 24 and 33 have no prerequisite in this repo and report SKIPPED — they checked nothing, and the green above says nothing about them.

## Diff-scoping was verified with a control pair, not taken on faith

The claim that the gates are diff-scoped (ADR-020) and therefore cannot block unrelated work was tested on a repo that carries real gate-61 debt:

| control | scope | result |
|---|---|---|
| touch a listener that *does* violate ADR-078 | 1 in scope, 8 out of scope | **FAIL** ✅ |
| touch an unrelated file only | 0 in scope, 9 out of scope | **PASS**, 0 findings ✅ |

The gate can fail, and it stays quiet on untouched trees. A pass here is therefore evidence, not silence.

## The `needs: [playwright]` edge does not delete this job

`hydra-gates` declares `needs: [..., playwright]`, and `needs:` implies `success()` — which would make the whole job vanish for any repo with the gates on and Playwright off, with no red, no skip and no trace. The shared workflow guards that with `if: ${{ inputs.enable-hydra-gates && !cancelled() }}`.

Verified live rather than assumed: on **openbuild** run [30911188960](https://github.com/ConductionNL/openbuild/actions/runs/30911188960), `E2E Tests (Playwright)` was **skipped** and `Hydra Gates` still ran to success.

## The pin

`hydra-gates-ref: v1.0.1`, not `main`, so a change to the gate package cannot move this repository's verdict without a commit here. It is the pin openbuild and openregister already run, which keeps results comparable across the fleet. `v1.1.0` exists; moving to it is a separate, measurable change.

## What is deliberately *not* enabled

`enable-axe` stays off. It produces `tests/axe/report.json`, the file gate-33 consumes. Measured against a vanilla Nextcloud with no app installed, **core's own pages already carry serious/critical axe violations**, so enabling it here would mix "this repo has an accessibility defect" with "Nextcloud core does". Separate change.

## Expected outcome

Red is an acceptable result. **No gate has been weakened, baselined or suppressed** to get a green.
