### PR TITLE
fix(a11y,e2e): add autocomplete to 4 portal inputs, drop 9 networkidle waits

### DIFF
--- a/src/portal/views/PortalPasswordReset.vue
+++ b/src/portal/views/PortalPasswordReset.vue
@@ -12,6 +12,7 @@ SPDX-FileCopyrightText: 2026 Conduction B.V.
 				<input id="portal-reset-email"
 					v-model="email"
 					type="email"
+					autocomplete="email"
 					required>
 			</div>
 			<button type="submit" class="portal-button-primary">

--- a/src/portal/views/PortalProfile.vue
+++ b/src/portal/views/PortalProfile.vue
@@ -12,11 +12,17 @@ SPDX-FileCopyrightText: 2026 Conduction B.V.
 			</div>
 			<div class="portal-field">
 				<label for="portal-phone">{{ t('pipelinq', 'Phone') }}</label>
-				<input id="portal-phone" v-model="form.phone" type="tel" autocomplete="tel">
+				<input id="portal-phone"
+					v-model="form.phone"
+					type="tel"
+					autocomplete="tel">
 			</div>
 			<div class="portal-field">
 				<label for="portal-address">{{ t('pipelinq', 'Address') }}</label>
-				<input id="portal-address" v-model="form.address" type="text" autocomplete="street-address">
+				<input id="portal-address"
+					v-model="form.address"
+					type="text"
+					autocomplete="street-address">
 			</div>
 			<div v-if="form.accountType === 'b2b'" class="portal-field">
 				<label for="portal-jobtitle">{{ t('pipelinq', 'Job title') }}</label>
@@ -41,7 +47,10 @@ SPDX-FileCopyrightText: 2026 Conduction B.V.
 			</div>
 			<div class="portal-field">
 				<label for="portal-change-email">{{ t('pipelinq', 'Email address') }}</label>
-				<input id="portal-change-email" v-model="form.email" type="email" autocomplete="email">
+				<input id="portal-change-email"
+					v-model="form.email"
+					type="email"
+					autocomplete="email">
 				<small v-if="pendingEmail">{{ t('pipelinq', 'A verification link has been sent to {email}.', { email: pendingEmail }) }}</small>
 			</div>
 			<p v-if="message"

--- a/src/portal/views/PortalProfile.vue
+++ b/src/portal/views/PortalProfile.vue
@@ -12,11 +12,11 @@ SPDX-FileCopyrightText: 2026 Conduction B.V.
 			</div>
 			<div class="portal-field">
 				<label for="portal-phone">{{ t('pipelinq', 'Phone') }}</label>
-				<input id="portal-phone" v-model="form.phone" type="tel">
+				<input id="portal-phone" v-model="form.phone" type="tel" autocomplete="tel">
 			</div>
 			<div class="portal-field">
 				<label for="portal-address">{{ t('pipelinq', 'Address') }}</label>
-				<input id="portal-address" v-model="form.address" type="text">
+				<input id="portal-address" v-model="form.address" type="text" autocomplete="street-address">
 			</div>
 			<div v-if="form.accountType === 'b2b'" class="portal-field">
 				<label for="portal-jobtitle">{{ t('pipelinq', 'Job title') }}</label>
@@ -41,7 +41,7 @@ SPDX-FileCopyrightText: 2026 Conduction B.V.
 			</div>
 			<div class="portal-field">
 				<label for="portal-change-email">{{ t('pipelinq', 'Email address') }}</label>
-				<input id="portal-change-email" v-model="form.email" type="email">
+				<input id="portal-change-email" v-model="form.email" type="email" autocomplete="email">
 				<small v-if="pendingEmail">{{ t('pipelinq', 'A verification link has been sent to {email}.', { email: pendingEmail }) }}</small>
 			</div>
 			<p v-if="message"

--- a/tests/e2e/docs-screenshots.spec.ts
+++ b/tests/e2e/docs-screenshots.spec.ts
@@ -94,7 +94,7 @@ async function go(page: Page, route: string): Promise<void> {
 		url = `${APP}${tail}`
 	}
 	await page.goto(url).catch(() => { /* tolerate a 404 — caller decides */ })
-	await page.waitForLoadState('networkidle').catch(() => { /* idle never fires on some pages */ })
+	await page.waitForLoadState('domcontentloaded').catch(() => { /* tolerate a navigation that never settles */ })
 	await dismissOverlays(page)
 	await page.waitForTimeout(900)
 }
@@ -215,7 +215,7 @@ test.describe('docs: user track', () => {
 		// the admin settings page. Capture the admin page as stand-in
 		// for the per-user surface until that route is wired in dev.
 		await page.goto('/index.php/settings/admin/pipelinq')
-		await page.waitForLoadState('networkidle').catch(() => {})
+		await page.waitForLoadState('domcontentloaded').catch(() => {})
 		await dismissOverlays(page)
 		await page.waitForTimeout(900)
 		await shoot(page, 'user', '07-settings.png')
@@ -299,7 +299,7 @@ test.describe('docs: admin track', () => {
 		// the admin settings page (Pipelines section) and on the in-app
 		// /pipelines route. Capture both.
 		await page.goto('/index.php/settings/admin/pipelinq')
-		await page.waitForLoadState('networkidle').catch(() => {})
+		await page.waitForLoadState('domcontentloaded').catch(() => {})
 		await dismissOverlays(page)
 		await page.waitForTimeout(900)
 		await shoot(page, 'admin', '01-admin-settings.png')
@@ -310,7 +310,7 @@ test.describe('docs: admin track', () => {
 	test('A2 configure request types', async ({ page }) => {
 		// docs/user-guide/admin/02-request-types.md
 		await page.goto('/index.php/settings/admin/pipelinq')
-		await page.waitForLoadState('networkidle').catch(() => {})
+		await page.waitForLoadState('domcontentloaded').catch(() => {})
 		await dismissOverlays(page)
 		await page.waitForTimeout(900)
 		await shoot(page, 'admin', '02-request-types.png')
@@ -320,7 +320,7 @@ test.describe('docs: admin track', () => {
 		// docs/user-guide/admin/03-permissions.md — Agent Profiles
 		// section on the admin page.
 		await page.goto('/index.php/settings/admin/pipelinq')
-		await page.waitForLoadState('networkidle').catch(() => {})
+		await page.waitForLoadState('domcontentloaded').catch(() => {})
 		await dismissOverlays(page)
 		await page.waitForTimeout(900)
 		const profiles = page.getByRole('heading', { name: /Agent Profiles/i }).first()
@@ -335,7 +335,7 @@ test.describe('docs: admin track', () => {
 	test('A4 configure CRM workflows and automation', async ({ page }) => {
 		// docs/user-guide/admin/04-configure-automation.md
 		await page.goto('/index.php/settings/admin/pipelinq')
-		await page.waitForLoadState('networkidle').catch(() => {})
+		await page.waitForLoadState('domcontentloaded').catch(() => {})
 		await dismissOverlays(page)
 		await page.waitForTimeout(900)
 		await shoot(page, 'admin', '04-admin-settings.png')
@@ -350,7 +350,7 @@ test.describe('docs: admin track', () => {
 	test('A5 connect contacts and calendar sync', async ({ page }) => {
 		// docs/user-guide/admin/05-configure-sync.md
 		await page.goto('/index.php/settings/admin/pipelinq')
-		await page.waitForLoadState('networkidle').catch(() => {})
+		await page.waitForLoadState('domcontentloaded').catch(() => {})
 		await dismissOverlays(page)
 		await page.waitForTimeout(900)
 		await shoot(page, 'admin', '05-admin-settings.png')
@@ -361,7 +361,7 @@ test.describe('docs: admin track', () => {
 	test('A6 manage Pipelinq settings', async ({ page }) => {
 		// docs/user-guide/admin/06-admin-settings.md
 		await page.goto('/index.php/settings/admin/pipelinq')
-		await page.waitForLoadState('networkidle').catch(() => {})
+		await page.waitForLoadState('domcontentloaded').catch(() => {})
 		await dismissOverlays(page)
 		await page.waitForTimeout(900)
 		await page.evaluate(() => window.scrollTo(0, 0))

--- a/tests/e2e/spec-coverage/my-work.spec.ts
+++ b/tests/e2e/spec-coverage/my-work.spec.ts
@@ -45,7 +45,7 @@ test('my work page main content renders', async ({ page }) => {
 // @e2e openspec/specs/my-work/spec.md#manual-refresh
 test('my work page renders without uncaught errors', async ({ page }) => {
 	await page.goto('/apps/pipelinq/my-work')
-	await page.waitForLoadState('networkidle').catch(() => {})
+	await page.waitForLoadState('domcontentloaded').catch(() => {})
 	await expect(page.locator('body')).not.toContainText('Uncaught Error', { timeout: 10000 })
 })
 


### PR DESCRIPTION
fix(a11y,e2e): add autocomplete to 4 portal inputs, drop 9 networkidle waits

Two full-tree gate failures, both real, burned down together because each is
small and neither touches the other's files.

gate-44 autocomplete-attr — 4 findings (WCAG 2.2 AA, SC 1.3.5 Identify Input
Purpose). Four portal inputs collect standard personal data with no
autocomplete token, so browsers and assistive tech cannot offer or identify
the value:

  src/portal/views/PortalProfile.vue        portal-phone         -> tel
  src/portal/views/PortalProfile.vue        portal-address       -> street-address
  src/portal/views/PortalProfile.vue        portal-change-email  -> email
  src/portal/views/PortalPasswordReset.vue  portal-reset-email   -> email

These are the portal's own inputs, not NcSelect/NcTextField wrappers, so the
token has to be written explicitly; nothing else in the component supplies it.

gate-58 e2e-networkidle — 9 findings (ADR-074 rule 4). Every one is

    await page.waitForLoadState('networkidle').catch(() => {})

which is the worst shape of this bug: Nextcloud keeps background XHR alive, so
`networkidle` never fires, the wait burns its full timeout, and the `.catch()`
swallows the timeout so the test still passes. The cost is silent wall-clock,
not a visible failure. All 9 become 'domcontentloaded':

  tests/e2e/docs-screenshots.spec.ts            8 sites
  tests/e2e/spec-coverage/my-work.spec.ts       1 site

The one surviving mention of `networkidle` in tests/ is a comment in
tests/e2e/visual/_visual-helpers.ts explaining why it is not used — prose, not
a call, and correctly not flagged.

Measured full-tree at origin/development with the hydra-gates checkers run
directly over the whole tree (CI's own numbers here are diff-scoped to ~1 file
and cannot show this):

  gate-44  FAIL 4 findings  -> PASS
  gate-58  FAIL 9 findings  -> PASS

Both gates listed their findings by file before the change and report clean
after, so each was shown capable of failing on this tree rather than merely
observed green.
