### PR TITLE
chore: normalise licence declarations to EUPL-1.2

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,4 +1,4 @@
-<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+<!-- SPDX-License-Identifier: EUPL-1.2 -->
 <!-- Copyright (C) 2026 Conduction B.V. -->
 
 <!--

--- a/src/main.js
+++ b/src/main.js
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: EUPL-1.2
 // Copyright (C) 2026 Conduction B.V.
 
 import { createApp, h, markRaw } from 'vue'

--- a/src/utils/widgetText.js
+++ b/src/utils/widgetText.js
@@ -1,6 +1,6 @@
 /**
  * SPDX-FileCopyrightText: 2026 Pipelinq Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: EUPL-1.2
  */
 
 /**

--- a/src/views/pipeline/PipelineBoard.vue
+++ b/src/views/pipeline/PipelineBoard.vue
@@ -1,4 +1,4 @@
-<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+<!-- SPDX-License-Identifier: EUPL-1.2 -->
 <!-- Copyright (C) 2026 Conduction B.V. -->
 
 <template>

--- a/src/views/pipeline/PipelineCard.vue
+++ b/src/views/pipeline/PipelineCard.vue
@@ -1,4 +1,4 @@
-<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+<!-- SPDX-License-Identifier: EUPL-1.2 -->
 <!-- Copyright (C) 2026 Conduction B.V. -->
 
 <template>

--- a/tests/e2e/docs-screenshots.spec.ts
+++ b/tests/e2e/docs-screenshots.spec.ts
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2026 Pipelinq Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: EUPL-1.2
  *
  * Documentation screenshot capture suite — pipelinq.
  *

--- a/tests/e2e/global-setup.ts
+++ b/tests/e2e/global-setup.ts
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2026 Pipelinq Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: EUPL-1.2
  *
  * Playwright globalSetup — logs into Nextcloud once and persists the
  * resulting cookie jar / localStorage to `tests/e2e/.auth/user.json`.

--- a/tests/e2e/helpers/pipelinq.ts
+++ b/tests/e2e/helpers/pipelinq.ts
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2026 Pipelinq Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: EUPL-1.2
  *
  * Shared helpers for the spec-coverage e2e suite.
  *

--- a/tests/e2e/spec-coverage/admin-settings.spec.ts
+++ b/tests/e2e/spec-coverage/admin-settings.spec.ts
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2026 Pipelinq Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: EUPL-1.2
  *
  * Gate-19 e2e coverage for openspec/specs/admin-settings/spec.md
  * UI-observable scenarios: admin settings page loads, navigation, structure.

--- a/tests/e2e/spec-coverage/barcode-lookup.spec.ts
+++ b/tests/e2e/spec-coverage/barcode-lookup.spec.ts
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2026 Pipelinq Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: EUPL-1.2
  *
  * Gate-19 behavioral e2e coverage for the Barcode lookup page
  * (/products-barcode). Maps to openspec/specs/pos-barcode-scan/spec.md.

--- a/tests/e2e/spec-coverage/bi-export-jobs-bug.spec.ts
+++ b/tests/e2e/spec-coverage/bi-export-jobs-bug.spec.ts
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2026 Pipelinq Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: EUPL-1.2
  *
  * Behavioral regression marker for the BI export jobs page (/export/jobs).
  * Complements the existing bi-export.spec.ts (which only asserts no hard 500)

--- a/tests/e2e/spec-coverage/bi-export.spec.ts
+++ b/tests/e2e/spec-coverage/bi-export.spec.ts
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2026 Pipelinq Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: EUPL-1.2
  *
  * Gate-19 e2e coverage for the BI export and data warehouse sink feature.
  * Maps to openspec/changes/bi-export-and-data-warehouse-sink/specs.md.

--- a/tests/e2e/spec-coverage/billing-categories.spec.ts
+++ b/tests/e2e/spec-coverage/billing-categories.spec.ts
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2026 Pipelinq Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: EUPL-1.2
  *
  * Gate-19 behavioral e2e coverage for the Billing categories page
  * (/billing-categories).

--- a/tests/e2e/spec-coverage/client-management.spec.ts
+++ b/tests/e2e/spec-coverage/client-management.spec.ts
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2026 Pipelinq Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: EUPL-1.2
  *
  * Gate-19 e2e coverage for openspec/specs/client-management/spec.md
  * UI-observable scenarios: list view, create form, form validation, navigation.

--- a/tests/e2e/spec-coverage/commercial-dashboard.spec.ts
+++ b/tests/e2e/spec-coverage/commercial-dashboard.spec.ts
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2026 Pipelinq Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: EUPL-1.2
  *
  * Gate-19 behavioral e2e coverage for the commercial-dashboard split
  * (openspec/changes/commercial-dashboard). The landing dashboard `/` is

--- a/tests/e2e/spec-coverage/complaints.spec.ts
+++ b/tests/e2e/spec-coverage/complaints.spec.ts
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2026 Pipelinq Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: EUPL-1.2
  *
  * Gate-19 behavioral e2e coverage for the Complaints index page (/complaints).
  * Maps to openspec/specs/klachtenregistratie/spec.md.

--- a/tests/e2e/spec-coverage/contactmomenten.spec.ts
+++ b/tests/e2e/spec-coverage/contactmomenten.spec.ts
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2026 Pipelinq Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: EUPL-1.2
  *
  * Gate-19 e2e coverage for openspec/specs/contactmomenten/spec.md
  * UI-observable scenarios: page loads, navigation, list.

--- a/tests/e2e/spec-coverage/contacts.spec.ts
+++ b/tests/e2e/spec-coverage/contacts.spec.ts
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2026 Pipelinq Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: EUPL-1.2
  *
  * Gate-19 behavioral e2e coverage for the Contacts index page (/contacts).
  * Maps to openspec/specs/contacts-sync/spec.md.

--- a/tests/e2e/spec-coverage/contract-renewal-tracking.spec.ts
+++ b/tests/e2e/spec-coverage/contract-renewal-tracking.spec.ts
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2026 Pipelinq Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: EUPL-1.2
  *
  * Gate-19 behavioral e2e coverage for contract-renewal-tracking
  * (openspec/specs/contract-renewal-tracking/spec.md).

--- a/tests/e2e/spec-coverage/cti-integration.spec.ts
+++ b/tests/e2e/spec-coverage/cti-integration.spec.ts
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2026 Pipelinq Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: EUPL-1.2
  *
  * Gate-19 behavioral e2e coverage for the CTI integration settings page
  * (/settings/cti) and the CTI webhook event log (/settings/cti/event-log).

--- a/tests/e2e/spec-coverage/dashboard-analytics.spec.ts
+++ b/tests/e2e/spec-coverage/dashboard-analytics.spec.ts
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2026 Pipelinq Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: EUPL-1.2
  *
  * Gate-19 behavioral e2e coverage for the decomposed analytics dashboard
  * widgets (openspec/changes/decompose-unified-analytics, REQ-DASH-010).

--- a/tests/e2e/spec-coverage/dashboard.spec.ts
+++ b/tests/e2e/spec-coverage/dashboard.spec.ts
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2026 Pipelinq Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: EUPL-1.2
  *
  * Gate-19 e2e coverage for openspec/specs/dashboard/spec.md
  * UI-observable scenarios: page title, KPI tiles, quick actions, layout, refresh.

--- a/tests/e2e/spec-coverage/expense-shillinq-ap.spec.ts
+++ b/tests/e2e/spec-coverage/expense-shillinq-ap.spec.ts
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2026 Pipelinq Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: EUPL-1.2
  *
  * Gate-19 e2e coverage for
  * openspec/changes/pipelinq-expense-to-shillinq-ap/specs.md

--- a/tests/e2e/spec-coverage/features-roadmap.spec.ts
+++ b/tests/e2e/spec-coverage/features-roadmap.spec.ts
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2026 Pipelinq Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: EUPL-1.2
  *
  * Gate-19 behavioral e2e coverage for the Features & roadmap page
  * (/features-roadmap). Maps to openspec/specs/notifications-activity/spec.md

--- a/tests/e2e/spec-coverage/forecast.spec.ts
+++ b/tests/e2e/spec-coverage/forecast.spec.ts
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2026 Pipelinq Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: EUPL-1.2
  *
  * Gate-19 behavioral e2e coverage for the Forecast report page (/forecast).
  * Maps to openspec/changes/forecast-roll-up-and-categories/specs.md.

--- a/tests/e2e/spec-coverage/lead-management.spec.ts
+++ b/tests/e2e/spec-coverage/lead-management.spec.ts
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2026 Pipelinq Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: EUPL-1.2
  *
  * Gate-19 e2e coverage for openspec/specs/lead-management/spec.md
  * UI-observable scenarios: leads page, navigation.

--- a/tests/e2e/spec-coverage/loyalty.spec.ts
+++ b/tests/e2e/spec-coverage/loyalty.spec.ts
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2026 Pipelinq Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: EUPL-1.2
  *
  * Gate-19 behavioral e2e coverage for the Loyalty programme reporting page
  * (/loyalty/reporting). Maps to openspec/changes/loyalty-program/specs.md.

--- a/tests/e2e/spec-coverage/my-work.spec.ts
+++ b/tests/e2e/spec-coverage/my-work.spec.ts
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2026 Pipelinq Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: EUPL-1.2
  *
  * Gate-19 e2e coverage for openspec/specs/my-work/spec.md
  * UI-observable scenarios: page loads, navigation, empty state.

--- a/tests/e2e/spec-coverage/outbound-messaging.spec.ts
+++ b/tests/e2e/spec-coverage/outbound-messaging.spec.ts
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2026 Pipelinq Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: EUPL-1.2
  *
  * Gate-19 e2e coverage for outbound-messaging-provider-wiring.
  * UI-observable scenarios of openspec/specs/outbound-messaging/spec.md

--- a/tests/e2e/spec-coverage/pipeline-insights.spec.ts
+++ b/tests/e2e/spec-coverage/pipeline-insights.spec.ts
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2026 Pipelinq Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: EUPL-1.2
  *
  * Gate-19 e2e coverage for openspec/specs/pipeline-insights/spec.md
  * UI-observable scenarios: pipeline page renders, KPI tile visible.

--- a/tests/e2e/spec-coverage/pipeline.spec.ts
+++ b/tests/e2e/spec-coverage/pipeline.spec.ts
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2026 Pipelinq Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: EUPL-1.2
  *
  * Gate-19 e2e coverage for openspec/specs/pipeline/spec.md
  * UI-observable scenarios: kanban page, sidebar, empty state, view toggles.

--- a/tests/e2e/spec-coverage/pipelines.spec.ts
+++ b/tests/e2e/spec-coverage/pipelines.spec.ts
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2026 Pipelinq Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: EUPL-1.2
  *
  * Gate-19 behavioral e2e coverage for the Pipelines index page (/pipelines)
  * — the pipeline-definition list, distinct from the deal board (/pipeline).

--- a/tests/e2e/spec-coverage/pos-transaction-core.spec.ts
+++ b/tests/e2e/spec-coverage/pos-transaction-core.spec.ts
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2026 Pipelinq Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: EUPL-1.2
  *
  * Gate-19 e2e coverage for openspec/specs/pos-transaction-core/spec.md
  * UI-observable scenarios: the POS transaction list (Kassabon) at /pos —

--- a/tests/e2e/spec-coverage/products.spec.ts
+++ b/tests/e2e/spec-coverage/products.spec.ts
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2026 Pipelinq Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: EUPL-1.2
  *
  * Gate-19 behavioral e2e coverage for the Products index page (/products).
  * Maps to openspec/specs/product-service-catalog/spec.md.

--- a/tests/e2e/spec-coverage/queues.spec.ts
+++ b/tests/e2e/spec-coverage/queues.spec.ts
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2026 Pipelinq Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: EUPL-1.2
  *
  * Gate-19 behavioral e2e coverage for the Queues index page (/queues).
  * Maps to openspec/specs/queue-management/spec.md.

--- a/tests/e2e/spec-coverage/request-management.spec.ts
+++ b/tests/e2e/spec-coverage/request-management.spec.ts
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2026 Pipelinq Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: EUPL-1.2
  *
  * Gate-19 e2e coverage for openspec/specs/request-management/spec.md
  * UI-observable scenarios: list view, create form, navigation, visual controls.

--- a/tests/e2e/spec-coverage/returns.spec.ts
+++ b/tests/e2e/spec-coverage/returns.spec.ts
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2026 Pipelinq Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: EUPL-1.2
  *
  * Gate-19 behavioral e2e coverage for the Returns / refunds page (/pos/refunds).
  * Maps to openspec/specs/pos-refund-return/spec.md.

--- a/tests/e2e/spec-coverage/semantic-handoff-emit.spec.ts
+++ b/tests/e2e/spec-coverage/semantic-handoff-emit.spec.ts
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2026 Pipelinq Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: EUPL-1.2
  *
  * Gate-19 e2e coverage for semantic-handoff-emit (ADR-051 emit side).
  * UI-observable scenarios of openspec/specs/request-management/spec.md and

--- a/tests/e2e/spec-coverage/tasks.spec.ts
+++ b/tests/e2e/spec-coverage/tasks.spec.ts
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2026 Pipelinq Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: EUPL-1.2
  *
  * Gate-19 behavioral e2e coverage for the Tasks index page (/tasks).
  * Maps to openspec/specs/task-background-jobs/spec.md.

--- a/tests/e2e/visual/_visual-helpers.ts
+++ b/tests/e2e/visual/_visual-helpers.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: EUPL-1.2
  *
  * Shared helpers for the visual-regression layer (GAP-5).
  *

--- a/tests/e2e/visual/pipelinq.visual.spec.ts
+++ b/tests/e2e/visual/pipelinq.visual.spec.ts
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2026 Conduction B.V.
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: EUPL-1.2
  *
  * Visual-regression baselines for PipelinQ's key surfaces (GAP-5).
  *

--- a/tests/e2e/workflows/client-crud.spec.ts
+++ b/tests/e2e/workflows/client-crud.spec.ts
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2026 Pipelinq Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: EUPL-1.2
  *
  * DEEP, data-dependent CRUD-with-persistence journey for CLIENTS.
  *

--- a/tests/e2e/workflows/helpers/fixtures.ts
+++ b/tests/e2e/workflows/helpers/fixtures.ts
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2026 Pipelinq Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: EUPL-1.2
  *
  * Seeded-fixture helper for the DEEP, data-dependent workflow suite.
  *

--- a/tests/e2e/workflows/pos-money.spec.ts
+++ b/tests/e2e/workflows/pos-money.spec.ts
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2026 Pipelinq Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: EUPL-1.2
  *
  * DEEP, data-dependent POS money workflow — proves the cart math is COMPUTED
  * CORRECTLY against known prices/rates, asserting the EXACT euro figures.

--- a/tests/e2e/workflows/product-crud.spec.ts
+++ b/tests/e2e/workflows/product-crud.spec.ts
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2026 Pipelinq Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: EUPL-1.2
  *
  * DEEP, data-dependent CRUD-with-persistence journey for PRODUCTS.
  *

--- a/tests/validate-manifest.js
+++ b/tests/validate-manifest.js
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: EUPL-1.2
 // Copyright (C) 2026 Conduction B.V.
 //
 // validate-manifest.js — schema-validates src/manifest.json against the


### PR DESCRIPTION
## What

All app metadata (`composer.json`, `package.json`, `appinfo/info.xml`, `LICENSE`) already declares **EUPL-1.2**, but 46 source files still carried `AGPL-3.0-or-later` declarations left over from the original Nextcloud app scaffolding. This aligns them with the project licence.

| Category | Count |
|---|---|
| `SPDX-License-Identifier: AGPL-3.0-or-later` → `EUPL-1.2` | 46 |
| — of which `src/` (`App.vue`, `main.js`, `utils/widgetText.js`, `views/pipeline/PipelineBoard.vue`, `views/pipeline/PipelineCard.vue`) | 5 |
| — of which `tests/e2e/**` | 40 |
| — of which `tests/validate-manifest.js` | 1 |
| `@license` tags with a non-EUPL value | 0 (none existed) |
| trailing-dot (`EUPL-1.2.`) / field-order (`@license <url> EUPL-1.2`) defects | 0 (none existed) |

Comment style is preserved exactly per file: `<!-- … -->` in `.vue`, `// …` in `main.js` / `validate-manifest.js`, `* …` in block comments.

## What is deliberately NOT changed

- **Every `@copyright` / `SPDX-FileCopyrightText` line.** This normalises the licence only; holders (`2026 Pipelinq Contributors`, `2026 Conduction B.V.`) and years are untouched.
- All four metadata files — already correct, so verified rather than churned.
- No third-party or vendored file. `vendor/`, `node_modules/`, `dist/`, `build/` are excluded, and this repo carries no vendored upstream source with a foreign copyright holder.

## Diff shape

46 files changed, 46 insertions(+), 46 deletions(-) — exactly one line per file, and **every changed line contains `license`**. Nothing else in any file moves.

## Verification

Identically conditioned before and after:

| Check | Before | After |
|---|---|---|
| vitest (`npm run test:unit`) | 6 files / 45 tests passed | 6 files / 45 tests passed |
| phpunit (`phpunit-unit.xml`, PHP 8.4 in `nextcloud:latest`) | 1603 tests, 4988 assertions, 3 warnings, 11 skipped | identical |
| eslint (`npm run lint`) | — | 0 errors (341 pre-existing warnings) |
| stylelint | — | clean |
| `npm run check:manifest` | — | `Manifest OK: v1.0.0 \| 51 pages \| 22 menu items` |
| hydra **gate-28** (license-triangle) | PASS | PASS |

Host PHP is 8.2 and the vendor tree requires >= 8.3, so the PHP suite was run under PHP 8.4 in a throwaway `nextcloud:latest` container.

No `@SuppressWarnings`, baseline entry, threshold change, `.skip`, waiver, `continue-on-error`, or weakened assertion was added anywhere.