### PR TITLE
chore(deps): move to @conduction/nextcloud-vue 2.2.0-vue3.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
 			"version": "0.1.0",
 			"license": "EUPL-1.2",
 			"dependencies": {
-				"@conduction/nextcloud-vue": "2.2.0-vue3.1",
+				"@conduction/nextcloud-vue": "2.2.0-vue3.3",
 				"@nextcloud/axios": "~2.5.2",
 				"@nextcloud/capabilities": "^1.2.1",
 				"@nextcloud/dialogs": "^7.4.1",
@@ -1816,9 +1816,9 @@
 			}
 		},
 		"node_modules/@conduction/nextcloud-vue": {
-			"version": "2.2.0-vue3.1",
-			"resolved": "https://registry.npmjs.org/@conduction/nextcloud-vue/-/nextcloud-vue-2.2.0-vue3.1.tgz",
-			"integrity": "sha512-NXxYi52JDn3QHvlo23bLoY6Gm/ecnj95PO89cZ8hFqP/sWyzkajM4agcID//p0v+t/ESS+8Q2R1dfLwqyCmMdQ==",
+			"version": "2.2.0-vue3.3",
+			"resolved": "https://registry.npmjs.org/@conduction/nextcloud-vue/-/nextcloud-vue-2.2.0-vue3.3.tgz",
+			"integrity": "sha512-kO6qtFPnQx1gNFZO/l5YVaSnpnsJspaqazWn5pWiwpma1DbTO9Oa6Jfk5svzFOfR85QB37HKqDqL0JnHpKiXJw==",
 			"license": "EUPL-1.2",
 			"dependencies": {
 				"@ckpack/vue-color": "^1.6.0",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
 		"extends @nextcloud/browserslist-config"
 	],
 	"dependencies": {
-		"@conduction/nextcloud-vue": "2.2.0-vue3.1",
+		"@conduction/nextcloud-vue": "2.2.0-vue3.3",
 		"@nextcloud/axios": "~2.5.2",
 		"@nextcloud/capabilities": "^1.2.1",
 		"@nextcloud/dialogs": "^7.4.1",


### PR DESCRIPTION
Moves to the current head of the resumed 2.x line. The apps landed on `2.2.0-vue3.1`; two releases have shipped since.

| Release | Contents |
|---|---|
| `2.2.0-vue3.2` | four dashboard defects — date-range chip shows its dates and calendar-aligned presets, a dangling `labelResolve` no longer renders a raw UUID, the table's "View all" pins to the bottom instead of scrolling away |
| `2.2.0-vue3.3` | gridstack's stylesheet ships with the library that requires it; CnFormDialog splits over-long schema descriptions behind an info popover; CnContextMenu closes again on outside press and stops hijacking every popper with a cursor transform |

### Verification

- **Lockfile** regenerated with **npm 10.8.2**, matching CI's node 20 toolchain. Local npm 11 prunes optional entries that do not apply to the current platform, which makes CI's `npm ci` fail with `Missing: ... from lock file`. Running `npm ci` locally does **not** reproduce it — npm 11 accepts the lockfile it just wrote. Checked with `npx npm@10.8.2 ci --dry-run` (exit 0).
- **Build** run as `USE_LOCAL_LIB=false npm run build` — exit 0, no unresolved modules, and no reference to a sibling `nextcloud-vue` checkout. That flag is load-bearing: `webpack.config.js` aliases `@conduction/nextcloud-vue` to `../nextcloud-vue/src` when that sibling exists, so a plain build can silently compile the sibling instead of the package under test.