### PR TITLE
fix: declare NC 32 as the floor — openregister cannot install below it

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -76,6 +76,23 @@ jobs:
     uses: ConductionNL/.github/.github/workflows/quality.yml@main
     with:
       app-name: pipelinq
+      # Pinned, because the shared workflow's DEFAULT is '["stable31", "stable32"]'
+      # and stable31 CANNOT WORK here. `additional-apps` below installs
+      # openregister, which declares min-version="32" (its
+      # lib/ContextChat/ContentProvider.php implements
+      # OCP\ContextChat\IContentProvider, absent from core before NC32). On NC31
+      # the install step logs
+      #   App "Open Register" cannot be installed because it is not compatible
+      #   with this version of the server.
+      # and then continues, because the enable failure is only a ::warning::. The
+      # run therefore proceeded without its data layer and every
+      # /apps/openregister/... call returned Nextcloud's HTML 404 page.
+      #
+      # Order matters as much as membership: newman, playwright and
+      # journeydoc-capture all check out `fromJSON(nextcloud-test-refs)[0]` as
+      # their single server, so with the inherited default those three jobs ran
+      # entirely on the version openregister cannot load.
+      nextcloud-test-refs: '["stable32"]'
       # Strict static-analysis gate suite (composer check:strict equivalent).
       # These mirror the shared-workflow defaults (all true) but are pinned
       # here explicitly so the strict-gate posture is self-documenting and

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -74,7 +74,19 @@ Vrij en open source onder de EUPL-1.2-licentie.
 
     <dependencies>
         <php min-version="8.3"/>
-        <nextcloud min-version="28" max-version="34"/>
+        <!--
+        min-version is 32, NOT 28, because the OpenRegister dependency noted below is
+        HARD (src/manifest.json lists "openregister" as a required dependency; the
+        optional ones there carry "required": false) and openregister declares
+        min-version="32" — its lib/ContextChat/ContentProvider.php implements
+        OCP\ContextChat\IContentProvider, an interface core does not have before
+        Nextcloud 32. On NC 28-31 openregister refuses to install ("cannot be
+        installed because it is not compatible with this version of the server") and
+        all Pipelinq data is OpenRegister objects, so the app cannot function there.
+        Declaring 28 advertised a range this app cannot deliver.
+        Same defect as openconnector#1173.
+        -->
+        <nextcloud min-version="32" max-version="34"/>
         <!-- App dependency (not expressible in app-info.xsd): OpenRegister
              (all Pipelinq data — clients, contacts, leads, requests, contracts,
              contactmomenten — is stored as OpenRegister registers/schemas; see


### PR DESCRIPTION
## What changed

**1. `appinfo/info.xml` `min-version` 28 → 32.** `src/manifest.json` lists `"openregister"` as a required dependency (OpenConnector, Deck, workflowengine, timemanager and Forms all carry `"required": false`); all Pipelinq data is OpenRegister objects.

**2. `nextcloud-test-refs` pinned to `["stable32"]`.** This repo set no value, so it inherited the shared workflow's default of `["stable31","stable32"]` — with `stable31` **first**, which is the entry Newman, Playwright and journeydoc-capture pin.

## The defect

openregister raised its own floor this morning — `<nextcloud min-version="32" max-version="34"/>`, commit `8d5181f7a` (openregister#2378), *"require Nextcloud 32, which is where the ContextChat interfaces exist"*. Its `lib/ContextChat/ContentProvider.php` implements `OCP\ContextChat\IContentProvider`, and core does not have that interface before NC32. **That raise is correct and is not being reverted here.**

The consequence lands on every app that depends on openregister but still tests on `stable31`:

```
Enabling app: openregister
App "Open Register" cannot be installed because it is not compatible with this version of the server.
##[warning]Failed to enable openregister, continuing...
```

The enable failure is only a `::warning::` (shared `quality.yml`, "Install Nextcloud" step), so the run **continues without its data layer** and every `/apps/openregister/...` call returns Nextcloud's HTML 404 page.

## This was measured, not inferred

- One **unchanged commit's** job passed at 08:05 and failed at 08:35, with zero code change in between — the only thing that moved was openregister's floor.
- Re-running `development`'s own Newman on yesterday's commits: **decidesk 93 → 191** failures, **larpingapp 10 → 22**.
- docudesk was immune, and only because it already tests `stable32` only.

## `stable31` is removed, not "dropped for coverage"

A `stable31` leg was exercising a configuration that **cannot exist**: the app under test declares openregister as a hard dependency, and openregister cannot install there. Nothing was being covered on that leg — its red said nothing about this app's code. Removing it corrects an impossible configuration. It does not reduce coverage.

The matrix is **not widened** either: no `stable33` is added where it was not already present.

## The ordering bug in the same family

Membership was not the only problem. In the shared `quality.yml`, three jobs pin the **first** entry rather than iterating the list:

| job | line | server |
|---|---|---|
| `newman` | 1748 | `fromJSON(inputs.nextcloud-test-refs)[0]` |
| `playwright` | 2024 | `fromJSON(inputs.nextcloud-test-refs)[0]` |
| `journeydoc-capture` | 2775 | `fromJSON(inputs.nextcloud-test-refs)[0]` |

(`phpunit` iterates the whole list, so it was broken by *membership*; the coverage-guard and coverage-artifact steps at 1644/1671/1684 are also `[0]`-pinned.)

So wherever `stable31` sat **first**, those three jobs ran *entirely* on the version openregister cannot load. doriath had already reordered for exactly this reason.

## Precedent

This is the same defect as **openconnector#1173**, which declared `min-version="28"` while its own `<app>openregister</app>` dependency required 32 — advertising, in the app store, a range it could not deliver. This PR follows that shape.

## Scope

No app version bump — only the supported-server range and the CI matrix change, so there are no `occ upgrade` implications.