### PR TITLE
chore(license): normalise the last stray AGPL-3.0 SPDX declaration to EUPL-1.2

### DIFF
--- a/src/manifest.d/README.md
+++ b/src/manifest.d/README.md
@@ -1,5 +1,5 @@
 <!--
-SPDX-License-Identifier: AGPL-3.0-or-later
+SPDX-License-Identifier: EUPL-1.2
 SPDX-FileCopyrightText: 2026 Conduction B.V.
 -->
 


### PR DESCRIPTION
## What

`src/manifest.d/README.md` declared `SPDX-License-Identifier: AGPL-3.0-or-later`. This was the **only** non-EUPL licence declaration left anywhere in the repository.

## Why it is safe

The stray tag sits directly above **our own** copyright line:

```
SPDX-License-Identifier: AGPL-3.0-or-later   <- corrected to EUPL-1.2
SPDX-FileCopyrightText: 2026 Conduction B.V. <- unchanged
```

No third party's copyright is involved, so this is a straightforward correction of our own mis-tagged file rather than a relicensing. The adjacent `SPDX-FileCopyrightText` line is deliberately untouched.

It contradicted every other licence surface in the repo:
- `LICENSE` — EUPL-1.2
- `appinfo/info.xml` — `<licence>EUPL-1.2</licence>`
- `composer.json` — `"license": "EUPL-1.2"`

## Scope

One line in one file. Licence-only.