### PR TITLE
fix(e2e): add a globalTimeout under the 45m CI cap

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -11,6 +11,17 @@ export default defineConfig({
 	fullyParallel: false,
 	retries: 1,
 	workers: 1,
+	// The shared quality.yml Playwright job is `timeout-minutes: 45`, and a job
+	// cancelled by that cap produces NO verdict: Playwright never prints its
+	// tally, the `if: failure()` trace upload never fires, and the
+	// `if: always()` report upload does not run on a cancelled job either — the
+	// run you most need to read is the one that leaves nothing behind, and it
+	// still renders as "fail" in `gh pr checks` while carrying no information.
+	// Runs cancelled at ~45m16s have been observed in this fleet. Measured
+	// overhead before `Run Playwright tests` starts is 2.0-2.4 min and the
+	// uploads after it take seconds, so 38m keeps ~7 min of margin while
+	// guaranteeing both a tally and the artifacts that explain it.
+	globalTimeout: 38 * 60_000,
 	reporter: [
 		['html', { open: 'never', outputFolder: 'tests/e2e/playwright-report' }],
 		['junit', { outputFile: 'tests/e2e/test-results/results.xml' }],


### PR DESCRIPTION
Part of the fleet-wide Playwright instrument sweep for ConductionNL/.github#188. Neither change can alter a verdict — both change whether you can *see* why a verdict happened.

## trace

This repo's `trace` is already `retain-on-failure`, so only the timeout half applies here.

Reproduced with two minimal Playwright projects differing only in the `trace` value, same deliberately failing test, `retries: 0` in both:

| config | trace zips written |
|---|---|
| `retries: 0` + `on-first-retry` | **0** |
| `retries: 0` + `retain-on-failure` | **1** (7.4 KB) |

## globalTimeout: 38 * 60_000

The shared `quality.yml` Playwright job is `timeout-minutes: 45`. A job cancelled by that cap yields **no verdict and no artifacts** — the trace upload is `if: failure()`, the report upload is `if: always()`, and neither runs on a cancelled job, while `gh pr checks` still renders it as "fail". Runs cancelled at ~45m16s have been observed in this fleet.

Margin, measured rather than assumed: overhead before `Run Playwright tests` starts is 2.0-2.4 min (openconnector run 31257480415 = 2m20s; opencatalogi, doriath, openregister in the same band); uploads after it take seconds. 38m + ~2.5m setup + uploads sits ~7 min under the cap. Verified that a fired `globalTimeout` exits with a tally (`3 did not run / 1 passed`) plus an HTML report and a trace zip on disk — exactly what a cancelled job does not give you.

Matches the value already landed in nldesign.