### PR TITLE
ci(quality): move the hydra-gates pin v1.0.1 -> v1.3.0

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -80,9 +80,17 @@ jobs:
       #
       # Pinned to a tag, not `main`, so a change to the gate package cannot
       # alter this repository's verdict without a commit here to move the pin.
-      # v1.0.1 is the pin openbuild and openregister already run.
+      # v1.0.1 was the pin openbuild and openregister ran when this was written.
       enable-hydra-gates: true
-      hydra-gates-ref: v1.0.1
+      # PIN MOVED v1.0.1 -> v1.3.0. `hydra-gates-require-full-coverage`
+      # (default ON) fails a run when a gate whose subject matter EXISTS did
+      # not report; its contract is that a not-applicable gate must DECLARE
+      # itself. v1.0.1 contains ZERO `_skip` calls — no na/structural/wiring
+      # vocabulary at all — so such a gate emits NOTHING and is counted as
+      # "DID NOT RUN". v1.3.0 ships 36 such declarations. Measured on doriath
+      # (PR #160): gates 4/24/33 went from unexplained "DID NOT RUN" to
+      # explicit NOT APPLICABLE, and Hydra Gates went failure -> success.
+      hydra-gates-ref: v1.3.0
       # `enable-axe` deliberately NOT set: it produces the report gate-33
       # consumes, and a vanilla Nextcloud already carries serious/critical axe
       # violations, so enabling it here would mix "this repo has a defect" with


### PR DESCRIPTION
## Why

Every repo in the fleet pins `hydra-gates-ref: v1.0.1`, and `hydra-gates-require-full-coverage` defaults to **true**. That input fails a run when a gate whose subject matter EXISTS did not report — its contract being that a legitimately not-applicable gate must **declare** itself: *"A gate that emits nothing at all still counts against coverage: not-applicable must be DECLARED."*

**`v1.0.1` contains ZERO `_skip` calls.** It has no `na` / `structural` / `wiring` vocabulary at all, so any gate whose prerequisite is absent emits **nothing** and is counted as "DID NOT RUN". **`v1.3.0` contains 36 such declarations.**

## Proof

doriath PR #160 (merged) bumped only this pin. Hydra Gates went **failure -> success**, and gates 4/24/33 moved from unexplained "DID NOT RUN" to explicit NOT APPLICABLE with a named reason each.

Worth recording, because the prevailing theory is wrong: gates 24 and 33 are **not** starved by skipped Newman/Playwright producers. In that same doriath run Playwright PASSED and Newman RAN, and 24/33 still did not report. gate-24's input is `scripts/check-integration-parity.sh` in the repo; gate-33's input is `tests/axe/report.json`, written only when `enable-axe: true`. The pin is the fix.

## Note

v1.3.0 declares 63 gates where v1.0.1 declared 61, so new gates may surface **real** findings. That is a desirable outcome, not a regression — any such failure is left enabled and unsuppressed.