### PR TITLE
feat(settings): add canonical PUT /api/settings (settings#update)

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -6,6 +6,10 @@ return [
     'routes' => [
         ['name' => 'settings#index', 'url' => '/api/settings', 'verb' => 'GET'],
         ['name' => 'settings#create', 'url' => '/api/settings', 'verb' => 'POST'],
+        // Canonical ADR-066 write verb (OpenRegister AppHost dialect). POST above
+        // stays as the legacy alias for the existing frontend callers. Declared
+        // here in the settings block, BEFORE the SPA/wildcard catch-alls (ADR-016).
+        ['name' => 'settings#update', 'url' => '/api/settings', 'verb' => 'PUT'],
         ['name' => 'settings#reimport', 'url' => '/api/settings/reimport', 'verb' => 'POST'],
         // First-time setup wizard (ADR-042)
         ['name' => 'setup#status',     'url' => '/api/setup/status',            'verb' => 'GET'],

--- a/lib/Controller/SettingsController.php
+++ b/lib/Controller/SettingsController.php
@@ -17,7 +17,6 @@
  * @link https://pipelinq.nl
  *
  * @spec openspec/specs/admin-settings/spec.md
- * @spec openspec/specs/admin-settings/spec.md
  */
 
 declare(strict_types=1);
@@ -148,17 +147,41 @@ class SettingsController extends Controller
     }//end index()
 
     /**
-     * Update Pipelinq settings.
+     * Update Pipelinq settings — the canonical instance-wide write.
      *
-     * Admin-only endpoint (requires admin settings permission). The index()
-     * method carries the read permission so non-admin users can read settings.
+     * This is the ADR-066 canonical write verb, matching
+     * {@see \OCA\OpenRegister\AppHost\Controller\GenericSettingsControllerBase::update()}.
+     * Pipelinq does NOT adopt `\OCA\OpenRegister\AppHost\Routes::standard()`,
+     * and it ships its own SettingsController — so
+     * `AppHost\Bootstrap::aliasControllerUnlessLeafDefinesIt()` never aliases
+     * the generic in and this leaf owes the method itself. Measured on the dev
+     * instance 2026-08-08, before this change: `PUT /api/settings` answered
+     * **405 Method Not Allowed** (no PUT route existed), not a 500.
+     *
+     * Scope: INSTANCE-WIDE. The write goes to
+     * {@see SettingsService::updateSettings()}, which persists the app-config
+     * map (`register`, `*_schema`, `export.*`, thresholds, …) shared by every
+     * user of the instance. It deliberately does NOT touch the per-user
+     * surface served by {@see updateUserSettings()} — that is a different
+     * scope with a different (non-admin) auth posture.
+     *
+     * Auth: the AuthorizedAdminSetting posture, identical to {@see create()}.
+     * An instance-wide write must never inherit the non-admin posture of the
+     * per-user write or of the {@see index()} read.
+     *
+     * Attribute syntax is deliberately NOT written out in this docblock:
+     * gate-5 (route-auth) decides by grepping the lines above the signature,
+     * so a comment quoting the attribute would satisfy the gate on its own and
+     * a later deletion of the real attribute would still report PASS. The
+     * posture is asserted properly, by reflection, in
+     * tests/Unit/Controller/SettingsControllerWriteTest.php.
      *
      * @return JSONResponse The updated settings response.
      *
      * @spec openspec/specs/admin-settings/spec.md
      */
     #[AuthorizedAdminSetting(Application::APP_ID)]
-    public function create(): JSONResponse
+    public function update(): JSONResponse
     {
         $data   = $this->request->getParams();
         $config = $this->settingsService->updateSettings($data);
@@ -169,6 +192,29 @@ class SettingsController extends Controller
                     'config'  => $config,
                 ]
                 );
+    }//end update()
+
+    /**
+     * Legacy alias for {@see update()} — `POST /api/settings`.
+     *
+     * The canonical AppHost route table keeps `settings#create` for the
+     * fleet's pre-ADR-066 `index/create/load` dialect, and pipelinq has live
+     * callers on it (`src/store/modules/settings.js::saveSettings()` and
+     * `src/views/settings/ExportConfigurationSettings.vue::save()`), so the
+     * POST verb stays reachable and behaviourally identical (ADR-029).
+     *
+     * The attribute is repeated deliberately: Nextcloud's SecurityMiddleware
+     * evaluates the attributes of the DISPATCHED method only, so delegating to
+     * `update()` does not carry `update()`'s posture across.
+     *
+     * @return JSONResponse The updated settings response.
+     *
+     * @spec openspec/specs/admin-settings/spec.md
+     */
+    #[AuthorizedAdminSetting(Application::APP_ID)]
+    public function create(): JSONResponse
+    {
+        return $this->update();
     }//end create()
 
     /**

--- a/tests/Unit/AppInfo/SettingsRouteContractTest.php
+++ b/tests/Unit/AppInfo/SettingsRouteContractTest.php
@@ -1,0 +1,238 @@
+<?php
+
+/**
+ * Route-table contract tests for the /api/settings surface.
+ *
+ * @category Test
+ * @package  OCA\Pipelinq\Tests\Unit\AppInfo
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://pipelinq.nl
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ *
+ * @spec openspec/specs/admin-settings/spec.md
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Pipelinq\Tests\Unit\AppInfo;
+
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+
+/**
+ * Pipelinq declares its own route table — it does NOT adopt
+ * `\OCA\OpenRegister\AppHost\Routes::standard()` — and it ships its own
+ * `SettingsController`, so `AppHost\Bootstrap::aliasControllerUnlessLeafDefinesIt()`
+ * never aliases OpenRegister's generic controller in. Both halves of the
+ * `settings#` surface are therefore owed by this app and can drift apart in
+ * two directions:
+ *
+ *   - a route with no method  -> ReflectionException, HTTP 500;
+ *   - a method with no route  -> the verb is simply not matched. Measured on
+ *     the dev instance 2026-08-08: `PUT /api/settings` answered **405 Method
+ *     Not Allowed** because no PUT entry existed, while GET and POST answered
+ *     200.
+ *
+ * These tests EVALUATE the array returned by `appinfo/routes.php` rather than
+ * grepping its source, so a route that is commented out, mistyped as a string
+ * or placed inside an unreachable branch cannot satisfy them.
+ *
+ * @spec openspec/specs/admin-settings/spec.md
+ */
+class SettingsRouteContractTest extends TestCase
+{
+    /**
+     * Load and evaluate the shipped route table.
+     *
+     * @return array<int, array<string, mixed>> The declared route entries.
+     *
+     * @spec openspec/specs/admin-settings/spec.md
+     */
+    private function routes(): array
+    {
+        $table = include __DIR__.'/../../../appinfo/routes.php';
+
+        $this->assertIsArray($table, 'appinfo/routes.php must return an array');
+        $this->assertArrayHasKey('routes', $table, 'appinfo/routes.php must declare a "routes" key');
+        $this->assertIsArray($table['routes'], 'The "routes" key must hold an array');
+
+        return $table['routes'];
+
+    }//end routes()
+
+    /**
+     * Find the index of a route entry by name + url + verb.
+     *
+     * @param array<int, array<string, mixed>> $routes The evaluated route table.
+     * @param string                           $name   The route name.
+     * @param string                           $url    The route url.
+     * @param string                           $verb   The HTTP verb.
+     *
+     * @return int|null The zero-based index, or null when absent.
+     *
+     * @spec openspec/specs/admin-settings/spec.md
+     */
+    private function indexOfRoute(array $routes, string $name, string $url, string $verb): ?int
+    {
+        foreach ($routes as $index => $route) {
+            if (is_array($route) === false) {
+                continue;
+            }
+
+            if (($route['name'] ?? null) === $name
+                && ($route['url'] ?? null) === $url
+                && ($route['verb'] ?? null) === $verb
+            ) {
+                return $index;
+            }
+        }
+
+        return null;
+
+    }//end indexOfRoute()
+
+    /**
+     * The canonical write verb must be routed.
+     *
+     * @return void
+     *
+     * @spec openspec/specs/admin-settings/spec.md
+     */
+    public function testCanonicalPutSettingsRouteIsDeclared(): void
+    {
+        $routes = $this->routes();
+
+        $this->assertNotNull(
+            $this->indexOfRoute($routes, 'settings#update', '/api/settings', 'PUT'),
+            'appinfo/routes.php does not declare the canonical ADR-066 write '
+            .'["name" => "settings#update", "url" => "/api/settings", "verb" => "PUT"]. '
+            .'Without it PUT /api/settings answers 405 Method Not Allowed.'
+        );
+
+    }//end testCanonicalPutSettingsRouteIsDeclared()
+
+    /**
+     * The legacy POST alias must survive the conversion.
+     *
+     * `src/store/modules/settings.js::saveSettings()` and
+     * `src/views/settings/ExportConfigurationSettings.vue::save()` both POST
+     * to this exact url, so removing the alias would break the live admin UI.
+     *
+     * @return void
+     *
+     * @spec openspec/specs/admin-settings/spec.md
+     */
+    public function testLegacyPostSettingsRouteIsPreserved(): void
+    {
+        $routes = $this->routes();
+
+        $this->assertNotNull(
+            $this->indexOfRoute($routes, 'settings#create', '/api/settings', 'POST'),
+            'The legacy POST /api/settings route was removed — the settings store '
+            .'and ExportConfigurationSettings.vue still call it.'
+        );
+
+        $this->assertNotNull(
+            $this->indexOfRoute($routes, 'settings#index', '/api/settings', 'GET'),
+            'The GET /api/settings read route was removed.'
+        );
+
+    }//end testLegacyPostSettingsRouteIsPreserved()
+
+    /**
+     * Settings routes must precede the SPA wildcard catch-all (ADR-016).
+     *
+     * `dashboard#page` matches `/{path}` with `path => .*`, so any route
+     * declared after it is unreachable for GET. Ordering is a property of the
+     * evaluated array, which is why this test reads indices and not source
+     * lines.
+     *
+     * @return void
+     *
+     * @spec openspec/specs/admin-settings/spec.md
+     */
+    public function testSettingsRoutesPrecedeTheSpaCatchAll(): void
+    {
+        $routes = $this->routes();
+
+        $catchAll = $this->indexOfRoute($routes, 'dashboard#page', '/{path}', 'GET');
+        $this->assertNotNull($catchAll, 'The SPA catch-all route is missing — this test cannot be read.');
+
+        $update = $this->indexOfRoute($routes, 'settings#update', '/api/settings', 'PUT');
+        $this->assertNotNull($update, 'settings#update PUT is not declared.');
+
+        $this->assertLessThan(
+            $catchAll,
+            $update,
+            'settings#update must be declared BEFORE the SPA wildcard catch-all (ADR-016).'
+        );
+
+    }//end testSettingsRoutesPrecedeTheSpaCatchAll()
+
+    /**
+     * Every declared `settings#` route must target a public method.
+     *
+     * A route whose target method does not exist is a ReflectionException at
+     * dispatch (HTTP 500), not a 404 — the router matched the url already.
+     *
+     * @return void
+     *
+     * @spec openspec/specs/admin-settings/spec.md
+     */
+    public function testEverySettingsRouteTargetsAPublicControllerMethod(): void
+    {
+        $reflection = new ReflectionClass(\OCA\Pipelinq\Controller\SettingsController::class);
+
+        $inspected = 0;
+        $missing   = [];
+
+        foreach ($this->routes() as $route) {
+            if (is_array($route) === false || is_string($route['name'] ?? null) === false) {
+                continue;
+            }
+
+            if (str_starts_with($route['name'], 'settings#') === false) {
+                continue;
+            }
+
+            $method = substr($route['name'], strlen('settings#'));
+            $inspected++;
+
+            if ($reflection->hasMethod($method) === false) {
+                $missing[] = sprintf('SettingsController::%s() [%s %s]', $method, $route['verb'] ?? '?', $route['url'] ?? '?');
+                continue;
+            }
+
+            $this->assertTrue(
+                $reflection->getMethod($method)->isPublic(),
+                sprintf('SettingsController::%s() must be public to be dispatchable', $method)
+            );
+        }//end foreach
+
+        // Positive control. An empty $missing list only means something if the
+        // loop actually looked at routes; a broken name filter would produce
+        // the same "no findings" as a healthy route table.
+        $this->assertGreaterThan(
+            0,
+            $inspected,
+            'No settings# route was inspected — the route-name filter matched nothing, '
+            .'so the empty finding list below proves nothing.'
+        );
+
+        $this->assertSame(
+            [],
+            $missing,
+            "These routes point at methods SettingsController does not define. Each is a 500, not a 404:\n  - "
+            .implode("\n  - ", $missing)
+        );
+
+    }//end testEverySettingsRouteTargetsAPublicControllerMethod()
+}//end class

--- a/tests/Unit/Controller/SettingsControllerWriteTest.php
+++ b/tests/Unit/Controller/SettingsControllerWriteTest.php
@@ -1,0 +1,358 @@
+<?php
+
+/**
+ * SettingsController instance-wide write-path unit tests.
+ *
+ * @category Test
+ * @package  OCA\Pipelinq\Tests\Unit\Controller
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://pipelinq.nl
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ *
+ * @spec openspec/specs/admin-settings/spec.md
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Pipelinq\Tests\Unit\Controller;
+
+use OCA\Pipelinq\Controller\SettingsController;
+use OCA\Pipelinq\Service\SettingsService;
+use OCP\App\IAppManager;
+use OCP\AppFramework\Http\Attribute\AuthorizedAdminSetting;
+use OCP\AppFramework\Http\Attribute\NoAdminRequired;
+use OCP\IGroupManager;
+use OCP\IL10N;
+use OCP\IRequest;
+use OCP\IUser;
+use OCP\IUserSession;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+use Psr\Log\LoggerInterface;
+use ReflectionClass;
+
+/**
+ * `PUT /api/settings` (`settings#update`) is the canonical ADR-066
+ * instance-wide write; `POST /api/settings` (`settings#create`) is the legacy
+ * alias kept for the live frontend callers.
+ *
+ * These tests assert the ITEM — that the write actually reaches
+ * `SettingsService::updateSettings()` with the request's own parameters and
+ * that the response carries what the service stored. A test that only checked
+ * for a JSONResponse, or only for `success => true`, would pass against a
+ * controller that silently wrote nothing.
+ *
+ * The auth tests exist because the single highest-risk mistake available here
+ * is copying `#[NoAdminRequired]` from `updateUserSettings()` — a legitimately
+ * non-admin PER-USER write — onto the INSTANCE-WIDE write.
+ *
+ * @spec openspec/specs/admin-settings/spec.md
+ */
+class SettingsControllerWriteTest extends TestCase
+{
+
+    /**
+     * The mocked request.
+     *
+     * @var IRequest&MockObject
+     */
+    private IRequest $request;
+
+    /**
+     * The mocked settings service.
+     *
+     * @var SettingsService&MockObject
+     */
+    private SettingsService $settingsService;
+
+    /**
+     * Set up the mocks shared by every test.
+     *
+     * @return void
+     *
+     * @spec openspec/specs/admin-settings/spec.md
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->request         = $this->createMock(originalClassName: IRequest::class);
+        $this->settingsService = $this->createMock(originalClassName: SettingsService::class);
+
+    }//end setUp()
+
+    /**
+     * Build the controller under test with its collaborators mocked.
+     *
+     * @return SettingsController The controller under test.
+     *
+     * @spec openspec/specs/admin-settings/spec.md
+     */
+    private function controller(): SettingsController
+    {
+        $userSession = $this->createMock(originalClassName: IUserSession::class);
+        $user        = $this->createMock(originalClassName: IUser::class);
+        $user->method('getUID')->willReturn('admin');
+        $userSession->method('getUser')->willReturn($user);
+
+        $l10n = $this->createMock(originalClassName: IL10N::class);
+        $l10n->method('t')->willReturnArgument(0);
+
+        return new SettingsController(
+            request: $this->request,
+            container: $this->createMock(originalClassName: ContainerInterface::class),
+            appManager: $this->createMock(originalClassName: IAppManager::class),
+            groupManager: $this->createMock(originalClassName: IGroupManager::class),
+            settingsService: $this->settingsService,
+            userSession: $userSession,
+            l10n: $l10n,
+            logger: $this->createMock(originalClassName: LoggerInterface::class),
+        );
+
+    }//end controller()
+
+    /**
+     * PUT /api/settings must persist the request parameters and return the
+     * config the service actually stored.
+     *
+     * @return void
+     *
+     * @spec openspec/specs/admin-settings/spec.md
+     */
+    public function testUpdatePersistsTheRequestParametersAndReturnsTheStoredConfig(): void
+    {
+        $submitted = ['register' => '16', 'lead_schema' => '62'];
+        $stored    = ['register' => '16', 'lead_schema' => '62', 'currency' => 'EUR'];
+
+        $this->request->method('getParams')->willReturn($submitted);
+
+        // The ITEM: the write reaches the service, with the submitted params.
+        $this->settingsService->expects($this->once())
+            ->method('updateSettings')
+            ->with($submitted)
+            ->willReturn($stored);
+
+        $response = $this->controller()->update();
+
+        $this->assertSame(
+            ['success' => true, 'config' => $stored],
+            $response->getData(),
+            'update() must return the config the service stored, not the submission'
+        );
+
+    }//end testUpdatePersistsTheRequestParametersAndReturnsTheStoredConfig()
+
+    /**
+     * POST /api/settings is a legacy alias and must write identically.
+     *
+     * `src/views/settings/ExportConfigurationSettings.vue::save()` still posts
+     * here, so the alias staying a real write — not an empty success — is
+     * load-bearing.
+     *
+     * @return void
+     *
+     * @spec openspec/specs/admin-settings/spec.md
+     */
+    public function testCreateDelegatesToUpdateAndStillWrites(): void
+    {
+        $submitted = ['export.retention_days' => '30'];
+        $stored    = ['export.retention_days' => '30'];
+
+        $this->request->method('getParams')->willReturn($submitted);
+
+        $this->settingsService->expects($this->once())
+            ->method('updateSettings')
+            ->with($submitted)
+            ->willReturn($stored);
+
+        $response = $this->controller()->create();
+
+        $this->assertSame(
+            ['success' => true, 'config' => $stored],
+            $response->getData(),
+            'create() must produce the same written result as update()'
+        );
+
+    }//end testCreateDelegatesToUpdateAndStillWrites()
+
+    /**
+     * An empty submission must still reach the service.
+     *
+     * An early return on an empty payload looks identical, from the caller's
+     * side, to a successful no-op write.
+     *
+     * @return void
+     *
+     * @spec openspec/specs/admin-settings/spec.md
+     */
+    public function testEmptySubmissionStillReachesTheService(): void
+    {
+        $this->request->method('getParams')->willReturn([]);
+
+        $this->settingsService->expects($this->once())
+            ->method('updateSettings')
+            ->with([])
+            ->willReturn(['unchanged' => true]);
+
+        $response = $this->controller()->update();
+
+        $this->assertSame(
+            ['success' => true, 'config' => ['unchanged' => true]],
+            $response->getData()
+        );
+
+    }//end testEmptySubmissionStillReachesTheService()
+
+    /**
+     * The instance-wide write must NOT touch the per-user surface.
+     *
+     * `updateUserSettings()` is a different scope with a different (non-admin)
+     * posture; `update()` writing through it would silently widen who can
+     * change instance configuration.
+     *
+     * @return void
+     *
+     * @spec openspec/specs/admin-settings/spec.md
+     */
+    public function testUpdateDoesNotWriteThroughThePerUserSurface(): void
+    {
+        $this->request->method('getParams')->willReturn(['register' => '16']);
+        $this->settingsService->method('updateSettings')->willReturn(['register' => '16']);
+
+        $this->settingsService->expects($this->never())->method('updateUserSettings');
+        $this->settingsService->expects($this->never())->method('getUserSettings');
+
+        $this->controller()->update();
+
+    }//end testUpdateDoesNotWriteThroughThePerUserSurface()
+
+    /**
+     * Collect the attribute class names declared on a controller method.
+     *
+     * Attribute NAMES are read as strings so the assertion does not depend on
+     * the attribute class being instantiable in the unit harness.
+     *
+     * @param string $method The controller method name.
+     *
+     * @return array<int, string> The declared attribute class names.
+     *
+     * @spec openspec/specs/admin-settings/spec.md
+     */
+    private function attributeNamesOf(string $method): array
+    {
+        $reflection = new ReflectionClass(SettingsController::class);
+        $this->assertTrue(
+            $reflection->hasMethod($method),
+            sprintf('SettingsController::%s() does not exist', $method)
+        );
+
+        return array_map(
+            static fn ($attribute) => $attribute->getName(),
+            $reflection->getMethod($method)->getAttributes()
+        );
+
+    }//end attributeNamesOf()
+
+    /**
+     * The instance-wide write carries the admin posture, and only that.
+     *
+     * @return void
+     *
+     * @spec openspec/specs/admin-settings/spec.md
+     */
+    public function testUpdateCarriesTheInstanceWideAdminPosture(): void
+    {
+        $attributes = $this->attributeNamesOf('update');
+
+        $this->assertContains(
+            AuthorizedAdminSetting::class,
+            $attributes,
+            'SettingsController::update() is the INSTANCE-WIDE write and must carry '
+            .'#[AuthorizedAdminSetting].'
+        );
+
+        $this->assertNotContains(
+            NoAdminRequired::class,
+            $attributes,
+            'SettingsController::update() must NOT carry #[NoAdminRequired]. That posture '
+            .'belongs to the per-user write updateUserSettings() and to the index() read; '
+            .'on the instance-wide write it would let any authenticated user rewrite the '
+            .'register/schema bindings for everyone.'
+        );
+
+    }//end testUpdateCarriesTheInstanceWideAdminPosture()
+
+    /**
+     * The legacy alias keeps its OWN attribute.
+     *
+     * Nextcloud's SecurityMiddleware evaluates the attributes of the
+     * DISPATCHED method only, so `create()` delegating to `update()` does not
+     * inherit `update()`'s posture. Dropping the attribute here would make
+     * `POST /api/settings` non-admin while `PUT` stayed admin-only.
+     *
+     * @return void
+     *
+     * @spec openspec/specs/admin-settings/spec.md
+     */
+    public function testCreateKeepsItsOwnAdminPostureDespiteDelegating(): void
+    {
+        $attributes = $this->attributeNamesOf('create');
+
+        $this->assertContains(
+            AuthorizedAdminSetting::class,
+            $attributes,
+            'SettingsController::create() must keep its own #[AuthorizedAdminSetting]; '
+            .'delegating to update() does not carry the attribute across the dispatcher.'
+        );
+
+        $this->assertNotContains(NoAdminRequired::class, $attributes);
+
+        $this->assertSame(
+            $this->attributeNamesOf('update'),
+            $attributes,
+            'create() and update() are the same instance-wide write and must share '
+            .'an identical auth posture — the net privilege change of this conversion is zero.'
+        );
+
+    }//end testCreateKeepsItsOwnAdminPostureDespiteDelegating()
+
+    /**
+     * The per-user write is the contrast case and stays non-admin.
+     *
+     * This is the positive control for the two assertions above: it proves the
+     * attribute reader can actually observe `#[NoAdminRequired]` on this class,
+     * so `assertNotContains()` on `update()` is a real measurement rather than
+     * a reader that never finds anything.
+     *
+     * @return void
+     *
+     * @spec openspec/specs/admin-settings/spec.md
+     */
+    public function testPerUserWriteRemainsNonAdminAndProvesTheAttributeReaderWorks(): void
+    {
+        $attributes = $this->attributeNamesOf('updateUserSettings');
+
+        $this->assertContains(
+            NoAdminRequired::class,
+            $attributes,
+            'updateUserSettings() is a PER-USER write and must stay #[NoAdminRequired]. '
+            .'If this fails, every assertNotContains(NoAdminRequired) above is unreadable.'
+        );
+
+        $this->assertNotContains(
+            AuthorizedAdminSetting::class,
+            $attributes,
+            'The per-user write must not be gated behind the admin settings panel.'
+        );
+
+    }//end testPerUserWriteRemainsNonAdminAndProvesTheAttributeReaderWorks()
+}//end class


### PR DESCRIPTION
## Summary

Adds the canonical ADR-066 write verb `PUT /api/settings` (`settings#update`) to pipelinq, as a **strict addition**. The existing `GET` and `POST` behaviour is unchanged.

## ⚠️ This is a 405 / missing-route case, not the fleet-wide 500

The fleet brief for this sweep said `PUT /api/settings` "resolves to a nonexistent method" (a dispatcher 500). **That is not what pipelinq did.** Measured on the running dev instance, 2026-08-08, against `origin/development`:

```
$ curl -s -o /dev/null -w "%{http_code}" -u admin:admin -H "OCS-APIRequest: true" \
       -X GET  http://localhost:8080/apps/pipelinq/api/settings
200
$ curl ... -X POST http://localhost:8080/apps/pipelinq/api/settings
200
$ curl ... -X PUT  http://localhost:8080/apps/pipelinq/api/settings
405
```

**405 Method Not Allowed**, not 500. The reason is that pipelinq does **not** call `\OCA\OpenRegister\AppHost\Routes::standard()` — it declares its own route table, and that table had `settings#index` (GET) and `settings#create` (POST) but no PUT entry at all. The router never matched, so the dispatcher never ran and there was no reflection error to produce a 500.

(Without the `OCS-APIRequest` header these same probes answer `412 {"message":"CSRF check failed"}` — the CSRF middleware answers before anything route-specific. The 405 above is stable either way, because verb matching happens first.)

Because pipelinq ships its own `lib/Controller/SettingsController.php`, OpenRegister's `AppHost\Bootstrap::aliasControllerUnlessLeafDefinesIt()` skips the generic controller entirely — so this leaf owes every `settings#` method itself. Adding `update()` without the route would ship an unreachable method (gate-14); adding the route without `update()` would convert the 405 into a real 500. Both halves land together here.

## What changed

- **`lib/Controller/SettingsController.php`** — `update()` is now the canonical instance-wide write and holds the body `create()` used to have. `create()` becomes `return $this->update();`.
- **`appinfo/routes.php`** — one new entry, `['name' => 'settings#update', 'url' => '/api/settings', 'verb' => 'PUT']`, placed in the settings block immediately after `settings#create` and well before the SPA/wildcard catch-alls (ADR-016).

### What `update()` writes, and why that is the right surface

`update()` calls `SettingsService::updateSettings($this->request->getParams())`, which persists the **instance-wide** app-config map — `register`, the `*_schema` bindings, `export.*`, the lead-staleness thresholds and so on. That is exactly what `create()` already wrote, and exactly what `REQ-AS-012 / Scenario: Save register mapping` describes; the conversion moves the body without altering it.

pipelinq also has a **per-user** settings pair (`getUserSettings` / `updateUserSettings` on `/api/settings/user`). That surface is deliberately **untouched** — different scope, different storage, different auth. There is a test asserting `update()` never reaches it.

`reimport()` (pipelinq's analogue of the canonical `load()`) is left exactly as it was.

## Auth decision

`update()` carries **`#[AuthorizedAdminSetting(Application::APP_ID)]`** — byte-identical to what `create()` already declared. **Net privilege change: zero.**

It specifically does **not** take `#[NoAdminRequired]`. Two sibling methods on this same class carry that attribute and neither is a valid model for this one:

- `index()` is a **read**;
- `updateUserSettings()` is a **per-user write**, legitimately non-admin because a user may only rewrite their own preferences.

The instance-wide write rewrites the register/schema bindings for *everyone* on the instance. Copying the non-admin posture across from either sibling would have been a privilege escalation.

`create()` keeps its own attribute even though its body is now a one-line delegation: Nextcloud's `SecurityMiddleware` evaluates the attributes of the **dispatched** method only, so delegating to `update()` does not carry `update()`'s posture across the dispatcher.

There was no in-body guard in `create()` to move.

### One thing worth flagging in the docblock

While probing gate-5 (route-auth) I found that its detection is a `grep` over the lines above the signature for `#\[(PublicPage|NoAdminRequired|NoCSRFRequired|AuthorizedAdminSetting)`. My first draft of the `update()` docblock explained the auth decision *using that literal syntax* — and the gate matched the **prose**. Proof: with the attribute deleted but the prose present, gate-5 still reported 17 findings and named nothing in `SettingsController`. That is a self-inflicted dead gate — the attribute could have been deleted later and the gate would still have said PASS. The docblock now describes the posture in words only, and with that fixed the same deletion probe correctly reports **18** findings including `SettingsController.php:183 method=update rule=missing-auth-attribute`.

## Tests

11 new tests, both files under `tests/Unit/`.

`tests/Unit/AppInfo/SettingsRouteContractTest.php` — **evaluates** the array returned by `appinfo/routes.php` rather than grepping its source, so a commented-out or mistyped entry cannot satisfy it:
- the `settings#update` / `/api/settings` / `PUT` entry exists;
- the legacy `POST` and the `GET` entries survive;
- `settings#update` is declared before the `dashboard#page` SPA catch-all (ADR-016), asserted on array **indices**;
- every `settings#`-prefixed route targets a public method on the controller, with an `$inspected > 0` **positive control** so an empty finding list cannot come from a filter that matched nothing.

`tests/Unit/Controller/SettingsControllerWriteTest.php`:
- `update()` reaches `SettingsService::updateSettings()` **with the submitted params** and returns what the service stored (not what was submitted);
- `create()` delegates and still performs a real write;
- an empty submission still reaches the service (an early return would look identical to a successful no-op from the caller's side);
- `update()` never calls `updateUserSettings()` / `getUserSettings()`;
- `update()` carries `AuthorizedAdminSetting` and not `NoAdminRequired`; `create()`'s posture is asserted **identical** to `update()`'s;
- `updateUserSettings()` still carries `NoAdminRequired` — this is the **positive control** for the two `assertNotContains` above, proving the reflection reader can actually observe that attribute on this class.

### Can-fail proof

**1. `update()` removed** (via editor, not `git checkout`) → RED, naming the method:

```
Error: Call to undefined method OCA\Pipelinq\Controller\SettingsController::update()
  - SettingsController::update() [PUT /api/settings]
SettingsController::update() does not exist
Tests: 11, Assertions: 33, Errors: 4, Failures: 3.
```

**2. route line removed** → RED on the route tests only:

```
1) SettingsRouteContractTest::testSettingsRoutesPrecedeTheSpaCatchAll
settings#update PUT is not declared.
2) SettingsRouteContractTest::testCanonicalPutSettingsRouteIsDeclared
appinfo/routes.php does not declare the canonical ADR-066 write [...]
Tests: 11, Assertions: 42, Failures: 2.
```

**3. both restored** → GREEN:

```
OK (11 tests, 44 assertions)
```

Full unit suite: `OK, 1614 tests, 5101 assertions` (3 warnings, 11 skipped — all pre-existing; the two new files emit none). PHPCS clean on `lib/Controller/SettingsController.php`.

### Coverage

Every statement added is covered — measured with pcov, clover parsed directly:

```
lib/Controller/SettingsController.php -> 26 / 64 statements
   method update  line 183  hit 4x
   method create  line 214  hit 1x
   UNCOVERED new statement lines (180-220): []
```

The change converts 9 previously **uncovered** statements (the old `create()` body, which had no test) into 10 **covered** ones, so the PR-time measured ratchet moves upward.

> Note, pre-existing and unrelated: the committed `.coverage-baseline` reads `45.36` while the tree now measures `45.05`. Per `scripts/coverage-guard.php`'s own contract the committed constant is only the push-time fail-safe — on a pull request the floor is **measured at the merge base**, which is the number this PR improves. Flagging it rather than editing it, since lowering a committed floor in an unrelated PR is exactly the wrong move.

## Mechanical gates

Run from a **fresh clone of `ConductionNL/.github@main`** — the local `.github` checkout is 77 commits behind `origin/main` and would have been a different program. Diff-scoped, verdicts read from stdout (not the exit byte):

```
[hydra-gates] Scope: diff vs origin/development — 4 changed file(s)
[gate-5]  route-auth: FAIL — 17 routed method(s) missing auth attribute
[gate-9]  semantic-auth: PASS
[gate-14] route-reachability: PASS
[gate-16] spec-coverage: PASS
[gate-46] spec-anchor-existence: PASS
[gate-63] settings-surface: SKIPPED (structural — no manifest in this diff)
[hydra-gates] 1 gate(s) failed
```

56 of 57 applicable gates that ran are green.

### About the gate-5 failure — please read before asking for a fix here

**None of the 17 findings are in `SettingsController`.** They are:

```
BerichtenboxAdminController: retry, stats
PortalAdminController:       saveConfig, accounts, auditEvents
PosPaymentController:        index, show, update, test
PosRoleController:           create, update, destroy
PosStaffController:          index, show, create, update, destroy
```

All 17 exist unchanged on `origin/development`. They enter scope only because gate-5 does this, by design and by its own comment: *"Touching `appinfo/routes.php` puts every routed method back in scope."* Adding one line to the route table re-opens every routed method in the repository for judgement.

I deliberately did **not** fix them in this PR:

1. Every one of these methods currently has **no** auth attribute, which in Nextcloud means **admin-required by default** — fail-closed, not an open endpoint. `appinfo/routes.php` says so explicitly for the portal ones: *"Admin / DPO (Nextcloud admin only; no `#[PublicPage]` — admin-default)."*
2. The only attribute that would satisfy gate-5 for an admin-default method is `AuthorizedAdminSetting`, which **widens** access to users delegated for that settings panel. Applying it to 17 endpoints across 5 controllers is a real privilege change on payment-provider config, POS staff/role CRUD and portal admin surfaces, and it belongs in its own reviewed PR — not smuggled into a settings-verb conversion whose stated contract is a zero net privilege change.

Recommend a follow-up issue for the 17-endpoint auth-posture declaration.

## Not done

**DO NOT MERGE** — the orchestrator merges this.
