### PR TITLE
fix(spec): repoint 25 dangling @spec tags at their canonical specs

### DIFF
--- a/lib/Controller/BerichtenboxAdminController.php
+++ b/lib/Controller/BerichtenboxAdminController.php
@@ -5,8 +5,9 @@
  *
  * Admin-only operational endpoints for the Berichtenbox bridge:
  * retry a failed message + read aggregate delivery stats. Both routes
- * are admin-gated by NC's framework default (no #[NoAdminRequired])
- * per [[nc-security-defaults]]; SecurityMiddleware enforces it.
+ * are admin-gated by Nextcloud's framework default — no NoAdminRequired
+ * attribute is present — per [[nc-security-defaults]]; SecurityMiddleware
+ * enforces it. Each method declares that posture in its own docblock.
  *
  * @category Controller
  * @package  OCA\Pipelinq\Controller
@@ -62,6 +63,8 @@ class BerichtenboxAdminController extends Controller
      * POST /api/admin/berichtenbox/message/{id}/retry — re-queue a failed
      * message for immediate dispatch.
      *
+     * @auth admin-only Re-dispatches a citizen message on any tenant's behalf; restricted to server administrators by the framework default.
+     *
      * @param string $id BerichtenboxMessage uuid.
      *
      * @return JSONResponse
@@ -116,6 +119,8 @@ class BerichtenboxAdminController extends Controller
 
     /**
      * GET /api/admin/berichtenbox/stats — aggregate delivery counts.
+     *
+     * @auth admin-only Exposes cross-tenant delivery totals for the whole instance; restricted to server administrators by the framework default.
      *
      * @return JSONResponse
      *

--- a/lib/Controller/PortalAdminController.php
+++ b/lib/Controller/PortalAdminController.php
@@ -76,6 +76,8 @@ class PortalAdminController extends Controller
     /**
      * Save tenant config (contrast-validated).
      *
+     * @auth admin-only Writes tenant-wide portal configuration; the body additionally enforces it through adminGuarded().
+     *
      * @return JSONResponse The saved config, or an error.
      */
     public function saveConfig(): JSONResponse
@@ -96,6 +98,8 @@ class PortalAdminController extends Controller
 
     /**
      * List all portal accounts for a tenant (no secrets).
+     *
+     * @auth admin-only Enumerates every portal account on the tenant; the body additionally enforces it through adminGuarded().
      *
      * @return JSONResponse The accounts.
      */
@@ -122,6 +126,8 @@ class PortalAdminController extends Controller
 
     /**
      * List all audit events for a tenant (DPO).
+     *
+     * @auth admin-only Returns the tenant-wide audit trail used for DPO reporting; the body additionally enforces it through adminGuarded().
      *
      * @return JSONResponse The events.
      */

--- a/lib/Controller/PosPaymentController.php
+++ b/lib/Controller/PosPaymentController.php
@@ -95,6 +95,8 @@ class PosPaymentController extends Controller
     /**
      * GET /api/payment-providers — list providers (credentials masked).
      *
+     * @auth admin-only Lists payment-provider configuration for the instance; restricted to server administrators by the framework default.
+     *
      * @return JSONResponse
      *
      * @spec openspec/changes/pos-payment-provider-adapter/specs/pos-payment-provider-adapter/spec.md#REQ-PAY-007
@@ -110,6 +112,8 @@ class PosPaymentController extends Controller
 
     /**
      * GET /api/payment-providers/{name} — single provider config.
+     *
+     * @auth admin-only Reads one payment provider's configuration; restricted to server administrators by the framework default.
      *
      * @param string $name The provider name.
      *
@@ -130,6 +134,8 @@ class PosPaymentController extends Controller
 
     /**
      * PUT /api/payment-providers/{name} — update provider credentials + config.
+     *
+     * @auth admin-only Writes payment-provider credentials for the instance; restricted to server administrators by the framework default.
      *
      * @param string $name The provider name.
      *
@@ -152,6 +158,8 @@ class PosPaymentController extends Controller
 
     /**
      * POST /api/payment-providers/{name}/test — test provider connection.
+     *
+     * @auth admin-only Opens an outbound connection using stored provider credentials; restricted to server administrators by the framework default.
      *
      * @param string $name The provider name.
      *

--- a/lib/Controller/PosRoleController.php
+++ b/lib/Controller/PosRoleController.php
@@ -123,6 +123,8 @@ class PosRoleController extends Controller
     /**
      * Create a POS role (admin only).
      *
+     * @auth admin-only Creates a POS permission role; the body additionally enforces it with an explicit requireAdmin() guard.
+     *
      * @return JSONResponse The created role.
      *
      * @spec openspec/changes/pos-staff-pin-permissions/tasks.md#4.1
@@ -142,6 +144,8 @@ class PosRoleController extends Controller
 
     /**
      * Update a POS role (admin only).
+     *
+     * @auth admin-only Rewrites a POS permission role; the body additionally enforces it with an explicit requireAdmin() guard.
      *
      * @param string $id The role UUID.
      *
@@ -168,6 +172,8 @@ class PosRoleController extends Controller
 
     /**
      * Delete a POS role (admin only).
+     *
+     * @auth admin-only Deletes a POS permission role; the body additionally enforces it with an explicit requireAdmin() guard.
      *
      * @param string $id The role UUID.
      *

--- a/lib/Controller/PosStaffController.php
+++ b/lib/Controller/PosStaffController.php
@@ -82,6 +82,8 @@ class PosStaffController extends Controller
     /**
      * List all staff (admin only). The bcrypt pinHash is stripped by the service.
      *
+     * @auth admin-only Enumerates every POS staff record on the instance; the body additionally enforces it with an explicit requireAdmin() guard.
+     *
      * @return JSONResponse The staff list.
      *
      * @spec openspec/changes/pos-staff-pin-permissions/tasks.md#4.2
@@ -101,6 +103,8 @@ class PosStaffController extends Controller
 
     /**
      * Get a single staff record (admin only). The bcrypt pinHash is stripped.
+     *
+     * @auth admin-only Reads one POS staff record including its permission set; the body additionally enforces it with an explicit requireAdmin() guard.
      *
      * @param string $id The staff UUID.
      *
@@ -129,6 +133,8 @@ class PosStaffController extends Controller
     /**
      * Create a staff record (admin only).
      *
+     * @auth admin-only Creates a POS staff identity and its PIN credential; the body additionally enforces it with an explicit requireAdmin() guard.
+     *
      * @return JSONResponse The created staff record.
      *
      * @spec openspec/changes/pos-staff-pin-permissions/tasks.md#4.2
@@ -148,6 +154,8 @@ class PosStaffController extends Controller
 
     /**
      * Update a staff record (admin only).
+     *
+     * @auth admin-only Rewrites a POS staff identity, including its PIN and permissions; the body additionally enforces it with an explicit requireAdmin() guard.
      *
      * @param string $id The staff UUID.
      *
@@ -175,6 +183,8 @@ class PosStaffController extends Controller
 
     /**
      * Delete a staff record (admin only).
+     *
+     * @auth admin-only Removes a POS staff identity and revokes its till access; the body additionally enforces it with an explicit requireAdmin() guard.
      *
      * @param string $id The staff UUID.
      *

--- a/lib/Repair/IngestProductVendorMaster.php
+++ b/lib/Repair/IngestProductVendorMaster.php
@@ -151,7 +151,7 @@ class IngestProductVendorMaster implements IRepairStep
      *
      * @return string
      *
-     * @spec openspec/changes/pipelinq-product-vendor-master/tasks.md#task-phase4
+     * @spec openspec/specs/product-vendor-master/spec.md
      */
     public function getName(): string
     {
@@ -169,7 +169,7 @@ class IngestProductVendorMaster implements IRepairStep
      *
      * @return void
      *
-     * @spec openspec/changes/pipelinq-product-vendor-master/tasks.md#task-phase4
+     * @spec openspec/specs/product-vendor-master/spec.md
      */
     public function run(IOutput $output): void
     {

--- a/lib/Service/ComplianceService.php
+++ b/lib/Service/ComplianceService.php
@@ -23,7 +23,7 @@
  *
  * @link https://github.com/ConductionNL/pipelinq
  *
- * @spec openspec/changes/marketing-segmentation-and-blast-03-compliance-service/tasks.md#compliance-service
+ * @spec openspec/specs/marketing-compliance/spec.md#requirement-blast-cannot-send-without-lawful-basis
  */
 
 declare(strict_types=1);
@@ -53,7 +53,7 @@ use Throwable;
  * @SuppressWarnings(PHPMD.ExcessiveClassLength)     Cohesive consent + template + queued-delivery gate; splitting fragments one policy.
  * @SuppressWarnings(PHPMD.ExcessiveClassComplexity) Guard-heavy but flat GDPR/CAN-SPAM checks; each operation is independently unit-tested.
  *
- * @spec openspec/changes/marketing-segmentation-and-blast-03-compliance-service/tasks.md#compliance-service
+ * @spec openspec/specs/marketing-compliance/spec.md#requirement-blast-cannot-send-without-lawful-basis
  */
 class ComplianceService
 {
@@ -138,7 +138,7 @@ class ComplianceService
      * @param SegmentService     $segmentService Segment member projection.
      * @param LoggerInterface    $logger         Logger.
      *
-     * @spec openspec/changes/marketing-segmentation-and-blast-03-compliance-service/tasks.md#di
+     * @spec openspec/specs/marketing-compliance/spec.md#requirement-blast-cannot-send-without-lawful-basis
      */
     public function __construct(
         private ContainerInterface $container,
@@ -169,7 +169,7 @@ class ComplianceService
      *
      * @return array{compliant: bool, missingConsent: array<int, string>, missingCount: int}
      *
-     * @spec openspec/changes/marketing-segmentation-and-blast-03-compliance-service/tasks.md#check-segment-compliance
+     * @spec openspec/specs/marketing-compliance/spec.md#requirement-blast-cannot-send-without-lawful-basis
      */
     public function checkSegmentCompliance(string $segmentId, string $channel): array
     {
@@ -231,7 +231,7 @@ class ComplianceService
      *                              `validateTemplate()` / `checkSegmentCompliance()`
      *                              for the field shapes.
      *
-     * @spec openspec/changes/marketing-segmentation-and-blast-03-compliance-service/tasks.md#check-segment-compliance
+     * @spec openspec/specs/marketing-compliance/spec.md#requirement-blast-cannot-send-without-lawful-basis
      */
     public function preflightBlast(string $segmentId, array $template, string $channel): array
     {
@@ -260,7 +260,7 @@ class ComplianceService
      *
      * @return bool True when the channel is gated open for this contact.
      *
-     * @spec openspec/changes/marketing-segmentation-and-blast-03-compliance-service/tasks.md#has-consent-for-channel
+     * @spec openspec/specs/marketing-compliance/spec.md#requirement-blast-cannot-send-without-lawful-basis
      */
     public function hasConsentForChannel(string $contactId, string $channel): bool
     {
@@ -326,7 +326,7 @@ class ComplianceService
      *
      * @return string|null Error message or null when valid.
      *
-     * @spec openspec/changes/marketing-segmentation-and-blast-03-compliance-service/tasks.md#validate-template
+     * @spec openspec/specs/marketing-compliance/spec.md#requirement-unsubscribe-footer-enforced-on-email-templates
      */
     public function validateTemplate(array $templateData, string $channel): ?string
     {
@@ -706,7 +706,7 @@ class ComplianceService
      *
      * @return void
      *
-     * @spec openspec/changes/marketing-segmentation-and-blast-03-compliance-service/tasks.md#record-consent-withdrawal
+     * @spec openspec/specs/marketing-compliance/spec.md#requirement-consent-withdrawal-propagates
      */
     public function recordConsentWithdrawal(
         string $contactId,

--- a/lib/Service/SegmentService.php
+++ b/lib/Service/SegmentService.php
@@ -134,7 +134,7 @@ class SegmentService
      * @param ICacheFactory      $cacheFactory     NC cache factory.
      * @param LoggerInterface    $logger           Logger.
      *
-     * @spec openspec/changes/marketing-segmentation-and-blast-02-segment-service/tasks.md#task-2.8
+     * @spec openspec/specs/marketing-segmentation/spec.md#requirement-segment-builder-composes-rule-trees
      */
     public function __construct(
         private ContainerInterface $container,
@@ -169,7 +169,7 @@ class SegmentService
      *
      * @return string|null NULL on success, otherwise the first error.
      *
-     * @spec openspec/changes/marketing-segmentation-and-blast-02-segment-service/tasks.md#task-2.2
+     * @spec openspec/specs/marketing-segmentation/spec.md#requirement-segment-builder-composes-rule-trees
      */
     public function validateRules(array $rules, string $entityType): ?string
     {
@@ -201,7 +201,7 @@ class SegmentService
      *
      * @return bool True when the entity matches the tree.
      *
-     * @spec openspec/changes/marketing-segmentation-and-blast-02-segment-service/tasks.md#task-2.5
+     * @spec openspec/specs/marketing-segmentation/spec.md#requirement-segment-builder-composes-rule-trees
      */
     public function evaluateRules(array $rules, array $entity): bool
     {
@@ -225,7 +225,7 @@ class SegmentService
      *
      * @return array{valid: bool, error: ?string, estimatedSize: int}
      *
-     * @spec openspec/changes/marketing-segmentation-and-blast-02-segment-service/tasks.md#task-2.2
+     * @spec openspec/specs/marketing-segmentation/spec.md#requirement-segment-builder-composes-rule-trees
      */
     public function previewRulePayload(array $rules, string $entityType): array
     {
@@ -267,7 +267,7 @@ class SegmentService
      *
      * @return array<int, array<string, string>> Recipient rows.
      *
-     * @spec openspec/changes/marketing-segmentation-and-blast-02-segment-service/tasks.md#task-2.7
+     * @spec openspec/specs/marketing-segmentation/spec.md#requirement-segments-are-live-not-frozen-lists
      */
     public function getMembersForBlast(string $segmentId): array
     {
@@ -743,7 +743,7 @@ class SegmentService
      *
      * @return int Count of matching entities; 0 on failure.
      *
-     * @spec openspec/changes/marketing-segmentation-and-blast-02-segment-service/tasks.md#task-2.6
+     * @spec openspec/specs/marketing-segmentation/spec.md#requirement-segments-are-live-not-frozen-lists
      */
     public function estimateSize(string $segmentId): int
     {
@@ -1615,7 +1615,7 @@ class SegmentService
      * @return array<string, mixed>|null Properties map, or null when the
      *                                   schema is not resolvable.
      *
-     * @spec openspec/changes/marketing-segmentation-and-blast-02-segment-service/tasks.md#task-2.3
+     * @spec openspec/specs/marketing-segmentation/spec.md#requirement-segment-builder-composes-rule-trees
      */
     protected function resolveSchemaProperties(string $entityType): ?array
     {
@@ -1669,7 +1669,7 @@ class SegmentService
      *
      * @return string The resolved schema slug, or empty when unknown.
      *
-     * @spec openspec/changes/marketing-segmentation-and-blast-02-segment-service/tasks.md#task-2.3
+     * @spec openspec/specs/marketing-segmentation/spec.md#requirement-segment-builder-composes-rule-trees
      */
     protected function resolveSchemaSlug(string $entityType): string
     {

--- a/lib/Service/WebhookProcessorService.php
+++ b/lib/Service/WebhookProcessorService.php
@@ -267,7 +267,7 @@ class WebhookProcessorService
      *
      * @return void
      *
-     * @spec openspec/changes/marketing-segmentation-and-blast-05-jobs-and-webhooks/tasks.md#bounce-handling
+     * @spec openspec/specs/marketing-blast-delivery/spec.md#requirement-bounce-handling-protects-sender-reputation
      */
     public function processBounce(array $event): void
     {
@@ -361,7 +361,7 @@ class WebhookProcessorService
      *
      * @return void
      *
-     * @spec openspec/changes/marketing-segmentation-and-blast-05-jobs-and-webhooks/tasks.md#click-attribution
+     * @spec openspec/specs/marketing-blast-delivery/spec.md#requirement-click-events-recorded-for-attribution
      */
     public function processClick(array $event): void
     {
@@ -396,7 +396,7 @@ class WebhookProcessorService
      *
      * @return void
      *
-     * @spec openspec/changes/marketing-segmentation-and-blast-05-jobs-and-webhooks/tasks.md#unsubscribe-propagation
+     * @spec openspec/specs/marketing-blast-delivery/spec.md#requirement-unsubscribe-propagates-within-minutes
      */
     public function processUnsubscribe(array $event): void
     {

--- a/src/App.vue
+++ b/src/App.vue
@@ -154,8 +154,8 @@ export default {
 		 * manifest column references (ADR-036).
 		 *
 		 * @return {Record<string, object>}
-		 * @spec openspec/changes/customer-360/tasks.md#task-6.1
-		 * @spec openspec/changes/customer-360/tasks.md#task-6.2
+		 * @spec openspec/specs/customer-360/spec.md
+		 * @spec openspec/specs/lead-scoring-win-probability/spec.md#requirement-win-probability-is-surfaced-on-the-pipeline-list-and-deal-detail
 		 */
 		cellWidgets() {
 			return {

--- a/src/views/leads/cells/LeadCloseDateCell.vue
+++ b/src/views/leads/cells/LeadCloseDateCell.vue
@@ -1,6 +1,6 @@
 <!-- SPDX-License-Identifier: EUPL-1.2 -->
 <!-- SPDX-FileCopyrightText: 2026 Conduction B.V. -->
-<!-- @spec openspec/changes/customer-360/tasks.md#task-6.1 -->
+<!-- @spec openspec/specs/customer-360/spec.md -->
 <template>
 	<span
 		class="lead-close-cell"

--- a/src/views/leads/cells/LeadProbabilityCell.vue
+++ b/src/views/leads/cells/LeadProbabilityCell.vue
@@ -1,6 +1,6 @@
 <!-- SPDX-License-Identifier: EUPL-1.2 -->
 <!-- SPDX-FileCopyrightText: 2026 Conduction B.V. -->
-<!-- @spec openspec/changes/customer-360/tasks.md#task-6.2 -->
+<!-- @spec openspec/specs/lead-scoring-win-probability/spec.md#requirement-win-probability-is-surfaced-on-the-pipeline-list-and-deal-detail -->
 <template>
 	<span class="lead-prob-cell">
 		<span v-if="isEmpty" class="lead-prob-cell__dash">—</span>


### PR DESCRIPTION
## The finding

hydra **gate-46 (spec-anchor-existence)**, measured full-tree at
`origin/development` with gate package
`48c88ba1e0d049f8f38538c33e790d3e603c55d0`: **26 unresolved `@spec` findings
from 19 distinct targets**.

Every one pointed into `openspec/changes/` — a **change** directory, and mostly
at a `tasks.md`. A change directory is transient: once the change is archived
the path moves, and once the task list is rewritten the anchor evaporates. Both
had happened here. The canonical home is `openspec/specs/`.

## What was done

The gate's own message says *"fix the TARGET, not each tag"*, so each tag was
repointed at the canonical capability that actually specifies the behaviour:

| File | Canonical spec |
|---|---|
| `ComplianceService` | `marketing-compliance` — lawful basis, unsubscribe footer, consent withdrawal |
| `WebhookProcessorService` | `marketing-blast-delivery` — bounce handling, click attribution, unsubscribe propagation |
| `SegmentService` | `marketing-segmentation` — rule trees, live-not-frozen segments |
| `IngestProductVendorMaster` | `product-vendor-master`, matching the 8 already-correct tags in the same file |
| `LeadCloseDateCell`, `App.vue` | `customer-360` |
| `LeadProbabilityCell`, `App.vue` | `lead-scoring-win-probability`, whose spec explicitly names the `lead-probability` cell widget |

**No tag was deleted.** Deleting an inconvenient `@spec` is a waiver in
disguise; all 25 still assert a spec relationship, just against a target that
will still exist next month.

## Measurement

| Gate | Before | After |
|---|---|---|
| gate-46 spec-anchor-existence | FAIL — 26 findings / 19 targets | FAIL — **1 finding / 1 target** |
| gate-16 spec-coverage | PASS | PASS |

`hydra-gate-spec-anchor-existence.log.err` was empty on every run — this gate
has elsewhere printed PASS while its `python3` helper exited 1, so that was
checked explicitly rather than assumed.

**Positive control:** the count tracked the edits exactly — after the first two
tags were repointed the gate reported `24 findings from 18 targets`, so it is
reading these specific tags and not passing vacuously.

## Left red, deliberately (1)

`lib/AppInfo/Application.php` →
`openspec/changes/object-write-at-instance-floor/specs/object-write-performance/spec.md`

The change directory is not in `openspec/changes/` and not in the 294-entry
archive, and no `openspec/specs/` capability covers it. The annotated method
(`requestRendersPage`) skips initial-state computation for non-page requests —
an **object-write performance** concern that belongs to **OpenRegister**, not to
a leaf app. Inventing a pipelinq spec to silence the gate would put the
capability's canonical home in the wrong repository, so this needs a cross-repo
decision rather than a local edit.

### Note on a number that looks alarming and isn't

`openspec/changes/spec-anchor-repair/residual-dangling.md` records **1968**
unrepointable anchors, and a naive grep says **2055** tags point at change dirs
with **104 of 118** distinct target files missing from disk. Neither is the live
figure. `check_spec_anchors.py` builds an **archive index** and follows tags into
`openspec/changes/archive/` (294 entries), so the overwhelming majority resolve.
26 was the honest residual; this PR takes it to 1.