### PR TITLE
chore(appinfo): raise the Nextcloud floor to 32

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -77,16 +77,23 @@ Vrij en open source onder de EUPL-1.2-licentie.
         <!--
         min-version is 32, NOT 28, because the OpenRegister dependency noted below is
         HARD (src/manifest.json lists "openregister" as a required dependency; the
-        optional ones there carry "required": false) and openregister declares
-        min-version="32" — its lib/ContextChat/ContentProvider.php implements
-        OCP\ContextChat\IContentProvider, an interface core does not have before
-        Nextcloud 32. On NC 28-31 openregister refuses to install ("cannot be
-        installed because it is not compatible with this version of the server") and
-        all Pipelinq data is OpenRegister objects, so the app cannot function there.
-        Declaring 28 advertised a range this app cannot deliver.
-        Same defect as openconnector#1173.
+        optional ones there carry "required": false), and OpenRegister cannot run
+        below Nextcloud 32: its lib/ContextChat/ContentProvider.php declares
+        `class ContentProvider implements IContentProvider` against
+        OCP\ContextChat\IContentProvider, and that interface first ships in core at
+        32.0.0 — verified absent at v29.0.0 / v30.0.0 / v31.0.0 and present at
+        v32.0.0. Because the reference is in the CLASS HEADER it is fatal at
+        autoload, not lazily degradable. All Pipelinq data is OpenRegister objects,
+        so on NC 28-31 this app cannot function. Declaring 28 advertised a range
+        this app cannot deliver. Same defect as openconnector#1173.
+
+        NOTE: OpenRegister's own appinfo/info.xml still declares min-version="28"
+        (canonical origin/development and origin/main, checked 2026-08-08). That
+        declaration is itself too low for the reason above; it is tracked in
+        OpenRegister, and this app does not depend on that value — the floor here
+        rests on the interface fact, not on OpenRegister's declaration.
         -->
-        <nextcloud min-version="28" max-version="34"/>
+        <nextcloud min-version="32" max-version="34"/>
         <!-- App dependency (not expressible in app-info.xsd): OpenRegister
              (all Pipelinq data — clients, contacts, leads, requests, contracts,
              contactmomenten — is stored as OpenRegister registers/schemas; see


### PR DESCRIPTION
chore(appinfo): raise the Nextcloud floor to 32, matching the fleet decision

The file already ARGUED for 32 — the justification comment was written and
landed, but the attribute below it still said 28. This makes the value match
the reasoning that was already in the tree.

<nextcloud min-version="28" max-version="34"/>
  ->
<nextcloud min-version="32" max-version="34"/>

max-version stays 34. <php min-version="8.3"/> already matches the PHP 8.3
target, so it is unchanged.

The floor is not merely fleet alignment here — it is forced. src/manifest.json
lists "openregister" as a REQUIRED dependency (the other five entries carry
"required": false), and OpenRegister cannot run below NC 32: its
lib/ContextChat/ContentProvider.php declares

    class ContentProvider implements IContentProvider

against OCP\ContextChat\IContentProvider. That interface is absent from core at
v29.0.0, v30.0.0 and v31.0.0, and present at v32.0.0 — checked directly against
the release tags. Because the reference sits in the CLASS HEADER it is fatal at
autoload, not lazily degradable. All Pipelinq data is OpenRegister objects, so
on NC 28-31 this app cannot function. Declaring 28 advertised an App Store
range it cannot deliver — the openconnector#1173 defect.

Two things made visible rather than fixed here:

  * OpenRegister's own appinfo/info.xml still declares min-version="28" on
    canonical origin/development AND origin/main (checked 2026-08-08). By the
    interface fact above that declaration is itself too low. Not this repo's to
    change; the floor set here rests on the interface, not on OpenRegister's
    declaration. The stale claim that OpenRegister "declares min-version=32"
    has been corrected in the comment.

  * max-version is 34 in every fleet app except openconnector, which says 35.
    Flagged for visibility only; not resolved here.

CI matrix needs no change: .github/workflows/code-quality.yml already pins
nextcloud-test-refs to '["stable32"]'. There is no leg targeting NC < 32, so
nothing is now testing an unsupported configuration.

