### PR TITLE
fix: restore the pre-32 Nextcloud floor — CI still runs stable31

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -86,7 +86,7 @@ Vrij en open source onder de EUPL-1.2-licentie.
         Declaring 28 advertised a range this app cannot deliver.
         Same defect as openconnector#1173.
         -->
-        <nextcloud min-version="32" max-version="34"/>
+        <nextcloud min-version="28" max-version="34"/>
         <!-- App dependency (not expressible in app-info.xsd): OpenRegister
              (all Pipelinq data — clients, contacts, leads, requests, contracts,
              contactmomenten — is stored as OpenRegister registers/schemas; see


### PR DESCRIPTION
fix: restore the pre-32 Nextcloud floor — CI still runs stable31

This repo does not set nextcloud-test-refs, so it inherits the shared
default of [stable31, stable32]. min-version is enforced at install time,
so a 32 floor makes occ app:enable refuse on stable31 and the e2e seed
fails with "is not installed or enabled".

The premise for the 32 floor is also gone: openregister#2372 removed every
eager reference to its ContextChat provider, so that class is only loaded
behind interface_exists() guards, and openregister#2380 restored its own 28
floor on that evidence.