### PR TITLE
chore(ci): stop pinning hydra-gates — track the package at @main

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -90,7 +90,13 @@ jobs:
       # "DID NOT RUN". v1.3.0 ships 36 such declarations. Measured on doriath
       # (PR #160): gates 4/24/33 went from unexplained "DID NOT RUN" to
       # explicit NOT APPLICABLE, and Hydra Gates went failure -> success.
-      hydra-gates-ref: v1.3.0
+      hydra-gates-ref: v1.4.0
+      # PIN MOVED v1.3.0 -> v1.4.0 (fleet consumer-ref sweep, 2026-08-05).
+      # A pinned ref is a silent expiry date on every upstream fix: this repo
+      # cannot receive a gate-package fix until this line moves. v1.4.0 is the
+      # latest tag and the FIRST one carrying `hydra-gates/scripts/axe-run.cjs`
+      # (verified absent at v1.3.0), so it is also the first that has #168's
+      # axe DOM scoping and #165's gate-46 fix.
       # `enable-axe` deliberately NOT set: it produces the report gate-33
       # consumes, and a vanilla Nextcloud already carries serious/critical axe
       # violations, so enabling it here would mix "this repo has a defect" with

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -74,29 +74,20 @@ jobs:
       # on untouched trees and will not block unrelated PRs.
       #
       # No count is written here on purpose: the number of gates depends on the
-      # pin below and the number that run depends on this repo's diff and
-      # toolchain. The package prints both (`COVERAGE: N of M`) in the job log.
-      # See https://github.com/ConductionNL/.github/tree/main/hydra-gates
-      #
-      # Pinned to a tag, not `main`, so a change to the gate package cannot
-      # alter this repository's verdict without a commit here to move the pin.
-      # v1.0.1 was the pin openbuild and openregister ran when this was written.
+      # package version in use and the number that run depends on this repo's
+      # diff and toolchain. The package prints both (`COVERAGE: N of M`) in the
+      # job log. See https://github.com/ConductionNL/.github/tree/main/hydra-gates
       enable-hydra-gates: true
-      # PIN MOVED v1.0.1 -> v1.3.0. `hydra-gates-require-full-coverage`
-      # (default ON) fails a run when a gate whose subject matter EXISTS did
-      # not report; its contract is that a not-applicable gate must DECLARE
-      # itself. v1.0.1 contains ZERO `_skip` calls — no na/structural/wiring
-      # vocabulary at all — so such a gate emits NOTHING and is counted as
-      # "DID NOT RUN". v1.3.0 ships 36 such declarations. Measured on doriath
-      # (PR #160): gates 4/24/33 went from unexplained "DID NOT RUN" to
-      # explicit NOT APPLICABLE, and Hydra Gates went failure -> success.
-      hydra-gates-ref: v1.4.0
-      # PIN MOVED v1.3.0 -> v1.4.0 (fleet consumer-ref sweep, 2026-08-05).
-      # A pinned ref is a silent expiry date on every upstream fix: this repo
-      # cannot receive a gate-package fix until this line moves. v1.4.0 is the
-      # latest tag and the FIRST one carrying `hydra-gates/scripts/axe-run.cjs`
-      # (verified absent at v1.3.0), so it is also the first that has #168's
-      # axe DOM scoping and #165's gate-46 fix.
+      # No `hydra-gates-ref` here on purpose. The shared workflow defaults it
+      # to @main, and this workflow is itself consumed at @main, so the two
+      # sides move together and a gate fix reaches this repo without a commit
+      # in this repo. A pin is a silent expiry date: 22 repos sat on v1.0.1 and
+      # 16 gates were dead fleet-wide while every one reported PASS (.github#159),
+      # and a default flipped at @main later reached those old runners and made
+      # them red on gates they had no subject matter for (.github#173).
+      # To hold this repo still for a specific reason, set the input explicitly
+      # and say why — it is still honoured. To roll back for everyone, revert on
+      # ConductionNL/.github main.
       # `enable-axe` deliberately NOT set: it produces the report gate-33
       # consumes, and a vanilla Nextcloud already carries serious/critical axe
       # violations, so enabling it here would mix "this repo has a defect" with


### PR DESCRIPTION
## What changed

This PR started life as a pin bump (`hydra-gates-ref: v1.3.0 -> v1.4.0`). It now **removes the `hydra-gates-ref` line entirely** so this caller inherits the shared workflow's default.

```diff
       enable-hydra-gates: true
-      hydra-gates-ref: v1.4.0
```

`enable-hydra-gates: true` is unchanged. `enable-axe` remains unset. The comment block that justified the pin is replaced with a short note explaining why there is deliberately no pin.

## Why

`ConductionNL/.github/.github/workflows/quality.yml` **already defaults `hydra-gates-ref` to `main`**, and this repo consumes `quality.yml` at `@main`. Overriding the input was the only thing holding the gates package still. Drop the override and both sides move together — a gate fix reaches this repo without a commit in this repo.

Bumping the pin is a treadmill: it works until the next fix lands upstream, and between bumps the repo is running whatever the gates package looked like on the day someone last remembered.

**A pin is a silent expiry date on every upstream fix.** We have paid for that twice:

- **[.github#159](https://github.com/ConductionNL/.github/issues/159)** — 22 repos sat pinned on `v1.0.1`, which predated the gate fixes. **16 gates were dead fleet-wide and every one of them reported PASS.** A gate that never runs emits a tick identical to one that did, so nothing in any repo's CI history showed it.
- **[.github#173](https://github.com/ConductionNL/.github/issues/173)** — the shared side flipped a default at `@main` while the package stayed pinned per caller. Old pinned runners did not carry the coverage accounting the new default assumed, so they went **red on gates they had no subject matter for**.

The two failures are opposite shapes of the same split: shared workflow at `@main`, package pinned. Removing the pin closes both.

## Rollback

- **For everyone:** revert on `ConductionNL/.github` `main`. One commit reaches the whole fleet — which is the point.
- **For this repo only:** set `hydra-gates-ref:` explicitly again, with a comment saying why this repo needs to hold still. The input is still honoured; it just is not the default posture.

## Safety net

[`ConductionNL/.github#177`](https://github.com/ConductionNL/.github/pull/177) adds the resolve probe plus the gates package suite gating `.github` `main`, so a broken package cannot reach `main` unnoticed now that consumers track it.
