### PR TITLE
chore: raise the Nextcloud floor to 32

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -74,7 +74,7 @@ Vrij en open source onder de EUPL-1.2-licentie.
 
     <dependencies>
         <php min-version="8.3"/>
-        <nextcloud min-version="28" max-version="34"/>
+        <nextcloud min-version="32" max-version="34"/>
         <!-- App dependency (not expressible in app-info.xsd): OpenRegister
              (all Pipelinq data — clients, contacts, leads, requests, contracts,
              contactmomenten — is stored as OpenRegister registers/schemas; see


### PR DESCRIPTION
Raises the declared Nextcloud floor to **32**, matching what we actually build and test against.

CI runs `nextcloud:32-apache`, the dev stack is on 34, and nothing exercised 28–31. Declaring support for versions nobody tests is a promise the app store passes to users.

Trigger: OpenRegister implements `OCP\ContextChat\IContentProvider`, which does not exist in core before NC 32, and no lazy-DI or event gating can defer a missing interface on a class header. OpenRegister moved to 32 in ConductionNL/openregister#2378; apps depending on it had unsatisfiable floors.

Only `<nextcloud min-version>` changes. `max-version` untouched — verified across all 24 repos by comparing each branch to its base: 0 changed.