### PR TITLE
ci: publish an installable build of development

### DIFF
--- a/.github/workflows/release-development.yml
+++ b/.github/workflows/release-development.yml
@@ -1,0 +1,36 @@
+# Publishes an installable build of the development branch.
+#
+# Beta and stable reach people through the Nextcloud app store. Development
+# did not reach anyone: the newest installable Pipelinq was v0.1.19 from
+# April while development had moved on by hundreds of commits, so trying
+# out unreleased work meant building it yourself.
+#
+# This publishes a GitHub prerelease with a .tar.gz on every push to
+# development. The App Versions app reads a repository's releases from the
+# forge API and installs from that asset, and it already trusts
+# github:ConductionNL/* by default, so nothing needs configuring on the
+# Nextcloud side.
+#
+# Deliberately never uploaded to the app store: the shared workflow skips
+# that step for this channel. A dev build is for people who asked for one.
+name: Development Release
+
+on:
+  push:
+    branches: [development]
+  workflow_dispatch:
+
+# A push during a running build supersedes it. Without this, a busy morning
+# produces a queue of releases that are obsolete before they finish, and
+# the tag each one cuts sticks around.
+concurrency:
+  group: development-release
+  cancel-in-progress: true
+
+jobs:
+  release:
+    uses: ConductionNL/.github/.github/workflows/release-beta.yml@main
+    with:
+      app-name: pipelinq
+      channel: dev
+    secrets: inherit


### PR DESCRIPTION
The newest installable Pipelinq is **v0.1.19 from 2026-04-27**, while `development` has moved on by **315 commits**. Beta and stable reach people through the Nextcloud app store; development reached nobody, so trying unreleased work meant building it yourself.

Every push to `development` now publishes a **GitHub prerelease** with a `.tar.gz`. The App Versions app reads releases from the forge API and installs from that asset, and already trusts `github:ConductionNL/*` by default — so nothing needs configuring on the Nextcloud side.

**It never goes to the app store.** The shared workflow skips that step for this channel, which is the only difference between dev and beta: packaging is identical on purpose, so a dev build is not a different artifact from the beta it later becomes.

Concurrency cancels an in-flight build when another push lands, so a busy morning doesn't leave a queue of releases that are obsolete before they finish, each having cut a tag.

Depends on ConductionNL/.github#186 (merged), which added the `channel` input and a `.sha256` sibling to the shared workflow.