### PR TITLE
fix(security): declare the admin-only auth posture on 17 routed endpoints

### DIFF
--- a/lib/Controller/BerichtenboxAdminController.php
+++ b/lib/Controller/BerichtenboxAdminController.php
@@ -5,8 +5,9 @@
  *
  * Admin-only operational endpoints for the Berichtenbox bridge:
  * retry a failed message + read aggregate delivery stats. Both routes
- * are admin-gated by NC's framework default (no #[NoAdminRequired])
- * per [[nc-security-defaults]]; SecurityMiddleware enforces it.
+ * are admin-gated by Nextcloud's framework default — no NoAdminRequired
+ * attribute is present — per [[nc-security-defaults]]; SecurityMiddleware
+ * enforces it. Each method declares that posture in its own docblock.
  *
  * @category Controller
  * @package  OCA\Pipelinq\Controller
@@ -62,6 +63,8 @@ class BerichtenboxAdminController extends Controller
      * POST /api/admin/berichtenbox/message/{id}/retry — re-queue a failed
      * message for immediate dispatch.
      *
+     * @auth admin-only Re-dispatches a citizen message on any tenant's behalf; restricted to server administrators by the framework default.
+     *
      * @param string $id BerichtenboxMessage uuid.
      *
      * @return JSONResponse
@@ -116,6 +119,8 @@ class BerichtenboxAdminController extends Controller
 
     /**
      * GET /api/admin/berichtenbox/stats — aggregate delivery counts.
+     *
+     * @auth admin-only Exposes cross-tenant delivery totals for the whole instance; restricted to server administrators by the framework default.
      *
      * @return JSONResponse
      *

--- a/lib/Controller/PortalAdminController.php
+++ b/lib/Controller/PortalAdminController.php
@@ -76,6 +76,8 @@ class PortalAdminController extends Controller
     /**
      * Save tenant config (contrast-validated).
      *
+     * @auth admin-only Writes tenant-wide portal configuration; the body additionally enforces it through adminGuarded().
+     *
      * @return JSONResponse The saved config, or an error.
      */
     public function saveConfig(): JSONResponse
@@ -96,6 +98,8 @@ class PortalAdminController extends Controller
 
     /**
      * List all portal accounts for a tenant (no secrets).
+     *
+     * @auth admin-only Enumerates every portal account on the tenant; the body additionally enforces it through adminGuarded().
      *
      * @return JSONResponse The accounts.
      */
@@ -122,6 +126,8 @@ class PortalAdminController extends Controller
 
     /**
      * List all audit events for a tenant (DPO).
+     *
+     * @auth admin-only Returns the tenant-wide audit trail used for DPO reporting; the body additionally enforces it through adminGuarded().
      *
      * @return JSONResponse The events.
      */

--- a/lib/Controller/PosPaymentController.php
+++ b/lib/Controller/PosPaymentController.php
@@ -95,6 +95,8 @@ class PosPaymentController extends Controller
     /**
      * GET /api/payment-providers — list providers (credentials masked).
      *
+     * @auth admin-only Lists payment-provider configuration for the instance; restricted to server administrators by the framework default.
+     *
      * @return JSONResponse
      *
      * @spec openspec/changes/pos-payment-provider-adapter/specs/pos-payment-provider-adapter/spec.md#REQ-PAY-007
@@ -110,6 +112,8 @@ class PosPaymentController extends Controller
 
     /**
      * GET /api/payment-providers/{name} — single provider config.
+     *
+     * @auth admin-only Reads one payment provider's configuration; restricted to server administrators by the framework default.
      *
      * @param string $name The provider name.
      *
@@ -130,6 +134,8 @@ class PosPaymentController extends Controller
 
     /**
      * PUT /api/payment-providers/{name} — update provider credentials + config.
+     *
+     * @auth admin-only Writes payment-provider credentials for the instance; restricted to server administrators by the framework default.
      *
      * @param string $name The provider name.
      *
@@ -152,6 +158,8 @@ class PosPaymentController extends Controller
 
     /**
      * POST /api/payment-providers/{name}/test — test provider connection.
+     *
+     * @auth admin-only Opens an outbound connection using stored provider credentials; restricted to server administrators by the framework default.
      *
      * @param string $name The provider name.
      *

--- a/lib/Controller/PosRoleController.php
+++ b/lib/Controller/PosRoleController.php
@@ -123,6 +123,8 @@ class PosRoleController extends Controller
     /**
      * Create a POS role (admin only).
      *
+     * @auth admin-only Creates a POS permission role; the body additionally enforces it with an explicit requireAdmin() guard.
+     *
      * @return JSONResponse The created role.
      *
      * @spec openspec/changes/pos-staff-pin-permissions/tasks.md#4.1
@@ -142,6 +144,8 @@ class PosRoleController extends Controller
 
     /**
      * Update a POS role (admin only).
+     *
+     * @auth admin-only Rewrites a POS permission role; the body additionally enforces it with an explicit requireAdmin() guard.
      *
      * @param string $id The role UUID.
      *
@@ -168,6 +172,8 @@ class PosRoleController extends Controller
 
     /**
      * Delete a POS role (admin only).
+     *
+     * @auth admin-only Deletes a POS permission role; the body additionally enforces it with an explicit requireAdmin() guard.
      *
      * @param string $id The role UUID.
      *

--- a/lib/Controller/PosStaffController.php
+++ b/lib/Controller/PosStaffController.php
@@ -82,6 +82,8 @@ class PosStaffController extends Controller
     /**
      * List all staff (admin only). The bcrypt pinHash is stripped by the service.
      *
+     * @auth admin-only Enumerates every POS staff record on the instance; the body additionally enforces it with an explicit requireAdmin() guard.
+     *
      * @return JSONResponse The staff list.
      *
      * @spec openspec/changes/pos-staff-pin-permissions/tasks.md#4.2
@@ -101,6 +103,8 @@ class PosStaffController extends Controller
 
     /**
      * Get a single staff record (admin only). The bcrypt pinHash is stripped.
+     *
+     * @auth admin-only Reads one POS staff record including its permission set; the body additionally enforces it with an explicit requireAdmin() guard.
      *
      * @param string $id The staff UUID.
      *
@@ -129,6 +133,8 @@ class PosStaffController extends Controller
     /**
      * Create a staff record (admin only).
      *
+     * @auth admin-only Creates a POS staff identity and its PIN credential; the body additionally enforces it with an explicit requireAdmin() guard.
+     *
      * @return JSONResponse The created staff record.
      *
      * @spec openspec/changes/pos-staff-pin-permissions/tasks.md#4.2
@@ -148,6 +154,8 @@ class PosStaffController extends Controller
 
     /**
      * Update a staff record (admin only).
+     *
+     * @auth admin-only Rewrites a POS staff identity, including its PIN and permissions; the body additionally enforces it with an explicit requireAdmin() guard.
      *
      * @param string $id The staff UUID.
      *
@@ -175,6 +183,8 @@ class PosStaffController extends Controller
 
     /**
      * Delete a staff record (admin only).
+     *
+     * @auth admin-only Removes a POS staff identity and revokes its till access; the body additionally enforces it with an explicit requireAdmin() guard.
      *
      * @param string $id The staff UUID.
      *


### PR DESCRIPTION
Supersedes #728, which closed the same gate-5 finding by adding
`#[AuthorizedAdminSetting(Application::APP_ID)]` to all 17 methods. This PR
declares the same posture without changing it.

## The finding

hydra **gate-5 (route-auth)**, measured full-tree at `origin/development` with
gate package `48c88ba1e0d049f8f38538c33e790d3e603c55d0`, reported **17 routed
methods with no declared auth posture**:

| Controller | Methods |
|---|---|
| `BerichtenboxAdminController` | `retry`, `stats` |
| `PortalAdminController` | `saveConfig`, `accounts`, `auditEvents` |
| `PosPaymentController` | `index`, `show`, `update`, `test` |
| `PosRoleController` | `create`, `update`, `destroy` |
| `PosStaffController` | `index`, `show`, `create`, `update`, `destroy` |

All 17 are already admin-gated and fail **closed**: Nextcloud's
`SecurityMiddleware` requires an administrator whenever no `#[NoAdminRequired]`
attribute is present. The defect was that the posture was declared only by
**omission** — nothing in the source stated it, so the intent was unreviewable
and a future edit could have widened it silently.

## Declared, not widened

The only auth *attribute* that satisfies gate-5 here is
`#[AuthorizedAdminSetting]`, and it does **not** mean "admin only". It
authorizes a method when `isAdminUser()` is true **or** when the user holds
delegated authorization for one of the named settings classes. Applying it to
these 17 would add an OR branch to the check — a widening, on exactly the
surfaces where widening is least acceptable: payment-provider credentials,
staff PINs, POS permission roles, and tenant audit trails.

hydra ConductionNL/.github#269 added the correct instrument:

```
@auth admin-only <reason of at least 20 characters>
```

at docblock-tag position. Each of the 17 now carries one stating what the
endpoint exposes and, where the body also guards, which guard enforces it
(`adminGuarded()` on PortalAdmin, `requireAdmin()` on PosRole/PosStaff).

Prose is deliberately not load-bearing: the reason text avoids the bracketed
attribute form, and a sentence in `BerichtenboxAdminController`'s class
docblock that mentioned the tag inline was reworded — #269 exists precisely
because a docblock once satisfied this gate by accident.

## Measurement

| Gate | Before | After |
|---|---|---|
| gate-5 route-auth | FAIL — 17 | **PASS** |
| gate-9 semantic-auth | FAIL — 7 | FAIL — 7 (unchanged; no declared posture contradicts its body) |

**Positive control:** removing a single tag returns
`[gate-5] route-auth: FAIL — 1 routed method(s) missing auth attribute`, so the
gate is reading these tags and not passing vacuously.

No attribute was added, so no executable line was added — this also avoids the
coverage-ratchet drop that failed `PHPUnit (PHP 8.3, NC stable32)` on #728.