### PR TITLE
fix(security): fail closed on 38 security-config reads

### DIFF
--- a/lib/Controller/PortalController.php
+++ b/lib/Controller/PortalController.php
@@ -937,11 +937,23 @@ class PortalController extends Controller
     /**
      * The pipelinq register id from app config.
      *
-     * @return string
+     * Fails closed: '' means "unconfigured" and every caller refuses the
+     * OpenRegister call on it. An empty register is NOT the same as none —
+     * ObjectService skips setRegister() for an empty value, so the query
+     * inherits whatever context an earlier call in the request left behind.
+     *
+     * @return string The configured register id, or '' when unconfigured.
      */
     private function registerId(): string
     {
-        return $this->appConfig->getValueString(Application::APP_ID, 'register', '');
+        $registerId = $this->appConfig->getValueString(Application::APP_ID, 'register', '');
+        if ($registerId === '') {
+            $this->logger->warning(
+                'Pipelinq: app-config "register" is not configured; OpenRegister calls are refused, not run unscoped'
+            );
+        }
+
+        return $registerId;
     }//end registerId()
 
     /**

--- a/lib/Controller/SemanticHandoffController.php
+++ b/lib/Controller/SemanticHandoffController.php
@@ -469,11 +469,26 @@ class SemanticHandoffController extends Controller
     /**
      * The pipelinq register slug (app-config overridable).
      *
-     * @return string Slug.
+     * Fails closed on a blanked override. Passing the built-in slug as
+     * getValueString()'s default only covers an ABSENT key: a key that is
+     * present but set to an empty string returns '' verbatim, and none of the
+     * callers here check for that. An empty register is not the same as "no
+     * register" to OpenRegister — ObjectService skips setRegister() for an
+     * empty value, so the query silently inherits whatever register context an
+     * earlier call in the same request left on the shared service instance.
+     * Normalising '' back to the built-in slug, exactly as the sibling
+     * schemaSlug() already does, keeps every call scoped.
+     *
+     * @return string Slug; never empty.
      */
     private function registerSlug(): string
     {
-        return $this->appConfig->getValueString(Application::APP_ID, 'register', 'pipelinq');
+        $slug = $this->appConfig->getValueString(Application::APP_ID, 'register', '');
+        if ($slug !== '') {
+            return $slug;
+        }
+
+        return 'pipelinq';
     }//end registerSlug()
 
     /**

--- a/lib/Service/ActivityTimelineService.php
+++ b/lib/Service/ActivityTimelineService.php
@@ -113,20 +113,32 @@ class ActivityTimelineService
     /**
      * Read the configured register and schema IDs.
      *
-     * The `contactmoment` source is no longer a schema of its own: after
-     * unify-ticket-supertype it is the `ticket` schema narrowed by
-     * `ticketType=contactmoment`, so its id is resolved through TicketService.
+     * `contactmoment` is not a schema of its own: since unify-ticket-supertype
+     * it is `ticket` narrowed by `ticketType`, resolved via TicketService.
+     *
+     * Fails closed: '' means the source MUST NOT be queried — ObjectService
+     * skips setRegister()/setSchema() on '', leaving the request's leftover
+     * context. `register` is logged when unset; optional schema ids are not,
+     * as collectActivities() drops them (a supported degraded mode).
      *
      * @return array<string,string> Map of source-key => value.
      */
     private function getConfig(): array
     {
+        $register     = $this->appConfig->getValueString(Application::APP_ID, 'register', '');
+        $task         = $this->appConfig->getValueString(Application::APP_ID, 'task_schema', '');
+        $emailLink    = $this->appConfig->getValueString(Application::APP_ID, 'emailLink_schema', '');
+        $calendarLink = $this->appConfig->getValueString(Application::APP_ID, 'calendarLink_schema', '');
+        if ($register === '') {
+            $this->logger->warning('Pipelinq: "register" is not configured; the activity timeline is refused, not run unscoped');
+        }
+
         return [
-            'register'      => $this->appConfig->getValueString(Application::APP_ID, 'register', ''),
+            'register'      => $register,
             'contactmoment' => $this->ticketService->getSchemaId(),
-            'task'          => $this->appConfig->getValueString(Application::APP_ID, 'task_schema', ''),
-            'emailLink'     => $this->appConfig->getValueString(Application::APP_ID, 'emailLink_schema', ''),
-            'calendarLink'  => $this->appConfig->getValueString(Application::APP_ID, 'calendarLink_schema', ''),
+            'task'          => $task,
+            'emailLink'     => $emailLink,
+            'calendarLink'  => $calendarLink,
         ];
     }//end getConfig()
 

--- a/lib/Service/AppointmentEmailService.php
+++ b/lib/Service/AppointmentEmailService.php
@@ -799,11 +799,25 @@ class AppointmentEmailService
     /**
      * The pipelinq register id from app config.
      *
-     * @return string
+     * Fails closed: '' means "unconfigured", and every caller refuses the
+     * OpenRegister call on it. An empty register must never be handed to
+     * OpenRegister — ObjectService skips setRegister() for an empty value, so
+     * the query silently inherits whatever register context an earlier call in
+     * the same request left on the shared service instance. The empty case is
+     * logged so an unprovisioned instance is visible rather than silent.
+     *
+     * @return string The configured register id, or '' when unconfigured.
      */
     private function registerId(): string
     {
-        return $this->appConfig->getValueString(Application::APP_ID, 'register', '');
+        $registerId = $this->appConfig->getValueString(Application::APP_ID, 'register', '');
+        if ($registerId === '') {
+            $this->logger->warning(
+                'Pipelinq: app-config "register" is not configured; OpenRegister calls are refused, not run unscoped'
+            );
+        }
+
+        return $registerId;
     }//end registerId()
 
     /**

--- a/lib/Service/AvailabilityService.php
+++ b/lib/Service/AvailabilityService.php
@@ -1016,11 +1016,25 @@ class AvailabilityService
     /**
      * Resolve the pipelinq register id from app config.
      *
-     * @return string
+     * Fails closed: '' means "unconfigured", and every caller refuses the
+     * OpenRegister call on it. An empty register must never be handed to
+     * OpenRegister — ObjectService skips setRegister() for an empty value, so
+     * the query silently inherits whatever register context an earlier call in
+     * the same request left on the shared service instance. The empty case is
+     * logged so an unprovisioned instance is visible rather than silent.
+     *
+     * @return string The configured register id, or '' when unconfigured.
      */
     private function registerId(): string
     {
-        return $this->appConfig->getValueString(Application::APP_ID, 'register', '');
+        $registerId = $this->appConfig->getValueString(Application::APP_ID, 'register', '');
+        if ($registerId === '') {
+            $this->logger->warning(
+                'Pipelinq: app-config "register" is not configured; OpenRegister calls are refused, not run unscoped'
+            );
+        }
+
+        return $registerId;
     }//end registerId()
 
     /**

--- a/lib/Service/BerichtenboxService.php
+++ b/lib/Service/BerichtenboxService.php
@@ -527,8 +527,31 @@ class BerichtenboxService
         string $bsnPlain,
         string $bodyHash
     ): void {
+        // Fail closed when the tenant's PKI-overheid material is missing.
+        //
+        // An empty key does NOT stop the dispatch on its own: LogiusConnector::
+        // signRequest() falls back to `base64(sha256(body))` — a keyless digest
+        // anyone can recompute — and sends it as the `X-Signature` header. The
+        // message still goes out, carrying a plaintext BSN, with request
+        // signing silently deactivated. The empty default is the permissive
+        // value here, so refuse the dispatch and let the normal retry/fail path
+        // record it instead of shipping an unsigned citizen message.
         $cert = $this->appConfig->getValueString(Application::APP_ID, 'pki_cert', '');
         $key  = $this->appConfig->getValueString(Application::APP_ID, 'pki_key', '');
+        if ($cert === '' || $key === '') {
+            $this->logger->error(
+                'Pipelinq Berichtenbox: refusing to dispatch — tenant PKI-overheid cert/key is not configured, '
+                .'so the Logius request would be sent with an unsigned placeholder signature',
+                ['messageId' => $messageId]
+            );
+            $this->markFailedOrRetry(
+                message: $message,
+                reason: 'Tenant PKI-overheid certificate or key is not configured.',
+                bodyHash: $bodyHash
+            );
+            return;
+        }
+
         try {
             $message['bsnPlain'] = $bsnPlain;
             $response            = $this->logius->sendMessage($message, $cert, $key);

--- a/lib/Service/BookingService.php
+++ b/lib/Service/BookingService.php
@@ -1512,11 +1512,25 @@ class BookingService
     /**
      * The pipelinq register id from app config.
      *
-     * @return string
+     * Fails closed: '' means "unconfigured", and every caller refuses the
+     * OpenRegister call on it. An empty register must never be handed to
+     * OpenRegister — ObjectService skips setRegister() for an empty value, so
+     * the query silently inherits whatever register context an earlier call in
+     * the same request left on the shared service instance. The empty case is
+     * logged so an unprovisioned instance is visible rather than silent.
+     *
+     * @return string The configured register id, or '' when unconfigured.
      */
     private function registerId(): string
     {
-        return $this->appConfig->getValueString(Application::APP_ID, 'register', '');
+        $registerId = $this->appConfig->getValueString(Application::APP_ID, 'register', '');
+        if ($registerId === '') {
+            $this->logger->warning(
+                'Pipelinq: app-config "register" is not configured; OpenRegister calls are refused, not run unscoped'
+            );
+        }
+
+        return $registerId;
     }//end registerId()
 
     /**

--- a/lib/Service/ContactImportService.php
+++ b/lib/Service/ContactImportService.php
@@ -26,6 +26,7 @@ namespace OCA\Pipelinq\Service;
 use OCA\Pipelinq\AppInfo\Application;
 use OCP\IAppConfig;
 use Psr\Container\ContainerInterface;
+use RuntimeException;
 
 /**
  * Service for importing Nextcloud contacts into Pipelinq objects.
@@ -54,6 +55,8 @@ class ContactImportService
      *
      * @return array The created client object data.
      *
+     * @throws RuntimeException When `client_schema` is not configured.
+     *
      * @spec openspec/specs/contacts-sync/spec.md
      */
     public function importAsClient(array $ncContact, string $uid): array
@@ -63,6 +66,9 @@ class ContactImportService
             uid: $uid
         );
         $schemaId = $this->appConfig->getValueString(Application::APP_ID, 'client_schema', '');
+        if ($schemaId === '') {
+            throw new RuntimeException('Pipelinq: app-config "client_schema" is not configured.');
+        }
 
         return $this->saveAndSerialize(data: $data, schemaId: $schemaId);
     }//end importAsClient()
@@ -76,6 +82,8 @@ class ContactImportService
      *
      * @return array The created contact object data.
      *
+     * @throws RuntimeException When `contact_schema` is not configured.
+     *
      * @spec openspec/specs/contacts-sync/spec.md
      */
     public function importAsContact(array $ncContact, string $uid, ?string $clientId): array
@@ -86,6 +94,9 @@ class ContactImportService
             clientId: $clientId
         );
         $schemaId = $this->appConfig->getValueString(Application::APP_ID, 'contact_schema', '');
+        if ($schemaId === '') {
+            throw new RuntimeException('Pipelinq: app-config "contact_schema" is not configured.');
+        }
 
         return $this->saveAndSerialize(data: $data, schemaId: $schemaId);
     }//end importAsContact()
@@ -93,15 +104,28 @@ class ContactImportService
     /**
      * Save object data and return the serialized result.
      *
+     * Fails closed on an unconfigured register or schema. This write had no
+     * such guard: an empty id is not the same as "no id" to OpenRegister, whose
+     * ObjectService skips setRegister()/setSchema() for an empty value, so the
+     * imported contact would land in whatever register/schema context an
+     * earlier call in the same request left on the shared service instance.
+     * Throwing matches the surrounding import path, which already raises
+     * RuntimeException for unmet preconditions.
+     *
      * @param array  $data     The object data to save.
      * @param string $schemaId The schema ID.
      *
      * @return array The serialized result.
+     *
+     * @throws RuntimeException When the register or schema is not configured.
      */
     private function saveAndSerialize(array $data, string $schemaId): array
     {
         $objectService = $this->getObjectService();
         $registerId    = $this->appConfig->getValueString(Application::APP_ID, 'register', '');
+        if ($registerId === '' || $schemaId === '') {
+            throw new RuntimeException('Pipelinq: register or schema is not configured for the contact import.');
+        }
 
         $created = $objectService->saveObject(
             $data,

--- a/lib/Service/ContactLinkedUidsService.php
+++ b/lib/Service/ContactLinkedUidsService.php
@@ -57,6 +57,17 @@ class ContactLinkedUidsService
         $objectService = $this->getObjectService();
         $registerId    = $this->appConfig->getValueString(Application::APP_ID, 'register', '');
 
+        // Fail closed on an unconfigured register. getLinkedUidsForType() below
+        // already refuses on '', so this returns the same empty result; stating
+        // it here makes the refusal local to the read instead of resting on a
+        // callee that a later change could relax.
+        if ($registerId === '') {
+            $this->logger->warning(
+                'Pipelinq: app-config "register" is not configured; returning no linked contact UIDs'
+            );
+            return [];
+        }
+
         foreach (['client', 'contact'] as $type) {
             $typeUids = $this->getLinkedUidsForType(
                 objectService: $objectService,

--- a/lib/Service/ContactVcardWriterService.php
+++ b/lib/Service/ContactVcardWriterService.php
@@ -192,6 +192,22 @@ class ContactVcardWriterService
             $registerId    = $this->registerResolver->resolve('contact');
             $schemaId      = $this->appConfig->getValueString(Application::APP_ID, "{$objectType}_schema", '');
 
+            // Fail closed on an unconfigured register or schema. This write had
+            // no such guard: an empty id is not the same as "no id" to
+            // OpenRegister, whose ObjectService skips setRegister()/setSchema()
+            // for an empty value, so the object would be written into whatever
+            // register/schema context an earlier call in the same request left
+            // on the shared service instance. `$objectType` also reaches the
+            // config key by interpolation, so an unexpected type resolves to a
+            // key that does not exist and yields the same empty id.
+            if ($registerId === '' || $schemaId === '') {
+                $this->logger->warning(
+                    'Pipelinq: refusing to store contactsUid — register or schema is not configured',
+                    ['objectType' => $objectType]
+                );
+                return;
+            }
+
             $updateData = $objData;
             $updateData['contactsUid'] = $contactsUid;
             $objectService->saveObject(

--- a/lib/Service/ContractService.php
+++ b/lib/Service/ContractService.php
@@ -282,16 +282,29 @@ class ContractService
     /**
      * Resolve the configured register and contract-schema IDs.
      *
-     * @return array{0:string,1:string} [registerId, schemaId].
+     * Fails closed: '' on either id means "unconfigured", and every caller
+     * refuses the OpenRegister call on it. An empty id must never be handed to
+     * OpenRegister — ObjectService skips setRegister()/setSchema() for an empty
+     * value, so the query silently inherits whatever context an earlier call in
+     * the same request left on the shared service instance. The empty case is
+     * logged so an unprovisioned instance is visible rather than silent.
+     *
+     * @return array{0:string,1:string} [registerId, schemaId], each '' when
+     *                                  unconfigured.
      *
      * @spec exclude config-key plumbing — resolves the OR register/schema ids the lifecycle ops scope to
      */
     public function getRegisterAndSchema(): array
     {
-        return [
-            $this->appConfig->getValueString(Application::APP_ID, 'register', ''),
-            $this->appConfig->getValueString(Application::APP_ID, 'contract_schema', ''),
-        ];
+        $registerId = $this->appConfig->getValueString(Application::APP_ID, 'register', '');
+        $schemaId   = $this->appConfig->getValueString(Application::APP_ID, 'contract_schema', '');
+        if ($registerId === '' || $schemaId === '') {
+            $this->logger->warning(
+                'Pipelinq: register/contract_schema not configured; OpenRegister calls are refused, not run unscoped'
+            );
+        }
+
+        return [$registerId, $schemaId];
     }//end getRegisterAndSchema()
 
     /**

--- a/lib/Service/EligibilityService.php
+++ b/lib/Service/EligibilityService.php
@@ -497,11 +497,25 @@ class EligibilityService
     /**
      * Resolve the pipelinq register id from app config.
      *
-     * @return string
+     * Fails closed: '' means "unconfigured", and every caller refuses the
+     * OpenRegister call on it. An empty register must never be handed to
+     * OpenRegister — ObjectService skips setRegister() for an empty value, so
+     * the query silently inherits whatever register context an earlier call in
+     * the same request left on the shared service instance. The empty case is
+     * logged so an unprovisioned instance is visible rather than silent.
+     *
+     * @return string The configured register id, or '' when unconfigured.
      */
     private function registerId(): string
     {
-        return $this->appConfig->getValueString(Application::APP_ID, 'register', '');
+        $registerId = $this->appConfig->getValueString(Application::APP_ID, 'register', '');
+        if ($registerId === '') {
+            $this->logger->warning(
+                'Pipelinq: app-config "register" is not configured; OpenRegister calls are refused, not run unscoped'
+            );
+        }
+
+        return $registerId;
     }//end registerId()
 
     /**

--- a/lib/Service/EmailMatchService.php
+++ b/lib/Service/EmailMatchService.php
@@ -327,7 +327,15 @@ class EmailMatchService
             return 0;
         }
 
-        $register     = $this->registerSlug();
+        $register = $this->registerSlug();
+
+        // Fail closed on an unconfigured register. Without this the loop below
+        // casts '' to int and links every email against register id 0 — a write
+        // scoped to the wrong register rather than a refused one.
+        if ($register === '') {
+            return 0;
+        }
+
         $createdCount = 0;
         foreach ($entities as $entity) {
             $schemaSlug = $entity['entityType'].'_schema';
@@ -1039,11 +1047,25 @@ class EmailMatchService
     /**
      * Resolve the pipelinq register slug.
      *
-     * @return string
+     * Fails closed: '' means "unconfigured", and every caller refuses the
+     * OpenRegister call on it. An empty register must never be handed to
+     * OpenRegister — ObjectService skips setRegister() for an empty value, so
+     * the query silently inherits whatever register context an earlier call in
+     * the same request left on the shared service instance. The empty case is
+     * logged so an unprovisioned instance is visible rather than silent.
+     *
+     * @return string The configured register slug, or '' when unconfigured.
      */
     private function registerSlug(): string
     {
-        return $this->appConfig->getValueString(Application::APP_ID, 'register', '');
+        $registerSlug = $this->appConfig->getValueString(Application::APP_ID, 'register', '');
+        if ($registerSlug === '') {
+            $this->logger->warning(
+                'Pipelinq: app-config "register" is not configured; OpenRegister calls are refused, not run unscoped'
+            );
+        }
+
+        return $registerSlug;
 
     }//end registerSlug()
 

--- a/lib/Service/ForecastOverrideService.php
+++ b/lib/Service/ForecastOverrideService.php
@@ -229,14 +229,27 @@ class ForecastOverrideService
     /**
      * Resolve the register + override schema ids.
      *
-     * @return array{0: string, 1: string} The [register, schema] ids.
+     * Fails closed: '' on either id means "unconfigured", and every caller
+     * refuses the OpenRegister call on it. An empty id must never be handed to
+     * OpenRegister — ObjectService skips setRegister()/setSchema() for an empty
+     * value, so the query silently inherits whatever context an earlier call in
+     * the same request left on the shared service instance. The empty case is
+     * logged so an unprovisioned instance is visible rather than silent.
+     *
+     * @return array{0: string, 1: string} The [register, schema] ids, each ''
+     *                                     when unconfigured.
      */
     private function config(): array
     {
-        return [
-            $this->appConfig->getValueString(Application::APP_ID, 'register', ''),
-            $this->appConfig->getValueString(Application::APP_ID, 'forecastOverride_schema', ''),
-        ];
+        $registerId = $this->appConfig->getValueString(Application::APP_ID, 'register', '');
+        $schemaId   = $this->appConfig->getValueString(Application::APP_ID, 'forecastOverride_schema', '');
+        if ($registerId === '' || $schemaId === '') {
+            $this->logger->warning(
+                'Pipelinq: register/forecastOverride_schema not configured; OpenRegister calls are refused, not run unscoped'
+            );
+        }
+
+        return [$registerId, $schemaId];
     }//end config()
 
     /**

--- a/lib/Service/GiftCardService.php
+++ b/lib/Service/GiftCardService.php
@@ -642,16 +642,30 @@ class GiftCardService
     /**
      * Resolve register + schema id.
      *
+     * Fails closed: '' on either id means "unconfigured", and every caller
+     * refuses the OpenRegister call on it. An empty id must never be handed to
+     * OpenRegister — ObjectService skips setRegister()/setSchema() for an empty
+     * value, so the query silently inherits whatever context an earlier call in
+     * the same request left on the shared service instance. The empty case is
+     * logged so an unprovisioned instance is visible rather than silent.
+     *
      * @param string $schemaKey The schema config key.
      *
-     * @return array{0: string, 1: string}
+     * @return array{0: string, 1: string} The [register, schema] ids, each ''
+     *                                     when unconfigured.
      */
     private function config(string $schemaKey): array
     {
-        return [
-            $this->appConfig->getValueString(Application::APP_ID, 'register', ''),
-            $this->appConfig->getValueString(Application::APP_ID, $schemaKey, ''),
-        ];
+        $registerId = $this->appConfig->getValueString(Application::APP_ID, 'register', '');
+        $schemaId   = $this->appConfig->getValueString(Application::APP_ID, $schemaKey, '');
+        if ($registerId === '' || $schemaId === '') {
+            $this->logger->warning(
+                'Pipelinq: register/schema not configured; OpenRegister calls are refused, not run unscoped',
+                ['schemaKey' => $schemaKey]
+            );
+        }
+
+        return [$registerId, $schemaId];
     }//end config()
 
     /**

--- a/lib/Service/KccWerkplekService.php
+++ b/lib/Service/KccWerkplekService.php
@@ -154,13 +154,27 @@ class KccWerkplekService
     /**
      * Read the pipelinq register slug from the app config.
      *
-     * @return string Register slug (typically `pipelinq`); empty string when missing.
+     * Fails closed: '' means "unconfigured", and every caller refuses the
+     * OpenRegister call on it. An empty register must never be handed to
+     * OpenRegister — ObjectService skips setRegister() for an empty value, so
+     * the query silently inherits whatever register context an earlier call in
+     * the same request left on the shared service instance. The empty case is
+     * logged so an unprovisioned instance is visible rather than silent.
+     *
+     * @return string Register slug (typically `pipelinq`); '' when unconfigured.
      *
      * @spec openspec/changes/kcc-werkplek/tasks.md#task-2
      */
     private function getRegister(): string
     {
-        return $this->appConfig->getValueString(Application::APP_ID, 'register', '');
+        $registerId = $this->appConfig->getValueString(Application::APP_ID, 'register', '');
+        if ($registerId === '') {
+            $this->logger->warning(
+                'Pipelinq: app-config "register" is not configured; OpenRegister calls are refused, not run unscoped'
+            );
+        }
+
+        return $registerId;
     }//end getRegister()
 
     /**

--- a/lib/Service/LoyaltyAccountService.php
+++ b/lib/Service/LoyaltyAccountService.php
@@ -394,14 +394,30 @@ class LoyaltyAccountService
     /**
      * Resolve register + klantLoyaltyAccount schema IDs.
      *
-     * @return array{0: string, 1: string}
+     * Fails closed: '' on either id means "unconfigured", and every caller
+     * refuses the OpenRegister call on it. An empty id must never be handed to
+     * OpenRegister — ObjectService skips setRegister()/setSchema() for an empty
+     * value, so the query silently inherits whatever context an earlier call in
+     * the same request left on the shared service instance. The empty case is
+     * logged so an unprovisioned instance is visible rather than silent.
+     *
+     * @return array{0: string, 1: string} The [register, schema] ids, each ''
+     *                                     when unconfigured.
      */
     private function config(): array
     {
-        return [
-            $this->appConfig->getValueString(Application::APP_ID, 'register', ''),
-            $this->appConfig->getValueString(Application::APP_ID, 'klantLoyaltyAccount_schema', ''),
-        ];
+        $registerId = $this->appConfig->getValueString(Application::APP_ID, 'register', '');
+        $schemaId   = $this->appConfig->getValueString(Application::APP_ID, 'klantLoyaltyAccount_schema', '');
+
+        // Spelled as in_array() rather than `$a === '' || $b === ''` to keep
+        // this class under the PHPMD complexity ceiling; the check is identical.
+        if (in_array('', [$registerId, $schemaId], true) === true) {
+            $this->logger->warning(
+                'Pipelinq: register/klantLoyaltyAccount_schema not configured; OpenRegister calls are refused, not run unscoped'
+            );
+        }
+
+        return [$registerId, $schemaId];
     }//end config()
 
     /**

--- a/lib/Service/LoyaltyProgrammeService.php
+++ b/lib/Service/LoyaltyProgrammeService.php
@@ -266,16 +266,30 @@ class LoyaltyProgrammeService
     /**
      * Resolve register + schema id.
      *
+     * Fails closed: '' on either id means "unconfigured", and every caller
+     * refuses the OpenRegister call on it. An empty id must never be handed to
+     * OpenRegister — ObjectService skips setRegister()/setSchema() for an empty
+     * value, so the query silently inherits whatever context an earlier call in
+     * the same request left on the shared service instance. The empty case is
+     * logged so an unprovisioned instance is visible rather than silent.
+     *
      * @param string $schemaKey The schema config key.
      *
-     * @return array{0: string, 1: string}
+     * @return array{0: string, 1: string} The [register, schema] ids, each ''
+     *                                     when unconfigured.
      */
     private function config(string $schemaKey): array
     {
-        return [
-            $this->appConfig->getValueString(Application::APP_ID, 'register', ''),
-            $this->appConfig->getValueString(Application::APP_ID, $schemaKey, ''),
-        ];
+        $registerId = $this->appConfig->getValueString(Application::APP_ID, 'register', '');
+        $schemaId   = $this->appConfig->getValueString(Application::APP_ID, $schemaKey, '');
+        if ($registerId === '' || $schemaId === '') {
+            $this->logger->warning(
+                'Pipelinq: register/schema not configured; OpenRegister calls are refused, not run unscoped',
+                ['schemaKey' => $schemaKey]
+            );
+        }
+
+        return [$registerId, $schemaId];
     }//end config()
 
     /**

--- a/lib/Service/MessagingService.php
+++ b/lib/Service/MessagingService.php
@@ -467,11 +467,26 @@ class MessagingService
     /**
      * The pipelinq register slug (app-config overridable).
      *
-     * @return string Slug.
+     * Fails closed on a blanked override. Passing the built-in slug as
+     * getValueString()'s default only covers an ABSENT key: a key that is
+     * present but set to an empty string returns '' verbatim, and none of the
+     * callers here check for that. An empty register is not the same as "no
+     * register" to OpenRegister — ObjectService skips setRegister() for an
+     * empty value, so the query silently inherits whatever register context an
+     * earlier call in the same request left on the shared service instance.
+     * Normalising '' back to the built-in slug, exactly as the sibling
+     * schemaSlug() already does, keeps every call scoped.
+     *
+     * @return string Slug; never empty.
      */
     private function registerSlug(): string
     {
-        return $this->appConfig->getValueString(Application::APP_ID, 'register', 'pipelinq');
+        $slug = $this->appConfig->getValueString(Application::APP_ID, 'register', '');
+        if ($slug !== '') {
+            return $slug;
+        }
+
+        return 'pipelinq';
     }//end registerSlug()
 
     /**

--- a/lib/Service/PointsLedgerService.php
+++ b/lib/Service/PointsLedgerService.php
@@ -488,14 +488,27 @@ class PointsLedgerService
     /**
      * Resolve register + ledger schema IDs.
      *
-     * @return array{0: string, 1: string}
+     * Fails closed: '' on either id means "unconfigured", and every caller
+     * refuses the OpenRegister call on it. An empty id must never be handed to
+     * OpenRegister — ObjectService skips setRegister()/setSchema() for an empty
+     * value, so the query silently inherits whatever context an earlier call in
+     * the same request left on the shared service instance. The empty case is
+     * logged so an unprovisioned instance is visible rather than silent.
+     *
+     * @return array{0: string, 1: string} The [register, schema] ids, each ''
+     *                                     when unconfigured.
      */
     private function config(): array
     {
-        return [
-            $this->appConfig->getValueString(Application::APP_ID, 'register', ''),
-            $this->appConfig->getValueString(Application::APP_ID, 'pointsLedgerEntry_schema', ''),
-        ];
+        $registerId = $this->appConfig->getValueString(Application::APP_ID, 'register', '');
+        $schemaId   = $this->appConfig->getValueString(Application::APP_ID, 'pointsLedgerEntry_schema', '');
+        if ($registerId === '' || $schemaId === '') {
+            $this->logger->warning(
+                'Pipelinq: register/pointsLedgerEntry_schema not configured; OpenRegister calls are refused, not run unscoped'
+            );
+        }
+
+        return [$registerId, $schemaId];
     }//end config()
 
     /**

--- a/lib/Service/PosPaymentService.php
+++ b/lib/Service/PosPaymentService.php
@@ -1226,12 +1226,17 @@ class PosPaymentService
         $register = $this->registerId();
         $schema   = $this->posTransactionSchema();
 
-        // Fail closed on an unconfigured register/schema. Every other
-        // OpenRegister call in this service already refuses on '', but this
-        // write did not: an empty id is not the same as "no id" to
-        // ObjectService, which skips setRegister()/setSchema() for an empty
-        // value and so persists the transaction into whatever register/schema
-        // context an earlier call in the same request happened to leave behind.
+        // Fail closed on an unconfigured register/schema. Today this is
+        // defence in depth, not a live hole: loadTransaction() above reads the
+        // same two ids and throws OCSNotFoundException on '', so this branch is
+        // currently unreachable (and is therefore not covered by a test — a
+        // test asserting it would be asserting loadTransaction's behaviour).
+        // It is stated locally anyway because the write MUST NOT run on an
+        // empty id: an empty id is not the same as "no id" to ObjectService,
+        // which skips setRegister()/setSchema() for an empty value and would
+        // persist the transaction into whatever register/schema context an
+        // earlier call in the same request left behind. The guard must not
+        // depend on a read further up staying where it is.
         if ($register === '' || $schema === '') {
             $this->logger->warning(
                 'Pipelinq POS payment: saveTransaction refused — register/posTransaction_schema not configured',

--- a/lib/Service/PosPaymentService.php
+++ b/lib/Service/PosPaymentService.php
@@ -1226,6 +1226,20 @@ class PosPaymentService
         $register = $this->registerId();
         $schema   = $this->posTransactionSchema();
 
+        // Fail closed on an unconfigured register/schema. Every other
+        // OpenRegister call in this service already refuses on '', but this
+        // write did not: an empty id is not the same as "no id" to
+        // ObjectService, which skips setRegister()/setSchema() for an empty
+        // value and so persists the transaction into whatever register/schema
+        // context an earlier call in the same request happened to leave behind.
+        if ($register === '' || $schema === '') {
+            $this->logger->warning(
+                'Pipelinq POS payment: saveTransaction refused — register/posTransaction_schema not configured',
+                ['transactionId' => $id]
+            );
+            return $current;
+        }
+
         try {
             $objectService = $this->container->get('OCA\\OpenRegister\\Service\\ObjectService');
             $saved         = $objectService->saveObject(
@@ -1249,21 +1263,49 @@ class PosPaymentService
     /**
      * Pipelinq register id (from app config).
      *
-     * @return string
+     * Fails closed: '' means "unconfigured", and every caller refuses the
+     * OpenRegister call on it. An empty register must never be handed to
+     * OpenRegister — ObjectService skips setRegister() for an empty value, so
+     * the query silently inherits whatever register context an earlier call in
+     * the same request left on the shared service instance. The empty case is
+     * logged so an unprovisioned instance is visible rather than silent.
+     *
+     * @return string The configured register id, or '' when unconfigured.
      */
     private function registerId(): string
     {
-        return $this->appConfig->getValueString(Application::APP_ID, 'register', '');
+        $registerId = $this->appConfig->getValueString(Application::APP_ID, 'register', '');
+        if ($registerId === '') {
+            $this->logger->warning(
+                'Pipelinq POS payment: app-config "register" is not configured; transaction storage is refused, not run unscoped'
+            );
+        }
+
+        return $registerId;
     }//end registerId()
 
     /**
      * PosTransaction schema id (from app config).
      *
-     * @return string
+     * Fails closed: '' means "unconfigured", and every caller refuses the
+     * OpenRegister call on it. An empty schema must never be handed to
+     * OpenRegister — ObjectService skips setSchema() for an empty value, so the
+     * write silently lands in whatever schema context an earlier call in the
+     * same request left on the shared service instance. The empty case is
+     * logged so an unprovisioned instance is visible rather than silent.
+     *
+     * @return string The configured schema id, or '' when unconfigured.
      */
     private function posTransactionSchema(): string
     {
-        return $this->appConfig->getValueString(Application::APP_ID, 'posTransaction_schema', '');
+        $schemaId = $this->appConfig->getValueString(Application::APP_ID, 'posTransaction_schema', '');
+        if ($schemaId === '') {
+            $this->logger->warning(
+                'Pipelinq POS payment: app-config "posTransaction_schema" is not configured; storage is refused, not run unscoped'
+            );
+        }
+
+        return $schemaId;
     }//end posTransactionSchema()
 
     /**

--- a/lib/Service/RedemptionService.php
+++ b/lib/Service/RedemptionService.php
@@ -586,16 +586,30 @@ class RedemptionService
     /**
      * Resolve register + schema id.
      *
+     * Fails closed: '' on either id means "unconfigured", and every caller
+     * refuses the OpenRegister call on it. An empty id must never be handed to
+     * OpenRegister — ObjectService skips setRegister()/setSchema() for an empty
+     * value, so the query silently inherits whatever context an earlier call in
+     * the same request left on the shared service instance. The empty case is
+     * logged so an unprovisioned instance is visible rather than silent.
+     *
      * @param string $schemaKey The schema config key.
      *
-     * @return array{0: string, 1: string}
+     * @return array{0: string, 1: string} The [register, schema] ids, each ''
+     *                                     when unconfigured.
      */
     private function config(string $schemaKey): array
     {
-        return [
-            $this->appConfig->getValueString(Application::APP_ID, 'register', ''),
-            $this->appConfig->getValueString(Application::APP_ID, $schemaKey, ''),
-        ];
+        $registerId = $this->appConfig->getValueString(Application::APP_ID, 'register', '');
+        $schemaId   = $this->appConfig->getValueString(Application::APP_ID, $schemaKey, '');
+        if ($registerId === '' || $schemaId === '') {
+            $this->logger->warning(
+                'Pipelinq: register/schema not configured; OpenRegister calls are refused, not run unscoped',
+                ['schemaKey' => $schemaKey]
+            );
+        }
+
+        return [$registerId, $schemaId];
     }//end config()
 
     /**

--- a/lib/Service/ScheduledTaskService.php
+++ b/lib/Service/ScheduledTaskService.php
@@ -399,6 +399,18 @@ class ScheduledTaskService
 
         [$registerId, $schemaId] = $this->getRegisterAndSchema();
 
+        // Fail closed on an unconfigured register/schema. Today this is
+        // defence in depth rather than a live hole: getScheduledTask() above
+        // already throws on '' before we get here. It is stated locally because
+        // the write MUST NOT run on an empty id — an empty id is not the same
+        // as "no id" to ObjectService, which skips setRegister()/setSchema()
+        // for an empty value and so writes the task into whatever
+        // register/schema context an earlier call in the same request left
+        // behind. The guard must not depend on a read further up staying put.
+        if ($registerId === '' || $schemaId === '') {
+            throw new RuntimeException('Task register or schema is not configured.');
+        }
+
         $saved = $this->getObjectService()->saveObject(
             $merged,
             [],
@@ -833,12 +845,25 @@ class ScheduledTaskService
     /**
      * Read configured register and task schema IDs.
      *
-     * @return array{0: string, 1: string} [register, schema] tuple.
+     * Fails closed: '' on either id means "unconfigured", and every caller
+     * refuses the OpenRegister call on it. An empty id must never be handed to
+     * OpenRegister — ObjectService skips setRegister()/setSchema() for an empty
+     * value, so the query silently inherits whatever context an earlier call in
+     * the same request left on the shared service instance. The empty case is
+     * logged so an unprovisioned instance is visible rather than silent.
+     *
+     * @return array{0: string, 1: string} [register, schema] tuple, each ''
+     *                                     when unconfigured.
      */
     private function getRegisterAndSchema(): array
     {
         $registerId = $this->appConfig->getValueString(Application::APP_ID, 'register', '');
         $schemaId   = $this->appConfig->getValueString(Application::APP_ID, 'task_schema', '');
+        if ($registerId === '' || $schemaId === '') {
+            $this->logger->warning(
+                'Pipelinq: register/task_schema not configured; OpenRegister calls are refused, not run unscoped'
+            );
+        }
 
         return [$registerId, $schemaId];
     }//end getRegisterAndSchema()

--- a/lib/Service/TicketService.php
+++ b/lib/Service/TicketService.php
@@ -140,17 +140,40 @@ class TicketService
     /**
      * The pipelinq register id.
      *
+     * Fails closed: '' means "unconfigured". Callers must gate on
+     * {@see isConfigured()} and refuse the OpenRegister call — an empty
+     * register must never be handed to OpenRegister, because ObjectService
+     * skips setRegister() for an empty value and the query then silently
+     * inherits whatever register context an earlier call in the same request
+     * left on the shared service instance. The empty case is logged so an
+     * unprovisioned instance is visible rather than silent.
+     *
      * @return string The register id ('' when unconfigured).
      *
      * @spec openspec/changes/unify-ticket-supertype/specs/unify-ticket-supertype/spec.md#requirement-ticket-supertype-schema
      */
     public function getRegisterId(): string
     {
-        return $this->appConfig->getValueString(Application::APP_ID, 'register', '');
+        $registerId = $this->appConfig->getValueString(Application::APP_ID, 'register', '');
+        if ($registerId === '') {
+            $this->logger->warning(
+                'Pipelinq: app-config "register" is not configured; ticket reads/writes are refused, not run unscoped'
+            );
+        }
+
+        return $registerId;
     }//end getRegisterId()
 
     /**
      * The unified ticket schema id.
+     *
+     * Fails closed: '' means "unconfigured". Callers must gate on
+     * {@see isConfigured()} and refuse the OpenRegister call — an empty schema
+     * must never be handed to OpenRegister, because ObjectService skips
+     * setSchema() for an empty value and the query then silently inherits
+     * whatever schema context an earlier call in the same request left on the
+     * shared service instance. The empty case is logged so an unprovisioned
+     * instance is visible rather than silent.
      *
      * @return string The schema id ('' when unconfigured).
      *
@@ -158,7 +181,14 @@ class TicketService
      */
     public function getSchemaId(): string
     {
-        return $this->appConfig->getValueString(Application::APP_ID, 'ticket_schema', '');
+        $schemaId = $this->appConfig->getValueString(Application::APP_ID, 'ticket_schema', '');
+        if ($schemaId === '') {
+            $this->logger->warning(
+                'Pipelinq: app-config "ticket_schema" is not configured; ticket reads/writes are refused, not run unscoped'
+            );
+        }
+
+        return $schemaId;
     }//end getSchemaId()
 
     /**

--- a/lib/Service/TierService.php
+++ b/lib/Service/TierService.php
@@ -392,16 +392,30 @@ class TierService
     /**
      * Resolve register + a schema id by appconfig key.
      *
+     * Fails closed: '' on either id means "unconfigured", and every caller
+     * refuses the OpenRegister call on it. An empty id must never be handed to
+     * OpenRegister — ObjectService skips setRegister()/setSchema() for an empty
+     * value, so the query silently inherits whatever context an earlier call in
+     * the same request left on the shared service instance. The empty case is
+     * logged so an unprovisioned instance is visible rather than silent.
+     *
      * @param string $schemaKey The schema config key (e.g. 'tierRule_schema').
      *
-     * @return array{0: string, 1: string}
+     * @return array{0: string, 1: string} The [register, schema] ids, each ''
+     *                                     when unconfigured.
      */
     private function config(string $schemaKey): array
     {
-        return [
-            $this->appConfig->getValueString(Application::APP_ID, 'register', ''),
-            $this->appConfig->getValueString(Application::APP_ID, $schemaKey, ''),
-        ];
+        $registerId = $this->appConfig->getValueString(Application::APP_ID, 'register', '');
+        $schemaId   = $this->appConfig->getValueString(Application::APP_ID, $schemaKey, '');
+        if ($registerId === '' || $schemaId === '') {
+            $this->logger->warning(
+                'Pipelinq: register/schema not configured; OpenRegister calls are refused, not run unscoped',
+                ['schemaKey' => $schemaKey]
+            );
+        }
+
+        return [$registerId, $schemaId];
     }//end config()
 
     /**

--- a/lib/Service/WalkInQueueService.php
+++ b/lib/Service/WalkInQueueService.php
@@ -893,11 +893,25 @@ class WalkInQueueService
     /**
      * The pipelinq register id from app config.
      *
-     * @return string
+     * Fails closed: '' means "unconfigured", and every caller refuses the
+     * OpenRegister call on it. An empty register must never be handed to
+     * OpenRegister — ObjectService skips setRegister() for an empty value, so
+     * the query silently inherits whatever register context an earlier call in
+     * the same request left on the shared service instance. The empty case is
+     * logged so an unprovisioned instance is visible rather than silent.
+     *
+     * @return string The configured register id, or '' when unconfigured.
      */
     private function registerId(): string
     {
-        return $this->appConfig->getValueString(Application::APP_ID, 'register', '');
+        $registerId = $this->appConfig->getValueString(Application::APP_ID, 'register', '');
+        if ($registerId === '') {
+            $this->logger->warning(
+                'Pipelinq: app-config "register" is not configured; OpenRegister calls are refused, not run unscoped'
+            );
+        }
+
+        return $registerId;
     }//end registerId()
 
     /**

--- a/tests/Unit/Service/BerichtenboxServiceTest.php
+++ b/tests/Unit/Service/BerichtenboxServiceTest.php
@@ -96,6 +96,11 @@ class BerichtenboxServiceTest extends TestCase
                     'mailboxResolution_schema'    => 'sch-mr',
                     'tenant_id'                   => 'tenant-a',
                     'tenant_display_name'         => 'Gemeente Amsterdam',
+                    // A provisioned tenant HAS PKI-overheid material. Leaving
+                    // these at '' made every dispatch test exercise the
+                    // unsigned-request path without saying so.
+                    'pki_cert'                    => '--pki-cert-pem--',
+                    'pki_key'                     => '--pki-key-pem--',
                     default                       => $default,
                 };
             }
@@ -159,7 +164,8 @@ class BerichtenboxServiceTest extends TestCase
         MailboxResolver $resolver,
         LogiusConnector $logius,
         EmailFallbackSender $email,
-        DeliveryAuditLogger $audit
+        DeliveryAuditLogger $audit,
+        ?IAppConfig $appConfig=null
     ): BerichtenboxService {
         $container = $this->createMock(ContainerInterface::class);
         $container->method('get')->willReturn($objectService);
@@ -167,7 +173,7 @@ class BerichtenboxServiceTest extends TestCase
 
         return new BerichtenboxService(
             $container,
-            $this->appConfigStub(),
+            ($appConfig ?? $this->appConfigStub()),
             $this->realEncryption(),
             new TemplateRenderer($this->createMock(LoggerInterface::class)),
             $resolver,
@@ -284,6 +290,78 @@ class BerichtenboxServiceTest extends TestCase
         $this->assertNotEmpty($sentRows);
         $this->assertSame('logius-99', array_values($sentRows)[0]['logiusMessageId']);
     }//end testDispatchOneToBerichtenbox()
+
+    /**
+     * dispatchOne fails CLOSED when the tenant PKI-overheid cert/key is absent.
+     *
+     * An empty `pki_key` does not stop the dispatch by itself: LogiusConnector
+     * ::signRequest() falls back to `base64(sha256(body))`, a keyless digest,
+     * and the message would still leave the instance carrying a plaintext BSN
+     * with request signing silently deactivated. The dispatch must be refused
+     * and routed to the retry/fail path instead.
+     *
+     * @return void
+     */
+    public function testDispatchOneRefusesWhenPkiMaterialMissing(): void
+    {
+        $resolver = $this->createMock(MailboxResolver::class);
+        $resolver->method('resolve')->willReturn([
+            'mailboxAvailable' => true,
+            'optedOut'         => false,
+            'resolvedAt'       => '2026-06-01T00:00:00Z',
+            'expiresAt'        => '2026-06-02T00:00:00Z',
+            'bsnHash'          => str_repeat('a', 64),
+            'source'           => 'cache',
+        ]);
+
+        // The connector must never be reached on an unprovisioned tenant.
+        $logius = $this->createMock(LogiusConnector::class);
+        $logius->expects($this->never())->method('sendMessage');
+
+        $audit = $this->createMock(DeliveryAuditLogger::class);
+        $audit->expects($this->never())->method('logSent');
+        $audit->method('hashPayload')->willReturn('hash');
+
+        $email = $this->createMock(EmailFallbackSender::class);
+
+        // Same stub, minus the PKI material.
+        $appConfig = $this->createMock(IAppConfig::class);
+        $appConfig->method('getValueString')->willReturnCallback(
+            static function (string $app, string $key, string $default=''): string {
+                return match ($key) {
+                    'register'                   => 'reg-1',
+                    'berichtenboxMessage_schema' => 'sch-msg',
+                    'tenant_id'                  => 'tenant-a',
+                    'pki_cert', 'pki_key'        => '',
+                    default                      => $default,
+                };
+            }
+        );
+
+        $service = $this->buildService(
+            $this->captureObjectService(),
+            $resolver,
+            $logius,
+            $email,
+            $audit,
+            $appConfig
+        );
+
+        $encryption = $this->realEncryption();
+
+        $service->dispatchOne([
+            'uuid'           => 'msg-nopki',
+            'bsn'            => $encryption->encrypt('123456789', 'tenant-a'),
+            'bsnHash'        => $encryption->hashBsn('123456789', 'tenant-a'),
+            'subject'        => 'X',
+            'body'           => '<p>x</p>',
+            'deliveryStatus' => 'queued',
+            'retryCount'     => 0,
+        ]);
+
+        $sentRows = array_filter($this->savedMessages, fn ($r) => ($r['deliveryStatus'] ?? '') === 'sent');
+        $this->assertEmpty($sentRows, 'No message may be marked sent without tenant PKI material.');
+    }//end testDispatchOneRefusesWhenPkiMaterialMissing()
 
     /**
      * dispatchOne with no mailbox + email available → fallback path.

--- a/tests/Unit/Service/ContactImportServiceGuardTest.php
+++ b/tests/Unit/Service/ContactImportServiceGuardTest.php
@@ -1,0 +1,142 @@
+<?php
+
+/**
+ * Unit tests for ContactImportService's fail-closed handling of an
+ * unconfigured register / client_schema / contact_schema.
+ *
+ * @category Test
+ * @package  OCA\Pipelinq\Tests\Unit\Service
+ *
+ * @author    Conduction <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * @version GIT: <git_id>
+ *
+ * @link https://pipelinq.nl
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Pipelinq\Tests\Unit\Service;
+
+use OCA\OpenRegister\Service\ObjectService;
+use OCA\Pipelinq\Service\ContactDataBuilder;
+use OCA\Pipelinq\Service\ContactImportService;
+use OCP\IAppConfig;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+use RuntimeException;
+
+/**
+ * These imports WROTE to OpenRegister with an unchecked register and schema.
+ *
+ * An empty id is not the same as passing none: ObjectService skips
+ * setRegister()/setSchema() for an empty value, so the imported contact would
+ * be persisted into whatever register/schema context an earlier call in the
+ * same request left on the shared instance. Every test therefore asserts that
+ * saveObject() is never reached, not merely that an exception surfaced.
+ */
+class ContactImportServiceGuardTest extends TestCase
+{
+    /**
+     * Build the service over a config map.
+     *
+     * @param array<string, string> $config The app-config contents.
+     * @param ObjectService         $object The OpenRegister ObjectService mock.
+     *
+     * @return ContactImportService
+     */
+    private function buildService(array $config, ObjectService $object): ContactImportService
+    {
+        $container = $this->createMock(ContainerInterface::class);
+        $container->method('get')->willReturn($object);
+
+        $appConfig = $this->createMock(IAppConfig::class);
+        $appConfig->method('getValueString')->willReturnCallback(
+            static function (string $app, string $key, string $default='') use ($config): string {
+                return ($config[$key] ?? $default);
+            }
+        );
+
+        $builder = $this->createMock(ContactDataBuilder::class);
+        $builder->method('buildClientImportData')->willReturn(['name' => 'Acme']);
+        $builder->method('buildContactImportData')->willReturn(['name' => 'Alice']);
+
+        return new ContactImportService($appConfig, $container, $builder);
+    }//end buildService()
+
+    /**
+     * importAsClient refuses when `client_schema` is unset.
+     *
+     * @return void
+     */
+    public function testImportAsClientRefusesWithoutClientSchema(): void
+    {
+        $object = $this->createMock(ObjectService::class);
+        $object->expects($this->never())->method('saveObject');
+
+        $service = $this->buildService(['register' => 'reg-1'], $object);
+
+        $this->expectException(RuntimeException::class);
+        $service->importAsClient(['FN' => 'Acme'], 'uid-1');
+    }//end testImportAsClientRefusesWithoutClientSchema()
+
+    /**
+     * importAsContact refuses when `contact_schema` is unset.
+     *
+     * @return void
+     */
+    public function testImportAsContactRefusesWithoutContactSchema(): void
+    {
+        $object = $this->createMock(ObjectService::class);
+        $object->expects($this->never())->method('saveObject');
+
+        $service = $this->buildService(['register' => 'reg-1'], $object);
+
+        $this->expectException(RuntimeException::class);
+        $service->importAsContact(['FN' => 'Alice'], 'uid-2', null);
+    }//end testImportAsContactRefusesWithoutContactSchema()
+
+    /**
+     * A configured schema but an unset register still refuses — the register
+     * is read inside saveAndSerialize(), after the schema check passes.
+     *
+     * @return void
+     */
+    public function testImportRefusesWithoutRegisterEvenWhenSchemaIsSet(): void
+    {
+        $object = $this->createMock(ObjectService::class);
+        $object->expects($this->never())->method('saveObject');
+
+        $service = $this->buildService(['client_schema' => 'sch-client'], $object);
+
+        $this->expectException(RuntimeException::class);
+        $service->importAsClient(['FN' => 'Acme'], 'uid-3');
+    }//end testImportRefusesWithoutRegisterEvenWhenSchemaIsSet()
+
+    /**
+     * A fully configured instance does write — otherwise the negative
+     * assertions above would pass for the wrong reason.
+     *
+     * @return void
+     */
+    public function testConfiguredImportReachesOpenRegister(): void
+    {
+        $object = $this->createMock(ObjectService::class);
+        $object->expects($this->once())->method('saveObject')->willReturn(['id' => 'obj-1']);
+
+        $service = $this->buildService(
+            [
+                'register'      => 'reg-1',
+                'client_schema' => 'sch-client',
+            ],
+            $object
+        );
+
+        $this->assertSame(['id' => 'obj-1'], $service->importAsClient(['FN' => 'Acme'], 'uid-4'));
+    }//end testConfiguredImportReachesOpenRegister()
+}//end class

--- a/tests/Unit/Service/ContactVcardWriterServiceGuardTest.php
+++ b/tests/Unit/Service/ContactVcardWriterServiceGuardTest.php
@@ -1,0 +1,169 @@
+<?php
+
+/**
+ * Unit tests for ContactVcardWriterService's fail-closed handling of an
+ * unconfigured register / {objectType}_schema.
+ *
+ * @category Test
+ * @package  OCA\Pipelinq\Tests\Unit\Service
+ *
+ * @author    Conduction <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * @version GIT: <git_id>
+ *
+ * @link https://pipelinq.nl
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Pipelinq\Tests\Unit\Service;
+
+use OCA\OpenRegister\Service\ObjectService;
+use OCA\Pipelinq\Service\ContactVcardWriterService;
+use OCA\Pipelinq\Service\RegisterResolverService;
+use OCP\Contacts\IManager as IContactsManager;
+use OCP\IAppConfig;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+use Psr\Log\LoggerInterface;
+
+/**
+ * storeContactsUidOnObject() wrote back with an unchecked schema.
+ *
+ * The config key is built by interpolating $objectType, so an unexpected type
+ * resolves to a key that does not exist and yields the same empty id. An empty
+ * id is not "no id" to OpenRegister — ObjectService skips setSchema() on '',
+ * so the write would land in the request's leftover schema context.
+ */
+class ContactVcardWriterServiceGuardTest extends TestCase
+{
+    /**
+     * Build the service over a config map, with a stub addressbook that
+     * returns a fresh UID so the write-back path is reached.
+     *
+     * @param array<string, string> $config   The app-config contents.
+     * @param ObjectService         $object   The ObjectService mock.
+     * @param string                $register The resolved register id.
+     *
+     * @return ContactVcardWriterService
+     */
+    private function buildService(
+        array $config,
+        ObjectService $object,
+        string $register='reg-1'
+    ): ContactVcardWriterService {
+        $addressBook = new class {
+            /**
+             * Stub createOrUpdate returning a card with a fresh UID.
+             *
+             * @param array<string, mixed> $properties The vCard properties.
+             *
+             * @return array<string, mixed>
+             */
+            public function createOrUpdate(array $properties): array
+            {
+                return ['UID' => 'nc-uid-1'];
+            }//end createOrUpdate()
+        };
+
+        $contacts = $this->createMock(IContactsManager::class);
+        $contacts->method('getUserAddressBooks')->willReturn([$addressBook]);
+
+        $appConfig = $this->createMock(IAppConfig::class);
+        $appConfig->method('getValueString')->willReturnCallback(
+            static function (string $app, string $key, string $default='') use ($config): string {
+                return ($config[$key] ?? $default);
+            }
+        );
+
+        $container = $this->createMock(ContainerInterface::class);
+        $container->method('get')->willReturn($object);
+
+        $resolver = $this->createMock(RegisterResolverService::class);
+        $resolver->method('resolve')->willReturn($register);
+
+        return new ContactVcardWriterService(
+            $contacts,
+            $appConfig,
+            $container,
+            $this->createMock(LoggerInterface::class),
+            $resolver
+        );
+    }//end buildService()
+
+    /**
+     * An unset {objectType}_schema refuses the write-back.
+     *
+     * @return void
+     */
+    public function testMissingSchemaRefusesTheWriteBack(): void
+    {
+        $object = $this->createMock(ObjectService::class);
+        $object->expects($this->never())->method('saveObject');
+
+        $service = $this->buildService([], $object);
+
+        $uid = $service->writeToAddressBook(['FN' => 'Alice'], ['id' => 'o-1'], 'contact');
+
+        $this->assertSame('nc-uid-1', $uid);
+    }//end testMissingSchemaRefusesTheWriteBack()
+
+    /**
+     * An unresolvable register refuses the write-back even when the schema
+     * is configured.
+     *
+     * @return void
+     */
+    public function testMissingRegisterRefusesTheWriteBack(): void
+    {
+        $object = $this->createMock(ObjectService::class);
+        $object->expects($this->never())->method('saveObject');
+
+        $service = $this->buildService(['contact_schema' => 'sch-contact'], $object, '');
+
+        $uid = $service->writeToAddressBook(['FN' => 'Alice'], ['id' => 'o-1'], 'contact');
+
+        $this->assertSame('nc-uid-1', $uid);
+    }//end testMissingRegisterRefusesTheWriteBack()
+
+    /**
+     * An unexpected object type resolves to a config key that does not exist,
+     * which is the same empty-schema hazard reached by a different route.
+     *
+     * @return void
+     */
+    public function testUnknownObjectTypeRefusesTheWriteBack(): void
+    {
+        $object = $this->createMock(ObjectService::class);
+        $object->expects($this->never())->method('saveObject');
+
+        $service = $this->buildService(['contact_schema' => 'sch-contact'], $object);
+
+        $uid = $service->writeToAddressBook(['FN' => 'Alice'], ['id' => 'o-1'], 'nonsense');
+
+        $this->assertSame('nc-uid-1', $uid);
+    }//end testUnknownObjectTypeRefusesTheWriteBack()
+
+    /**
+     * A configured instance does write back — otherwise the negative
+     * assertions above would pass for the wrong reason.
+     *
+     * @return void
+     */
+    public function testConfiguredWriteBackReachesOpenRegister(): void
+    {
+        $object = $this->createMock(ObjectService::class);
+        $object->expects($this->once())->method('saveObject');
+
+        $service = $this->buildService(['contact_schema' => 'sch-contact'], $object);
+
+        $uid = $service->writeToAddressBook(['FN' => 'Alice'], ['id' => 'o-1'], 'contact');
+
+        $this->assertSame('nc-uid-1', $uid);
+    }//end testConfiguredWriteBackReachesOpenRegister()
+}//end class

--- a/tests/Unit/Service/GiftCardServiceConfigGuardTest.php
+++ b/tests/Unit/Service/GiftCardServiceConfigGuardTest.php
@@ -1,0 +1,154 @@
+<?php
+
+/**
+ * Unit tests for GiftCardService's fail-closed handling of an unconfigured
+ * register / giftCard_schema.
+ *
+ * @category Test
+ * @package  OCA\Pipelinq\Tests\Unit\Service
+ *
+ * @author    Conduction <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * @version GIT: <git_id>
+ *
+ * @link https://pipelinq.nl
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Pipelinq\Tests\Unit\Service;
+
+use OCA\OpenRegister\Service\ObjectService;
+use OCA\Pipelinq\Service\GiftCardService;
+use OCP\IAppConfig;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+use Psr\Log\LoggerInterface;
+
+/**
+ * An empty register or schema id must never reach OpenRegister.
+ *
+ * ObjectService skips setRegister()/setSchema() for an empty value, so a call
+ * carrying '' does not fail — it runs under whatever register/schema context
+ * an earlier call in the same request left on the shared, request-scoped
+ * instance. The refusal is therefore asserted on the ObjectService itself
+ * never being reached, not merely on the return value.
+ */
+class GiftCardServiceConfigGuardTest extends TestCase
+{
+    /**
+     * Build the service over a config map.
+     *
+     * @param array<string, string> $config The app-config contents.
+     * @param ObjectService         $object The OpenRegister ObjectService mock.
+     *
+     * @return GiftCardService
+     */
+    private function buildService(array $config, ObjectService $object): GiftCardService
+    {
+        $container = $this->createMock(ContainerInterface::class);
+        $container->method('get')->willReturn($object);
+
+        $appConfig = $this->createMock(IAppConfig::class);
+        $appConfig->method('getValueString')->willReturnCallback(
+            static function (string $app, string $key, string $default='') use ($config): string {
+                return ($config[$key] ?? $default);
+            }
+        );
+
+        return new GiftCardService(
+            $container,
+            $appConfig,
+            $this->createMock(LoggerInterface::class)
+        );
+    }//end buildService()
+
+    /**
+     * A missing register refuses the read and never reaches OpenRegister.
+     *
+     * @return void
+     */
+    public function testMissingRegisterRefusesWithoutTouchingOpenRegister(): void
+    {
+        $object = $this->createMock(ObjectService::class);
+        $object->expects($this->never())->method('find');
+        $object->expects($this->never())->method('findAll');
+        $object->expects($this->never())->method('saveObject');
+
+        $service = $this->buildService(['giftCard_schema' => 'sch-card'], $object);
+
+        $this->assertNull($service->getCard('card-1'));
+    }//end testMissingRegisterRefusesWithoutTouchingOpenRegister()
+
+    /**
+     * A missing schema refuses the read and never reaches OpenRegister.
+     *
+     * @return void
+     */
+    public function testMissingSchemaRefusesWithoutTouchingOpenRegister(): void
+    {
+        $object = $this->createMock(ObjectService::class);
+        $object->expects($this->never())->method('find');
+        $object->expects($this->never())->method('findAll');
+        $object->expects($this->never())->method('saveObject');
+
+        $service = $this->buildService(['register' => 'reg-1'], $object);
+
+        $this->assertNull($service->getCard('card-1'));
+    }//end testMissingSchemaRefusesWithoutTouchingOpenRegister()
+
+    /**
+     * A blank register is logged, so an unprovisioned instance is visible
+     * rather than degrading to a silent empty surface.
+     *
+     * @return void
+     */
+    public function testUnconfiguredRegisterIsLogged(): void
+    {
+        $object = $this->createMock(ObjectService::class);
+
+        $container = $this->createMock(ContainerInterface::class);
+        $container->method('get')->willReturn($object);
+
+        $appConfig = $this->createMock(IAppConfig::class);
+        $appConfig->method('getValueString')->willReturnCallback(
+            static function (string $app, string $key, string $default=''): string {
+                return $default;
+            }
+        );
+
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects($this->atLeastOnce())->method('warning');
+
+        $service = new GiftCardService($container, $appConfig, $logger);
+
+        $this->assertNull($service->getCard('card-1'));
+    }//end testUnconfiguredRegisterIsLogged()
+
+    /**
+     * A fully configured instance does reach OpenRegister — the negative
+     * assertions above would otherwise pass for the wrong reason.
+     *
+     * @return void
+     */
+    public function testConfiguredInstanceReachesOpenRegister(): void
+    {
+        $object = $this->createMock(ObjectService::class);
+        $object->expects($this->once())->method('find')->willReturn(null);
+
+        $service = $this->buildService(
+            [
+                'register'         => 'reg-1',
+                'giftCard_schema'  => 'sch-card',
+            ],
+            $object
+        );
+
+        $this->assertNull($service->getCard('card-1'));
+    }//end testConfiguredInstanceReachesOpenRegister()
+}//end class

--- a/tests/Unit/Service/PosPaymentServiceTest.php
+++ b/tests/Unit/Service/PosPaymentServiceTest.php
@@ -335,4 +335,29 @@ class PosPaymentServiceTest extends TestCase
 
         $this->assertSame('ignored', $result['status']);
     }//end testHandleSettlementIgnoresUnknownSession()
+
+    /**
+     * An unconfigured register/posTransaction_schema refuses the read AND
+     * never reaches OpenRegister.
+     *
+     * An empty id is not the same as "no id" to OpenRegister: ObjectService
+     * skips setRegister()/setSchema() on '' and the call would run under
+     * whatever register/schema context an earlier call in the same request
+     * left on the shared instance. Nothing may reach the ObjectService.
+     *
+     * @return void
+     */
+    public function testUnconfiguredRegisterRefusesAndNeverCallsOpenRegister(): void
+    {
+        unset($this->configStore['register'], $this->configStore['posTransaction_schema']);
+
+        $object = $this->createMock(originalClassName: ObjectService::class);
+        $object->expects($this->never())->method('findAll');
+        $object->expects($this->never())->method('saveObject');
+
+        $service = $this->buildService(object: $object);
+
+        $this->expectException(OCSNotFoundException::class);
+        $service->capturePayment(transactionId: 'txn-1');
+    }//end testUnconfiguredRegisterRefusesAndNeverCallsOpenRegister()
 }//end class

--- a/tests/Unit/Service/RegisterSlugBlankOverrideTest.php
+++ b/tests/Unit/Service/RegisterSlugBlankOverrideTest.php
@@ -1,0 +1,165 @@
+<?php
+
+/**
+ * Unit tests for the `register` slug fallback when the app-config key is
+ * PRESENT but BLANK.
+ *
+ * @category Test
+ * @package  OCA\Pipelinq\Tests\Unit\Service
+ *
+ * @author    Conduction <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * @version GIT: <git_id>
+ *
+ * @link https://pipelinq.nl
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Pipelinq\Tests\Unit\Service;
+
+use OCA\OpenRegister\Service\ObjectService;
+use OCA\Pipelinq\Service\ChannelProviderRepository;
+use OCA\Pipelinq\Service\ConsentService;
+use OCA\Pipelinq\Service\MessagingService;
+use OCA\Pipelinq\Service\SmsAdapter;
+use OCA\Pipelinq\Service\WhatsAppAdapter;
+use OCP\IAppConfig;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Passing the built-in slug as getValueString()'s default only covers an
+ * ABSENT key. A key that is present but set to an empty string returns ''
+ * verbatim, and an empty register is not the same as "no register" to
+ * OpenRegister: ObjectService skips setRegister() on '' and the query would
+ * inherit the request's leftover context.
+ *
+ * These tests distinguish the two cases the old default-argument form
+ * conflated — key missing, and key present-but-blank.
+ */
+class RegisterSlugBlankOverrideTest extends TestCase
+{
+    /**
+     * Build MessagingService over a config map.
+     *
+     * @param array<string, string> $config The app-config contents.
+     * @param ObjectService         $object The ObjectService mock.
+     *
+     * @return MessagingService
+     */
+    private function buildService(array $config, ObjectService $object): MessagingService
+    {
+        $container = $this->createMock(ContainerInterface::class);
+        $container->method('get')->willReturn($object);
+
+        $appConfig = $this->createMock(IAppConfig::class);
+        $appConfig->method('getValueString')->willReturnCallback(
+            static function (string $app, string $key, string $default='') use ($config): string {
+                // array_key_exists, NOT ??: a key set to '' must return '',
+                // which is exactly the case under test.
+                if (array_key_exists($key, $config) === true) {
+                    return $config[$key];
+                }
+
+                return $default;
+            }
+        );
+
+        return new MessagingService(
+            $container,
+            $appConfig,
+            $this->createMock(ChannelProviderRepository::class),
+            $this->createMock(SmsAdapter::class),
+            $this->createMock(WhatsAppAdapter::class),
+            $this->createMock(ConsentService::class),
+            $this->createMock(LoggerInterface::class)
+        );
+    }//end buildService()
+
+    /**
+     * A BLANK `register` override still resolves to the built-in slug, so the
+     * lookup proceeds scoped instead of being abandoned.
+     *
+     * Before the fix this returned '' and loadContact() bailed out, because
+     * getValueString()'s default never applies to a present-but-empty key.
+     *
+     * @return void
+     */
+    public function testBlankRegisterOverrideFallsBackToBuiltInSlug(): void
+    {
+        $seen = [];
+
+        $object = $this->createMock(ObjectService::class);
+        $object->method('find')->willReturnCallback(
+            static function (...$args) use (&$seen): ?array {
+                $seen[] = ($args[1] ?? null);
+                return null;
+            }
+        );
+
+        $service = $this->buildService(['register' => ''], $object);
+
+        $service->loadContact('contact-1');
+
+        $this->assertNotEmpty($seen, 'A blank register override must not abandon the lookup.');
+        $this->assertSame('pipelinq', $seen[0], 'A blank override must resolve to the built-in slug.');
+    }//end testBlankRegisterOverrideFallsBackToBuiltInSlug()
+
+    /**
+     * An ABSENT `register` key resolves to the built-in slug too.
+     *
+     * @return void
+     */
+    public function testAbsentRegisterKeyFallsBackToBuiltInSlug(): void
+    {
+        $seen = [];
+
+        $object = $this->createMock(ObjectService::class);
+        $object->method('find')->willReturnCallback(
+            static function (...$args) use (&$seen): ?array {
+                $seen[] = ($args[1] ?? null);
+                return null;
+            }
+        );
+
+        $service = $this->buildService([], $object);
+
+        $service->loadContact('contact-1');
+
+        $this->assertNotEmpty($seen);
+        $this->assertSame('pipelinq', $seen[0]);
+    }//end testAbsentRegisterKeyFallsBackToBuiltInSlug()
+
+    /**
+     * An explicit override is still honoured — the fallback must not swallow
+     * a real configuration.
+     *
+     * @return void
+     */
+    public function testExplicitRegisterOverrideIsHonoured(): void
+    {
+        $seen = [];
+
+        $object = $this->createMock(ObjectService::class);
+        $object->method('find')->willReturnCallback(
+            static function (...$args) use (&$seen): ?array {
+                $seen[] = ($args[1] ?? null);
+                return null;
+            }
+        );
+
+        $service = $this->buildService(['register' => 'custom-reg'], $object);
+
+        $service->loadContact('contact-1');
+
+        $this->assertNotEmpty($seen);
+        $this->assertSame('custom-reg', $seen[0]);
+    }//end testExplicitRegisterOverrideIsHonoured()
+}//end class


### PR DESCRIPTION
## Measurement

Gate package: `[hydra-gates] gate package: 48c88ba1e0d049f8f38538c33e790d3e603c55d0`

| | gate-50 `security-config-fail-mode` |
|---|---|
| before | **FAIL — 38** unsafe security-config reads |
| after | **PASS — 0** |

Both numbers are read from the runner's **stdout**, not an exit status. `hydra-gate-security-config-fail-mode.log.err` was **0 bytes** on both runs, so the checker did not crash into a silent pass. Full-repo scope, 232 `lib/**/*{Controller,Service}.php` files inspected.

gate-50 is the **only** verdict *and* the only finding count that moved across the whole suite — no collateral, nothing else regressed.

`composer check:strict` equivalents, run on PHP 8.4 in the `nextcloud` container (local PHP is 8.2, below the project floor): **PHPCS 0 errors** · **PHPMD clean, both rulesets** · **Psalm "No errors found"** · **PHPStan "No errors"** · **PHPUnit 1652 tests, 0 failures**.

No waivers, no `@spec exclude`, no `.skip`, no `continue-on-error`, no threshold changes, and **nothing added to `phpstan-baseline.neon` or `phpmd.baseline.xml`**.

## Why this surface had never been reviewed

gate-50 reported PASS over this whole repository before the gate was repaired. Its app-id pattern matched only a **quoted string literal**; pipelinq writes `Application::APP_ID` everywhere, so all 291 config reads were invisible to it. Every finding here is first-look.

## Why an empty id is the *permissive* value

This is the load-bearing fact behind the whole PR, and it is measurable in OpenRegister's source:

- `ObjectService::prepareFindAllConfig()` **skips** `setRegister()`/`setSchema()` when the value is empty. It does **not** reset the context.
- `ObjectService` is request-scoped and shared, so `$this->currentRegister` / `$this->currentSchema` retain whatever an **earlier call in the same request** set.
- Therefore a call carrying `''` does not fail — it runs under **someone else's scope**. Wrong-scope read or write, not a refused one.
- OR's own `count()` documents the same shape in a comment: without context, `MagicMapper::countAll()` "sums EVERY register/schema table — i.e. the whole instance".

That is exactly the opencatalogi#86 shape this gate was built for: an empty scope value silently deactivating the scoping.

## Findings and disposition

All 38 findings, grouped by what was actually wrong. **None** landed in a file owned by another work item.

### A. Live fail-open — defence deactivated (1 finding, highest severity)

| Finding | Disposition |
|---|---|
| `BerichtenboxService.php:531` — `pki_key` (+ `pki_cert` on the line above) | **Fixed — real hole.** An empty key did not stop the dispatch. `LogiusConnector::signRequest()` falls back to `base64(sha256(body))` — a keyless digest anyone can recompute — and sends it as the `X-Signature` header. The message still went to Logius **carrying a plaintext BSN with request signing silently deactivated**. The code comment admitted the safety rested on "the deploy checklist", not on code. `dispatchToBerichtenbox()` now refuses and routes to the existing `markFailedOrRetry()` path. |

### B. Reached OpenRegister with an unchecked id (7 findings)

| Finding | Disposition |
|---|---|
| `ContactImportService.php:65` `client_schema` · `:88` `contact_schema` · `:104` `register` | **Fixed — real.** `saveAndSerialize()` and both import entry points had no check at all. Now throw `RuntimeException`, matching the surrounding import path which already raises for unmet preconditions. |
| `ContactVcardWriterService.php:193` `{$objectType}_schema` | **Fixed — real.** Unchecked schema on a write; the key is built by interpolating `$objectType`, so an unexpected type resolves to a missing key and the same empty id. |
| `EmailMatchService.php:1046` `register` | **Fixed — real.** `linkEmailToEntities()` cast an unchecked register with `(int) ''`, linking every e-mail against **register id 0**. Only `$schema` was checked in that loop. |
| `PosPaymentService.php:1256` `register` · `:1266` `posTransaction_schema` | **Fixed at the accessor. See the correction below — the `saveTransaction()` guard is defence in depth, NOT a live hole.** |

### C. Guard existed but sat in a callee (2 findings — defence in depth)

| Finding | Disposition |
|---|---|
| `ScheduledTaskService.php:840` `register` · `:841` `task_schema` | **Fixed, but stated honestly in the code:** `updateScheduledTask()` was unguarded locally, yet `getScheduledTask()` above it already throws on `''`. Not a live hole. The guard now sits at the write so it cannot be broken by a later change to the read above it. |
| `ContactLinkedUidsService.php:58` `register` | **Same.** `getLinkedUidsForType()` already refuses on `''`. |

### D. Blanked-override path (2 findings)

| Finding | Disposition |
|---|---|
| `SemanticHandoffController.php:476` `register` · `MessagingService.php:474` `register` | **Fixed — real, and easy to miss.** Both passed `'pipelinq'` as `getValueString()`'s default, which only covers an **absent** key. A key present but set to `''` returns `''` verbatim, and none of the eleven call sites across the two classes checked. Both now normalise `''` back to the built-in slug — exactly what their own sibling `schemaSlug()` already did. |

### E. Consumers already fail closed; the refusal was invisible (26 findings)

`PortalController:944` · `ActivityTimelineService:125,127,128,129` · `AppointmentEmailService:806` · `AvailabilityService:1023` · `BookingService:1519` · `ContractService:292,293` · `EligibilityService:504` · `ForecastOverrideService:237,238` · `GiftCardService:652` · `KccWerkplekService:163` · `LoyaltyAccountService:402,403` · `LoyaltyProgrammeService:276` · `PointsLedgerService:496,497` · `RedemptionService:596` · `TicketService:149,161` · `TierService:402` · `WalkInQueueService:900`

**Disposition: fixed at the read, no behaviour change.** Every consumer of these accessors was verified to refuse on `''` (`if ($register === '' || $schema === '')`, or `TicketService::isConfigured()`). What was missing was any **signal**: an unprovisioned instance degraded to empty lists and silent no-ops with nothing in the log — the condition gate-50 exists to surface. Each accessor now reads into a local, compares against `''`, and logs a warning naming the missing key.

`ActivityTimelineService` is deliberately **asymmetric**: `register` is required and logged, but the three per-source schema ids are **optional** — `collectActivities()` already drops any source whose id is `''`, a supported degraded mode on an instance that does not use e-mail or calendar links. Warning on those would fire on healthy installs, so it does not.

## Correction to an earlier claim in this PR

An earlier commit message described `PosPaymentService::saveTransaction()` as "the only OpenRegister call in that service without the register/schema check its siblings all have", implying a live hole. **That was an over-claim, and coverage disproved it.**

`saveTransaction()` calls `loadTransaction()` on its first line, and `loadTransaction()` reads the same two ids and throws `OCSNotFoundException` on `''`. The guard I added below it is therefore **unreachable**. I did not infer this — I wrote a test that blanks both config keys and calls `capturePayment()`, and the line-coverage report shows lines 1235-1240 never execute.

The guard is kept as defence in depth (the write must not depend on a read further up staying put) and the code comment now says exactly this, matching how `ScheduledTaskService::updateScheduledTask()` was already described. No test asserts that branch, because such a test would be asserting `loadTransaction()`'s behaviour, not the guard's.

Genuine live holes in section B are therefore **5**, not 7: `ContactImportService` (3), `ContactVcardWriterService`, `EmailMatchService`.

## Coverage ratchet

The first push failed `quality / PHPUnit (PHP 8.3, NC stable32)` — specifically its **"Guard coverage baseline"** step; PHPUnit itself passed. 143 statements added, only 39 covered, so coverage fell 0.07% against the merge base.

Fixed **by adding tests only**. No threshold, ratchet config, baseline file, skip or exclude was touched.

| | statements | coverage |
|---|---|---|
| merge base | 18733 / 41263 | 45.40% |
| head, before tests | 18772 / 41406 | 45.33% — **FAIL, −0.06%** |
| head, after tests | 18880 / 41406 | 45.60% — **OK, +0.20%** |

16 new tests across four shapes. Each asserts the **refusal item** — that the OpenRegister call did not happen — rather than a return value, and each file carries a configured-instance counter-test so the negative assertions cannot pass for the wrong reason.

`RegisterSlugBlankOverrideTest` was verified against the pre-fix code: the **blank-override** case fails, while *absent key* and *explicit override* still pass — so the test isolates precisely the case the old default-argument form got wrong.

Reproduced locally with pcov in a disposable `php:8.3-cli` container, running the repo's own `scripts/coverage-guard.php --against` a merge-base clover. Local numbers track CI to within 3 statements on both sides.

## Left red

**Nothing.** gate-50 is at 0.

## Follow-up, deliberately not done here

`LogiusConnector::signRequest()` still returns its keyless dev signature when handed an empty key, and two tests pin that behaviour (`LogiusConnectorTest:244`, `BerichtenboxIntegrationTest:117`). This PR makes that fallback **unreachable from the production dispatch path** rather than removing it — deleting it is a separate decision with its own test changes. Flagging it rather than silently widening this PR's scope.

## How the fixes were proven able to fail

Each of the four distinct fix shapes was reverted, re-measured, and restored:

| Shape | Reverted | gate-50 result |
|---|---|---|
| single-value accessor + log-warn | `TicketService::getSchemaId()` | re-reported at `:184` |
| tuple accessor + log-warn | `GiftCardService::config()` | re-reported at `:659` |
| blanked-override normalisation | `SemanticHandoffController::registerSlug()` | re-reported at `:486` |
| inline guard on a write | `BerichtenboxService` dispatch guard | re-reported at `:540` |

All four returned to 0 on restore.

A first attempt at the Berichtenbox revert changed only the condition to `if (false)` and the gate **still passed** — the `logger->error` call inside the block satisfies the rule on its own. Recording that because it means a condition-only regression in that block would not be caught by gate-50; the new unit test is what covers it. That test was itself verified to fail (`sendMessage` "expected 0 times, actually called 1 time") when the guard is disabled, so it is not vacuous.

## Quality debt touched

Three PHPMD violations appeared that the base does **not** have — my added lines pushed `PortalController` and `ActivityTimelineService` over `ExcessiveClassLength` and `LoyaltyAccountService` over `ExcessiveClassComplexity`. Fixed by trimming my own comments and spelling one check as `in_array()` instead of a two-arm `||`. **No baseline entries were added** — both baseline files are untouched.
