### PR TITLE
chore(ci): ratchet playwright-coverage-threshold 75 -> 20, the measured floor

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -183,7 +183,27 @@ jobs:
       enable-playwright: true
       playwright-test-path: tests/e2e
       enable-playwright-coverage: true
-      playwright-coverage-threshold: 75
+      # RATCHET, not an aspiration. This was 75 while the number the workflow
+      # actually computed was 28% — and the gate emitted `::warning::` and
+      # returned zero, so the run went green anyway (ConductionNL/.github#189).
+      # The declared floor had never once been enforced, which is why it could
+      # sit 47 points above reality without anyone noticing.
+      #
+      # .github#189 makes the threshold enforce (`::error::` + non-zero exit)
+      # AND replaces the metric: it is no longer
+      # `count(test() calls) / count(scenario headings)` — two totals that were
+      # never compared to each other — but real per-scenario matching against
+      # `@e2e` references, in gate-19's dialect.
+      #
+      # Measured on this repo at 51476e2 with the shipped program:
+      #   2659 scenarios found, 2140 @e2e-excluded (with reasons), 519
+      #   enforceable, 116 covered by an @e2e reference => 22%.
+      #
+      # So 20 is the floor we can actually hold today, with two points of slack.
+      # Left at 75 this repo would have gone red on the merge of .github#189
+      # with no code change. Raise this as scenarios get annotated; it must only
+      # ever go up.
+      playwright-coverage-threshold: 20
       # Pin openregister to development: main lacks the react/async composer dep
       # that lib/Service/ObjectService.php (Async\await call) requires, so app:enable
       # fails with "Call to undefined function React\Async\await()" during seed.


### PR DESCRIPTION
## Why now

`ConductionNL/.github#189` makes `playwright-coverage-threshold` **enforce for the first time**, and replaces the number behind it.

pipelinq is the **only repo in the fleet** that sets `enable-playwright-coverage: true` (measured 2026-08-08 across all 31 callers of `quality.yml`), so it is the only repo with any blast radius from that change — and this PR is the whole of it.

## What was wrong with 75

It was never enforced. The old step emitted `::warning::` and returned zero:

```
Spec-to-test coverage: 28%
##[warning]Spec-to-test coverage 28% is below threshold 75%
```

Run `31082256226` printed exactly that and went **green**. A declared floor can sit 47 points above reality indefinitely when nothing reads it.

## What the number means now

Not `count(test() calls) / count(scenario headings)` — two independent totals that were never compared to each other, and which ten unrelated `test()` calls raised exactly as much as covering ten scenarios did. It is now real per-scenario matching against `@e2e` references, in gate-19's dialect.

Measured on this repo at `51476e2` with the program `.github#189` ships:

| | |
|---|---|
| scenarios found | 2659 |
| `@e2e exclude`d (all reason-bearing) | 2140 |
| **enforceable** | **519** |
| covered by an `@e2e` reference | 116 |
| **scenario coverage** | **22%** |

## Why 20

It is the floor this repo can actually hold today, with two points of slack. Left at 75, pipelinq's `E2E Tests (Playwright)` job — and therefore `Quality Report`, the required check — goes **red on the merge of .github#189, with no code change here**.

This is a ratchet: raise it as scenarios get annotated. It must only ever go up.

## Note on `beta`

`beta` also carries `playwright-coverage-threshold: 75`. It is human-gated, so it is not touched here and will need the same change to come across on the next `development → beta` sync.