### PR TITLE
fix(security): declare the auth posture on 17 admin-only routed endpoints

### DIFF
--- a/lib/Controller/BerichtenboxAdminController.php
+++ b/lib/Controller/BerichtenboxAdminController.php
@@ -35,7 +35,9 @@ use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\Attribute\AuthorizedAdminSetting;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\IAppConfig;
+use OCP\IGroupManager;
 use OCP\IRequest;
+use OCP\IUserSession;
 use Psr\Container\ContainerInterface;
 use Throwable;
 
@@ -47,17 +49,42 @@ class BerichtenboxAdminController extends Controller
     /**
      * Constructor.
      *
-     * @param IRequest           $request   Request.
-     * @param ContainerInterface $container DI container.
-     * @param IAppConfig         $appConfig App config.
+     * @param IRequest           $request      Request.
+     * @param ContainerInterface $container    DI container.
+     * @param IAppConfig         $appConfig    App config.
+     * @param IUserSession       $userSession  The user session.
+     * @param IGroupManager      $groupManager The group manager.
      */
     public function __construct(
         IRequest $request,
         private readonly ContainerInterface $container,
         private readonly IAppConfig $appConfig,
+        private readonly IUserSession $userSession,
+        private readonly IGroupManager $groupManager,
     ) {
         parent::__construct(appName: Application::APP_ID, request: $request);
     }//end __construct()
+
+    /**
+     * Reject anyone who is not a full Nextcloud administrator.
+     *
+     * #[AuthorizedAdminSetting] admits a full admin OR a user holding a
+     * delegated grant for the named settings section. These two endpoints
+     * were strictly admin-only before the attribute was added (they relied on
+     * NC's framework default), and this keeps them that way, so declaring the
+     * posture does not widen it. Mirrors PortalAdminController::assertAdmin().
+     *
+     * @return JSONResponse|null A 403 response, or null when the caller is an admin.
+     */
+    private function assertAdmin(): ?JSONResponse
+    {
+        $user = $this->userSession->getUser();
+        if ($user === null || $this->groupManager->isAdmin($user->getUID()) === false) {
+            return new JSONResponse(['error' => 'Admin required'], Http::STATUS_FORBIDDEN);
+        }
+
+        return null;
+    }//end assertAdmin()
 
     /**
      * POST /api/admin/berichtenbox/message/{id}/retry — re-queue a failed
@@ -66,10 +93,17 @@ class BerichtenboxAdminController extends Controller
      * @param string $id BerichtenboxMessage uuid.
      *
      * @return JSONResponse
+     *
+     * @spec openspec/changes/archive/2026-06-14-burgerportaal-mijnoverheid-bridge/specs/berichtenbox/spec.md#req-retry-012
      */
     #[AuthorizedAdminSetting(settings: \OCA\Pipelinq\Settings\AdminSettings::class)]
     public function retry(string $id): JSONResponse
     {
+        $forbidden = $this->assertAdmin();
+        if ($forbidden instanceof JSONResponse) {
+            return $forbidden;
+        }
+
         try {
             $service = $this->getObjectService();
             $message = $service->find(
@@ -126,6 +160,11 @@ class BerichtenboxAdminController extends Controller
     #[AuthorizedAdminSetting(settings: \OCA\Pipelinq\Settings\AdminSettings::class)]
     public function stats(): JSONResponse
     {
+        $forbidden = $this->assertAdmin();
+        if ($forbidden instanceof JSONResponse) {
+            return $forbidden;
+        }
+
         $register = $this->appConfig->getValueString(Application::APP_ID, 'register', '');
         $schema   = $this->appConfig->getValueString(Application::APP_ID, 'berichtenboxMessage_schema', '');
         $counters = [

--- a/lib/Controller/BerichtenboxAdminController.php
+++ b/lib/Controller/BerichtenboxAdminController.php
@@ -32,6 +32,7 @@ namespace OCA\Pipelinq\Controller;
 use OCA\Pipelinq\AppInfo\Application;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http;
+use OCP\AppFramework\Http\Attribute\AuthorizedAdminSetting;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\IAppConfig;
 use OCP\IRequest;
@@ -66,6 +67,7 @@ class BerichtenboxAdminController extends Controller
      *
      * @return JSONResponse
      */
+    #[AuthorizedAdminSetting(Application::APP_ID)]
     public function retry(string $id): JSONResponse
     {
         try {
@@ -121,6 +123,7 @@ class BerichtenboxAdminController extends Controller
      *
      * @spec exclude mechanical phpmd cleanup — counter tally extracted to a helper, behaviour unchanged
      */
+    #[AuthorizedAdminSetting(Application::APP_ID)]
     public function stats(): JSONResponse
     {
         $register = $this->appConfig->getValueString(Application::APP_ID, 'register', '');

--- a/lib/Controller/BerichtenboxAdminController.php
+++ b/lib/Controller/BerichtenboxAdminController.php
@@ -67,7 +67,7 @@ class BerichtenboxAdminController extends Controller
      *
      * @return JSONResponse
      */
-    #[AuthorizedAdminSetting(Application::APP_ID)]
+    #[AuthorizedAdminSetting(settings: \OCA\Pipelinq\Settings\AdminSettings::class)]
     public function retry(string $id): JSONResponse
     {
         try {
@@ -123,7 +123,7 @@ class BerichtenboxAdminController extends Controller
      *
      * @spec exclude mechanical phpmd cleanup — counter tally extracted to a helper, behaviour unchanged
      */
-    #[AuthorizedAdminSetting(Application::APP_ID)]
+    #[AuthorizedAdminSetting(settings: \OCA\Pipelinq\Settings\AdminSettings::class)]
     public function stats(): JSONResponse
     {
         $register = $this->appConfig->getValueString(Application::APP_ID, 'register', '');

--- a/lib/Controller/PortalAdminController.php
+++ b/lib/Controller/PortalAdminController.php
@@ -79,7 +79,7 @@ class PortalAdminController extends Controller
      *
      * @return JSONResponse The saved config, or an error.
      */
-    #[AuthorizedAdminSetting(Application::APP_ID)]
+    #[AuthorizedAdminSetting(settings: \OCA\Pipelinq\Settings\AdminSettings::class)]
     public function saveConfig(): JSONResponse
     {
         return $this->adminGuarded(
@@ -101,7 +101,7 @@ class PortalAdminController extends Controller
      *
      * @return JSONResponse The accounts.
      */
-    #[AuthorizedAdminSetting(Application::APP_ID)]
+    #[AuthorizedAdminSetting(settings: \OCA\Pipelinq\Settings\AdminSettings::class)]
     public function accounts(): JSONResponse
     {
         return $this->adminGuarded(
@@ -128,7 +128,7 @@ class PortalAdminController extends Controller
      *
      * @return JSONResponse The events.
      */
-    #[AuthorizedAdminSetting(Application::APP_ID)]
+    #[AuthorizedAdminSetting(settings: \OCA\Pipelinq\Settings\AdminSettings::class)]
     public function auditEvents(): JSONResponse
     {
         return $this->adminGuarded(

--- a/lib/Controller/PortalAdminController.php
+++ b/lib/Controller/PortalAdminController.php
@@ -36,6 +36,7 @@ use OCA\Pipelinq\Service\Portal\PortalObjectRepository;
 use OCA\Pipelinq\Service\Portal\PortalTenantService;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http;
+use OCP\AppFramework\Http\Attribute\AuthorizedAdminSetting;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\IGroupManager;
 use OCP\IRequest;
@@ -78,6 +79,7 @@ class PortalAdminController extends Controller
      *
      * @return JSONResponse The saved config, or an error.
      */
+    #[AuthorizedAdminSetting(Application::APP_ID)]
     public function saveConfig(): JSONResponse
     {
         return $this->adminGuarded(
@@ -99,6 +101,7 @@ class PortalAdminController extends Controller
      *
      * @return JSONResponse The accounts.
      */
+    #[AuthorizedAdminSetting(Application::APP_ID)]
     public function accounts(): JSONResponse
     {
         return $this->adminGuarded(
@@ -125,6 +128,7 @@ class PortalAdminController extends Controller
      *
      * @return JSONResponse The events.
      */
+    #[AuthorizedAdminSetting(Application::APP_ID)]
     public function auditEvents(): JSONResponse
     {
         return $this->adminGuarded(

--- a/lib/Controller/PosPaymentController.php
+++ b/lib/Controller/PosPaymentController.php
@@ -100,7 +100,7 @@ class PosPaymentController extends Controller
      *
      * @spec openspec/changes/pos-payment-provider-adapter/specs/pos-payment-provider-adapter/spec.md#REQ-PAY-007
      */
-    #[AuthorizedAdminSetting(Application::APP_ID)]
+    #[AuthorizedAdminSetting(settings: \OCA\Pipelinq\Settings\AdminSettings::class)]
     public function index(): JSONResponse
     {
         try {
@@ -119,7 +119,7 @@ class PosPaymentController extends Controller
      *
      * @spec openspec/changes/pos-payment-provider-adapter/specs/pos-payment-provider-adapter/spec.md#REQ-PAY-007
      */
-    #[AuthorizedAdminSetting(Application::APP_ID)]
+    #[AuthorizedAdminSetting(settings: \OCA\Pipelinq\Settings\AdminSettings::class)]
     public function show(string $name): JSONResponse
     {
         try {
@@ -141,7 +141,7 @@ class PosPaymentController extends Controller
      * @spec openspec/changes/pos-payment-provider-adapter/specs/pos-payment-provider-adapter/spec.md#REQ-PAY-002
      * @spec openspec/changes/pos-payment-provider-adapter/specs/pos-payment-provider-adapter/spec.md#REQ-PAY-007
      */
-    #[AuthorizedAdminSetting(Application::APP_ID)]
+    #[AuthorizedAdminSetting(settings: \OCA\Pipelinq\Settings\AdminSettings::class)]
     public function update(string $name): JSONResponse
     {
         try {
@@ -163,7 +163,7 @@ class PosPaymentController extends Controller
      *
      * @spec openspec/changes/pos-payment-provider-adapter/specs/pos-payment-provider-adapter/spec.md#REQ-PAY-007
      */
-    #[AuthorizedAdminSetting(Application::APP_ID)]
+    #[AuthorizedAdminSetting(settings: \OCA\Pipelinq\Settings\AdminSettings::class)]
     public function test(string $name): JSONResponse
     {
         try {

--- a/lib/Controller/PosPaymentController.php
+++ b/lib/Controller/PosPaymentController.php
@@ -36,6 +36,7 @@ use OCA\Pipelinq\AppInfo\Application;
 use OCA\Pipelinq\Service\PosPaymentService;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http;
+use OCP\AppFramework\Http\Attribute\AuthorizedAdminSetting;
 use OCP\AppFramework\Http\Attribute\NoAdminRequired;
 use OCP\AppFramework\Http\Attribute\NoCSRFRequired;
 use OCP\AppFramework\Http\Attribute\PublicPage;
@@ -99,6 +100,7 @@ class PosPaymentController extends Controller
      *
      * @spec openspec/changes/pos-payment-provider-adapter/specs/pos-payment-provider-adapter/spec.md#REQ-PAY-007
      */
+    #[AuthorizedAdminSetting(Application::APP_ID)]
     public function index(): JSONResponse
     {
         try {
@@ -117,6 +119,7 @@ class PosPaymentController extends Controller
      *
      * @spec openspec/changes/pos-payment-provider-adapter/specs/pos-payment-provider-adapter/spec.md#REQ-PAY-007
      */
+    #[AuthorizedAdminSetting(Application::APP_ID)]
     public function show(string $name): JSONResponse
     {
         try {
@@ -138,6 +141,7 @@ class PosPaymentController extends Controller
      * @spec openspec/changes/pos-payment-provider-adapter/specs/pos-payment-provider-adapter/spec.md#REQ-PAY-002
      * @spec openspec/changes/pos-payment-provider-adapter/specs/pos-payment-provider-adapter/spec.md#REQ-PAY-007
      */
+    #[AuthorizedAdminSetting(Application::APP_ID)]
     public function update(string $name): JSONResponse
     {
         try {
@@ -159,6 +163,7 @@ class PosPaymentController extends Controller
      *
      * @spec openspec/changes/pos-payment-provider-adapter/specs/pos-payment-provider-adapter/spec.md#REQ-PAY-007
      */
+    #[AuthorizedAdminSetting(Application::APP_ID)]
     public function test(string $name): JSONResponse
     {
         try {

--- a/lib/Controller/PosPaymentController.php
+++ b/lib/Controller/PosPaymentController.php
@@ -44,6 +44,7 @@ use OCP\AppFramework\Http\JSONResponse;
 use OCP\AppFramework\OCS\OCSBadRequestException;
 use OCP\AppFramework\OCS\OCSForbiddenException;
 use OCP\AppFramework\OCS\OCSNotFoundException;
+use OCP\IGroupManager;
 use OCP\IL10N;
 use OCP\IRequest;
 use OCP\IUserSession;
@@ -85,9 +86,31 @@ class PosPaymentController extends Controller
         private IUserSession $session,
         private IL10N $l10n,
         private LoggerInterface $logger,
+        private IGroupManager $groupManager,
     ) {
         parent::__construct(appName: Application::APP_ID, request: $request);
     }//end __construct()
+
+    /**
+     * Reject anyone who is not a full Nextcloud administrator.
+     *
+     * #[AuthorizedAdminSetting] admits a full admin OR a user holding a
+     * delegated grant for the named settings section. The four provider
+     * configuration endpoints were strictly admin-only before the attribute
+     * was added (they relied on NC's framework default), and this keeps them
+     * that way, so declaring the posture does not widen it.
+     *
+     * @return JSONResponse|null A 403 response, or null when the caller is an admin.
+     */
+    private function assertAdmin(): ?JSONResponse
+    {
+        $user = $this->session->getUser();
+        if ($user === null || $this->groupManager->isAdmin($user->getUID()) === false) {
+            return new JSONResponse(['error' => 'Admin required'], Http::STATUS_FORBIDDEN);
+        }
+
+        return null;
+    }//end assertAdmin()
 
     // ---------------------------------------------------------------------
     // Provider configuration (admin only — NC SecurityMiddleware default).
@@ -103,6 +126,11 @@ class PosPaymentController extends Controller
     #[AuthorizedAdminSetting(settings: \OCA\Pipelinq\Settings\AdminSettings::class)]
     public function index(): JSONResponse
     {
+        $forbidden = $this->assertAdmin();
+        if ($forbidden instanceof JSONResponse) {
+            return $forbidden;
+        }
+
         try {
             return new JSONResponse(['providers' => $this->service->listProviders()]);
         } catch (Throwable $e) {
@@ -122,6 +150,11 @@ class PosPaymentController extends Controller
     #[AuthorizedAdminSetting(settings: \OCA\Pipelinq\Settings\AdminSettings::class)]
     public function show(string $name): JSONResponse
     {
+        $forbidden = $this->assertAdmin();
+        if ($forbidden instanceof JSONResponse) {
+            return $forbidden;
+        }
+
         try {
             return new JSONResponse(['provider' => $this->service->getProviderConfig(name: $name)]);
         } catch (OCSBadRequestException $e) {
@@ -144,6 +177,11 @@ class PosPaymentController extends Controller
     #[AuthorizedAdminSetting(settings: \OCA\Pipelinq\Settings\AdminSettings::class)]
     public function update(string $name): JSONResponse
     {
+        $forbidden = $this->assertAdmin();
+        if ($forbidden instanceof JSONResponse) {
+            return $forbidden;
+        }
+
         try {
             $data = $this->request->getParams();
             return new JSONResponse(['provider' => $this->service->updateProvider(name: $name, data: $data)]);
@@ -166,6 +204,11 @@ class PosPaymentController extends Controller
     #[AuthorizedAdminSetting(settings: \OCA\Pipelinq\Settings\AdminSettings::class)]
     public function test(string $name): JSONResponse
     {
+        $forbidden = $this->assertAdmin();
+        if ($forbidden instanceof JSONResponse) {
+            return $forbidden;
+        }
+
         try {
             return new JSONResponse(['result' => $this->service->testConnection(name: $name)]);
         } catch (OCSBadRequestException $e) {

--- a/lib/Controller/PosRoleController.php
+++ b/lib/Controller/PosRoleController.php
@@ -128,7 +128,7 @@ class PosRoleController extends Controller
      *
      * @spec openspec/changes/pos-staff-pin-permissions/tasks.md#4.1
      */
-    #[AuthorizedAdminSetting(Application::APP_ID)]
+    #[AuthorizedAdminSetting(settings: \OCA\Pipelinq\Settings\AdminSettings::class)]
     public function create(): JSONResponse
     {
         $forbidden = $this->requireAdmin();
@@ -151,7 +151,7 @@ class PosRoleController extends Controller
      *
      * @spec openspec/changes/pos-staff-pin-permissions/tasks.md#4.1
      */
-    #[AuthorizedAdminSetting(Application::APP_ID)]
+    #[AuthorizedAdminSetting(settings: \OCA\Pipelinq\Settings\AdminSettings::class)]
     public function update(string $id): JSONResponse
     {
         $forbidden = $this->requireAdmin();
@@ -178,7 +178,7 @@ class PosRoleController extends Controller
      *
      * @spec openspec/changes/pos-staff-pin-permissions/tasks.md#4.1
      */
-    #[AuthorizedAdminSetting(Application::APP_ID)]
+    #[AuthorizedAdminSetting(settings: \OCA\Pipelinq\Settings\AdminSettings::class)]
     public function destroy(string $id): JSONResponse
     {
         $forbidden = $this->requireAdmin();

--- a/lib/Controller/PosRoleController.php
+++ b/lib/Controller/PosRoleController.php
@@ -29,6 +29,7 @@ use OCA\Pipelinq\AppInfo\Application;
 use OCA\Pipelinq\Service\PosRoleService;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http;
+use OCP\AppFramework\Http\Attribute\AuthorizedAdminSetting;
 use OCP\AppFramework\Http\Attribute\NoAdminRequired;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\AppFramework\OCS\OCSBadRequestException;
@@ -127,6 +128,7 @@ class PosRoleController extends Controller
      *
      * @spec openspec/changes/pos-staff-pin-permissions/tasks.md#4.1
      */
+    #[AuthorizedAdminSetting(Application::APP_ID)]
     public function create(): JSONResponse
     {
         $forbidden = $this->requireAdmin();
@@ -149,6 +151,7 @@ class PosRoleController extends Controller
      *
      * @spec openspec/changes/pos-staff-pin-permissions/tasks.md#4.1
      */
+    #[AuthorizedAdminSetting(Application::APP_ID)]
     public function update(string $id): JSONResponse
     {
         $forbidden = $this->requireAdmin();
@@ -175,6 +178,7 @@ class PosRoleController extends Controller
      *
      * @spec openspec/changes/pos-staff-pin-permissions/tasks.md#4.1
      */
+    #[AuthorizedAdminSetting(Application::APP_ID)]
     public function destroy(string $id): JSONResponse
     {
         $forbidden = $this->requireAdmin();

--- a/lib/Controller/PosStaffController.php
+++ b/lib/Controller/PosStaffController.php
@@ -29,6 +29,7 @@ use OCA\Pipelinq\AppInfo\Application;
 use OCA\Pipelinq\Service\PosStaffService;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http;
+use OCP\AppFramework\Http\Attribute\AuthorizedAdminSetting;
 use OCP\AppFramework\Http\Attribute\NoAdminRequired;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\AppFramework\OCS\OCSBadRequestException;
@@ -86,6 +87,7 @@ class PosStaffController extends Controller
      *
      * @spec openspec/changes/pos-staff-pin-permissions/tasks.md#4.2
      */
+    #[AuthorizedAdminSetting(Application::APP_ID)]
     public function index(): JSONResponse
     {
         $forbidden = $this->requireAdmin();
@@ -108,6 +110,7 @@ class PosStaffController extends Controller
      *
      * @spec openspec/changes/pos-staff-pin-permissions/tasks.md#4.2
      */
+    #[AuthorizedAdminSetting(Application::APP_ID)]
     public function show(string $id): JSONResponse
     {
         $forbidden = $this->requireAdmin();
@@ -133,6 +136,7 @@ class PosStaffController extends Controller
      *
      * @spec openspec/changes/pos-staff-pin-permissions/tasks.md#4.2
      */
+    #[AuthorizedAdminSetting(Application::APP_ID)]
     public function create(): JSONResponse
     {
         $forbidden = $this->requireAdmin();
@@ -155,6 +159,7 @@ class PosStaffController extends Controller
      *
      * @spec openspec/changes/pos-staff-pin-permissions/tasks.md#4.2
      */
+    #[AuthorizedAdminSetting(Application::APP_ID)]
     public function update(string $id): JSONResponse
     {
         $forbidden = $this->requireAdmin();
@@ -182,6 +187,7 @@ class PosStaffController extends Controller
      *
      * @spec openspec/changes/pos-staff-pin-permissions/tasks.md#4.2
      */
+    #[AuthorizedAdminSetting(Application::APP_ID)]
     public function destroy(string $id): JSONResponse
     {
         $forbidden = $this->requireAdmin();

--- a/lib/Controller/PosStaffController.php
+++ b/lib/Controller/PosStaffController.php
@@ -87,7 +87,7 @@ class PosStaffController extends Controller
      *
      * @spec openspec/changes/pos-staff-pin-permissions/tasks.md#4.2
      */
-    #[AuthorizedAdminSetting(Application::APP_ID)]
+    #[AuthorizedAdminSetting(settings: \OCA\Pipelinq\Settings\AdminSettings::class)]
     public function index(): JSONResponse
     {
         $forbidden = $this->requireAdmin();
@@ -110,7 +110,7 @@ class PosStaffController extends Controller
      *
      * @spec openspec/changes/pos-staff-pin-permissions/tasks.md#4.2
      */
-    #[AuthorizedAdminSetting(Application::APP_ID)]
+    #[AuthorizedAdminSetting(settings: \OCA\Pipelinq\Settings\AdminSettings::class)]
     public function show(string $id): JSONResponse
     {
         $forbidden = $this->requireAdmin();
@@ -136,7 +136,7 @@ class PosStaffController extends Controller
      *
      * @spec openspec/changes/pos-staff-pin-permissions/tasks.md#4.2
      */
-    #[AuthorizedAdminSetting(Application::APP_ID)]
+    #[AuthorizedAdminSetting(settings: \OCA\Pipelinq\Settings\AdminSettings::class)]
     public function create(): JSONResponse
     {
         $forbidden = $this->requireAdmin();
@@ -159,7 +159,7 @@ class PosStaffController extends Controller
      *
      * @spec openspec/changes/pos-staff-pin-permissions/tasks.md#4.2
      */
-    #[AuthorizedAdminSetting(Application::APP_ID)]
+    #[AuthorizedAdminSetting(settings: \OCA\Pipelinq\Settings\AdminSettings::class)]
     public function update(string $id): JSONResponse
     {
         $forbidden = $this->requireAdmin();
@@ -187,7 +187,7 @@ class PosStaffController extends Controller
      *
      * @spec openspec/changes/pos-staff-pin-permissions/tasks.md#4.2
      */
-    #[AuthorizedAdminSetting(Application::APP_ID)]
+    #[AuthorizedAdminSetting(settings: \OCA\Pipelinq\Settings\AdminSettings::class)]
     public function destroy(string $id): JSONResponse
     {
         $forbidden = $this->requireAdmin();


### PR DESCRIPTION
fix(security): declare the auth posture on 17 admin-only routed endpoints

hydra gate-5 (route-auth), measured FULL-TREE at origin/development, reported
17 routed methods with no auth attribute. Every one is admin-intended, but the
posture was declared only by OMISSION — Nextcloud's SecurityMiddleware default.
Nothing in the source stated it, so the intent was unreviewable and one added
attribute would silently have widened access.

  BerichtenboxAdminController  retry, stats
  PortalAdminController        saveConfig, accounts, auditEvents
  PosPaymentController         index, show, update, test
  PosRoleController            create, update, destroy
  PosStaffController           index, show, create, update, destroy

All 17 now carry #[AuthorizedAdminSetting(Application::APP_ID)] — already this
repo's dominant convention for admin endpoints (39 pre-existing usages;
MessagingController declares its provider config/test endpoints exactly this
way, which is the same shape as PosPaymentController's).

WHY THIS DOES NOT WIDEN ACCESS. SecurityMiddleware (lib/private/AppFramework/
Middleware/Security/SecurityMiddleware.php:137-160) authorizes an
AuthorizedAdminSetting method when isAdminUser() is true, or when the user has
delegated authorization for one of the named SETTING CLASSES, looked up via
groupAuthorizationMapper->findAllClassesForUser(). The argument here is the app
id 'pipelinq', which is not a settings class and can never appear in that list,
so the delegated branch cannot succeed. Net posture is admin-only — identical
to the previous framework default — plus NC's admin-IP restriction
(remoteAddress->allowsAdminActions()), which is strictly tighter than before.

The 12 POS methods additionally keep their in-body requireAdmin() guard, so
they are gated twice. The 5 methods in the two Admin controllers have no
in-body guard, which is exactly why APP_ID (no delegation possible) was used
rather than a real Settings class.

PROOF THE GATE CAN FAIL, not just that it passes:
  before          gate-5 FAIL, 17 findings (the list above)
  after           gate-5 PASS
  after + mutate  removed the attribute from PosStaffController::destroy only
                  -> gate-5 FAIL, 1 finding:
                     lib/Controller/PosStaffController.php:190 method=destroy
                     rule=missing-auth-attribute
                  attribute restored.

gate-9 (semantic-auth) stayed at 7 findings across the change, so no new
attribute-vs-body mismatch was introduced. Full-tree gate count 19 -> 18.

