### PR TITLE
fix(portal,notes): translate exceptions on a public download, drop an OpenRegister HTTP loopback

### DIFF
--- a/lib/Controller/PortalDocumentController.php
+++ b/lib/Controller/PortalDocumentController.php
@@ -39,6 +39,7 @@ use OCP\AppFramework\Http\DataDownloadResponse;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\IRequest;
 use Psr\Log\LoggerInterface;
+use Throwable;
 
 /**
  * Portal document download proxy.
@@ -119,53 +120,68 @@ class PortalDocumentController extends PortalApiController
      */
     public function download(string $token)
     {
-        $result = $this->signing->validateToken(token: $token);
-        if ($result === 'expired') {
-            return new JSONResponse(
-                ['errorCode' => 'linkExpired', 'message' => 'Deze link is verlopen. Download het document opnieuw vanuit het portaal.'],
-                Http::STATUS_GONE
-            );
-        }
-
-        if (is_array($result) === false) {
-            return new JSONResponse(['errorCode' => 'notFound', 'message' => 'Niet gevonden.'], Http::STATUS_NOT_FOUND);
-        }
-
-        $accountId  = (string) ($result['accountId'] ?? '');
-        $objectId   = (string) ($result['objectId'] ?? '');
-        $objectType = (string) ($result['objectType'] ?? '');
-        $account    = $this->repository->find(self::ACCOUNT_SCHEMA, $accountId);
-
-        // Defence in depth: re-verify the bound account still has access.
-        if ($account === null
-            || ($account['status'] ?? 'active') === 'closed'
-            || ($objectType !== 'data-export' && $this->ensureAccess(account: $account, objectType: $objectType, objectId: $objectId) === false)
-        ) {
-            return new JSONResponse(['errorCode' => 'notFound', 'message' => 'Niet gevonden.'], Http::STATUS_NOT_FOUND);
-        }
-
-        $this->audit->log(
-                $accountId,
-                (string) ($account['tenantId'] ?? ''),
-                'document-download',
-                'success',
-                [
-                    'targetObjectType' => $objectType,
-                    'targetObjectId'   => $objectId,
-                ]
+        try {
+            $result = $this->signing->validateToken(token: $token);
+            if ($result === 'expired') {
+                return new JSONResponse(
+                    ['errorCode' => 'linkExpired', 'message' => 'Deze link is verlopen. Download het document opnieuw vanuit het portaal.'],
+                    Http::STATUS_GONE
                 );
+            }
 
-        // The portal models documents as JSON descriptors over OR objects; an
-        // instance that stores a PDF file id streams the file here via
-        // IRootFolder instead. Streaming the bound file is deferred to a live
-        // instance (see DEPLOYMENT.md), the descriptor below is the canonical
-        // machine-readable representation in the meantime.
-        $payload = $this->documentPayload(objectType: $objectType, objectId: $objectId);
-        return new DataDownloadResponse(
-            (string) json_encode($payload),
-            $objectType.'-'.$objectId.'.json',
-            'application/json'
-        );
+            if (is_array($result) === false) {
+                return new JSONResponse(['errorCode' => 'notFound', 'message' => 'Niet gevonden.'], Http::STATUS_NOT_FOUND);
+            }
+
+            $accountId  = (string) ($result['accountId'] ?? '');
+            $objectId   = (string) ($result['objectId'] ?? '');
+            $objectType = (string) ($result['objectType'] ?? '');
+            $account    = $this->repository->find(self::ACCOUNT_SCHEMA, $accountId);
+
+            // Defence in depth: re-verify the bound account still has access.
+            if ($account === null
+                || ($account['status'] ?? 'active') === 'closed'
+                || ($objectType !== 'data-export' && $this->ensureAccess(account: $account, objectType: $objectType, objectId: $objectId) === false)
+            ) {
+                return new JSONResponse(['errorCode' => 'notFound', 'message' => 'Niet gevonden.'], Http::STATUS_NOT_FOUND);
+            }
+
+            $this->audit->log(
+                    $accountId,
+                    (string) ($account['tenantId'] ?? ''),
+                    'document-download',
+                    'success',
+                    [
+                        'targetObjectType' => $objectType,
+                        'targetObjectId'   => $objectId,
+                    ]
+                    );
+
+            // The portal models documents as JSON descriptors over OR objects; an
+            // instance that stores a PDF file id streams the file here via
+            // IRootFolder instead. Streaming the bound file is deferred to a live
+            // instance (see DEPLOYMENT.md), the descriptor below is the canonical
+            // machine-readable representation in the meantime.
+            $payload = $this->documentPayload(objectType: $objectType, objectId: $objectId);
+            return new DataDownloadResponse(
+                (string) json_encode($payload),
+                $objectType.'-'.$objectId.'.json',
+                'application/json'
+            );
+        } catch (Throwable $e) {
+            // This endpoint is #[PublicPage]: it is reachable unauthenticated,
+            // so an uncaught throw would return a framework 500 with a stack
+            // trace to an anonymous caller. PortalObjectRepository::find()
+            // throws when the bound account cannot be read, which is the
+            // commonest way to get here. Answer with the same opaque
+            // NOT_FOUND the authorization failures use, so a storage fault
+            // cannot be told apart from an unknown token by probing.
+            $this->logger->error(
+                    'Portal document download failed',
+                    ['exception' => $e]
+                    );
+            return new JSONResponse(['errorCode' => 'notFound', 'message' => 'Niet gevonden.'], Http::STATUS_NOT_FOUND);
+        }//end try
     }//end download()
 
     /**

--- a/lib/Service/NoteEventService.php
+++ b/lib/Service/NoteEventService.php
@@ -23,16 +23,13 @@ declare(strict_types=1);
 
 namespace OCA\Pipelinq\Service;
 
-use OC\Security\CSRF\CsrfTokenManager;
-use OCP\Http\Client\IClientService;
-use OCP\IURLGenerator;
 use OCP\IUserSession;
+use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
+use Throwable;
 
 /**
  * Service for triggering note-related events and notifications.
- *
- * @psalm-suppress UndefinedClass CsrfTokenManager is an internal Nextcloud class (no OCP interface yet); tracked as fleet debt.
  */
 class NoteEventService
 {
@@ -50,21 +47,15 @@ class NoteEventService
      * @param ActivityService     $activityService     The activity service.
      * @param SettingsService     $settingsService     The settings service.
      * @param IUserSession        $userSession         The user session.
-     * @param IURLGenerator       $urlGenerator        The URL generator.
-     * @param IClientService      $clientService       The HTTP client service.
-     * @param CsrfTokenManager    $csrfTokenManager    The CSRF token manager.
+     * @param ContainerInterface  $container           DI container (lazy OpenRegister resolve).
      * @param LoggerInterface     $logger              The logger.
-     *
-     * @psalm-suppress UndefinedClass CsrfTokenManager is an internal Nextcloud class (no OCP interface yet).
      */
     public function __construct(
         private NotificationService $notificationService,
         private ActivityService $activityService,
         private SettingsService $settingsService,
         private IUserSession $userSession,
-        private IURLGenerator $urlGenerator,
-        private IClientService $clientService,
-        private CsrfTokenManager $csrfTokenManager,
+        private ContainerInterface $container,
         private LoggerInterface $logger,
     ) {
     }//end __construct()
@@ -124,9 +115,6 @@ class NoteEventService
      * @param string $objectId   The object ID.
      *
      * @return ?array The entity data with title and assignee, or null on failure.
-     *
-     * @psalm-suppress UnusedParam $objectId is used in URL interpolation
-     * @psalm-suppress UndefinedClass CsrfTokenManager is an internal Nextcloud class (no OCP interface yet).
      */
     private function fetchEntityData(string $entityType, string $objectId): ?array
     {
@@ -139,24 +127,66 @@ class NoteEventService
             return null;
         }
 
-        $url = $this->urlGenerator->getAbsoluteURL(
-            "/apps/openregister/api/objects/{$register}/{$schema}/{$objectId}"
-        );
+        // ADR-080 D2/D3: store discovery belongs to OpenRegister. This used to
+        // hand-build an objects-API path and fetch it over HTTP, a loopback
+        // request out of the instance and back into it, carrying a CSRF token
+        // and allow_local_address, purely to read an object this process can
+        // already read in-memory. ObjectService is resolved from the container
+        // so a missing OpenRegister degrades to null here rather than breaking
+        // class loading.
+        try {
+            $objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
+            $object        = $objectService->find(
+                id: $objectId,
+                register: $register,
+                schema: $schema
+            );
+        } catch (Throwable $e) {
+            $this->logger->warning(
+                    'Could not read note entity from OpenRegister',
+                    [
+                        'entityType' => $entityType,
+                        'objectId'   => $objectId,
+                        'exception'  => $e->getMessage(),
+                    ]
+                    );
+            return null;
+        }//end try
 
-        $client   = $this->clientService->newClient();
-        $response = $client->get(
-                $url,
-                [
-                    'headers'   => [
-                        'OCS-APIREQUEST' => 'true',
-                        'requesttoken'   => $this->csrfTokenManager->getToken()->getEncryptedValue(),
-                    ],
-                    'nextcloud' => ['allow_local_address' => true],
-                ]
-                );
-
-        return json_decode($response->getBody(), true);
+        return $this->toArray($object);
     }//end fetchEntityData()
+
+    /**
+     * Normalise an OpenRegister result to a plain array.
+     *
+     * @param mixed $row The value returned by ObjectService.
+     *
+     * @return ?array The object as an array, or null when it cannot be read.
+     */
+    private function toArray(mixed $row): ?array
+    {
+        if (is_array($row) === true) {
+            return $row;
+        }
+
+        if (is_object($row) === true) {
+            if (method_exists($row, 'jsonSerialize') === true) {
+                $serialized = $row->jsonSerialize();
+                if (is_array($serialized) === true) {
+                    return $serialized;
+                }
+            }
+
+            if (method_exists($row, 'getObject') === true) {
+                $inner = $row->getObject();
+                if (is_array($inner) === true) {
+                    return $inner;
+                }
+            }
+        }
+
+        return null;
+    }//end toArray()
 
     /**
      * Publish activity and notification for a note addition.

--- a/tests/Unit/Service/NoteEventServiceTest.php
+++ b/tests/Unit/Service/NoteEventServiceTest.php
@@ -19,15 +19,13 @@ declare(strict_types=1);
 
 namespace OCA\Pipelinq\Tests\Unit\Service;
 
-use OC\Security\CSRF\CsrfTokenManager;
 use OCA\Pipelinq\Service\ActivityService;
 use OCA\Pipelinq\Service\NoteEventService;
 use OCA\Pipelinq\Service\NotificationService;
 use OCA\Pipelinq\Service\SettingsService;
-use OCP\Http\Client\IClientService;
-use OCP\IURLGenerator;
 use OCP\IUserSession;
 use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
 
 /**
@@ -60,9 +58,7 @@ class NoteEventServiceTest extends TestCase
         $activityService     = $this->createMock(ActivityService::class);
         $settingsService     = $this->createMock(SettingsService::class);
         $userSession         = $this->createMock(IUserSession::class);
-        $urlGenerator        = $this->createMock(IURLGenerator::class);
-        $clientService       = $this->createMock(IClientService::class);
-        $csrfTokenManager    = $this->createMock(CsrfTokenManager::class);
+        $container           = $this->createMock(ContainerInterface::class);
         $this->logger        = $this->createMock(LoggerInterface::class);
 
         $this->service = new NoteEventService(
@@ -70,9 +66,7 @@ class NoteEventServiceTest extends TestCase
             $activityService,
             $settingsService,
             $userSession,
-            $urlGenerator,
-            $clientService,
-            $csrfTokenManager,
+            $container,
             $this->logger,
         );
     }//end setUp()

--- a/tests/Unit/Service/NoteEventServiceTest.php
+++ b/tests/Unit/Service/NoteEventServiceTest.php
@@ -103,4 +103,194 @@ class NoteEventServiceTest extends TestCase
         $this->service->triggerNoteEvents(objectType: 'pipelinq_lead', objectId: '123');
         $this->service->triggerNoteEvents(objectType: 'pipelinq_request', objectId: '123');
     }//end testTypeMapContainsExpectedTypes()
+
+    /**
+     * Build a service whose settings resolve, so fetchEntityData reaches
+     * OpenRegister instead of returning early on empty register/schema.
+     *
+     * @param ContainerInterface $container      The container to inject.
+     * @param ActivityService    $activityService The activity service to inject.
+     *
+     * @return NoteEventService The configured service.
+     */
+    private function serviceWithResolvedSettings(
+        ContainerInterface $container,
+        ActivityService $activityService
+    ): NoteEventService {
+        $settingsService = $this->createMock(SettingsService::class);
+        $settingsService->method('getSettings')->willReturn(
+            [
+                'register'      => 'pipelinq',
+                'lead_schema'   => 'lead',
+            ]
+        );
+
+        return new NoteEventService(
+            $this->createMock(NotificationService::class),
+            $activityService,
+            $settingsService,
+            $this->createMock(IUserSession::class),
+            $container,
+            $this->logger,
+        );
+    }//end serviceWithResolvedSettings()
+
+    /**
+     * An absent or broken OpenRegister must degrade to "no entity data"
+     * rather than propagating, and must say so in the log.
+     *
+     * Guards the ADR-080 rewrite: the read is now an in-process
+     * ObjectService call, so container resolution is the new failure mode
+     * that the previous HTTP path did not have.
+     *
+     * @return void
+     */
+    public function testMissingOpenRegisterIsLoggedAndPublishesNothing(): void
+    {
+        $container = $this->createMock(ContainerInterface::class);
+        $container->method('get')->willThrowException(new \RuntimeException('OpenRegister not installed'));
+
+        $activityService = $this->createMock(ActivityService::class);
+        // Assert on the ITEM: no activity is published, not merely that the
+        // call returned.
+        $activityService->expects($this->never())->method('publishNoteAdded');
+
+        $this->logger->expects($this->once())
+            ->method('warning')
+            ->with(
+                $this->equalTo('Could not read note entity from OpenRegister'),
+                $this->callback(
+                    static fn (array $c): bool => $c['entityType'] === 'lead' && $c['objectId'] === 'lead-1'
+                )
+            );
+
+        $service = $this->serviceWithResolvedSettings($container, $activityService);
+        $service->triggerNoteEvents(objectType: 'pipelinq_lead', objectId: 'lead-1');
+    }//end testMissingOpenRegisterIsLoggedAndPublishesNothing()
+
+    /**
+     * A plain array from ObjectService is used directly, and the object is
+     * requested with the register and schema resolved from settings.
+     *
+     * @return void
+     */
+    public function testEntityIsReadThroughObjectServiceWithResolvedScope(): void
+    {
+        $objectService = new class {
+            /**
+             * Captured call arguments.
+             *
+             * @var array<string, string>
+             */
+            public array $seen = [];
+
+            /**
+             * @param string $id       The object id.
+             * @param string $register The register slug.
+             * @param string $schema   The schema slug.
+             *
+             * @return array The stub object.
+             */
+            public function find(string $id, string $register, string $schema): array
+            {
+                $this->seen = [
+                    'id'       => $id,
+                    'register' => $register,
+                    'schema'   => $schema,
+                ];
+                return ['title' => 'Acme deal', 'assignee' => 'alice'];
+            }
+        };
+
+        $container = $this->createMock(ContainerInterface::class);
+        $container->method('get')->willReturn($objectService);
+
+        $this->logger->expects($this->never())->method('warning');
+
+        $activityService = $this->createMock(ActivityService::class);
+        $activityService->expects($this->once())->method('publishNoteAdded');
+
+        $service = $this->serviceWithResolvedSettings($container, $activityService);
+        $service->triggerNoteEvents(objectType: 'pipelinq_lead', objectId: 'lead-7');
+
+        // The scope must come from settings, not be left empty — an empty
+        // register/schema is the permissive value in OpenRegister.
+        self::assertSame(
+            ['id' => 'lead-7', 'register' => 'pipelinq', 'schema' => 'lead'],
+            $objectService->seen,
+            'ObjectService must be called with the resolved register and schema'
+        );
+    }//end testEntityIsReadThroughObjectServiceWithResolvedScope()
+
+    /**
+     * An ObjectEntity-shaped return is normalised through jsonSerialize()
+     * rather than being discarded.
+     *
+     * @return void
+     */
+    public function testJsonSerialisableEntityIsNormalised(): void
+    {
+        $objectService = new class {
+            /**
+             * @param string $id       The object id.
+             * @param string $register The register slug.
+             * @param string $schema   The schema slug.
+             *
+             * @return object The stub entity.
+             */
+            public function find(string $id, string $register, string $schema): object
+            {
+                return new class implements \JsonSerializable {
+                    /**
+                     * @return array The serialised object.
+                     */
+                    public function jsonSerialize(): array
+                    {
+                        return ['title' => 'Serialised deal', 'assignee' => 'bob'];
+                    }
+                };
+            }
+        };
+
+        $container = $this->createMock(ContainerInterface::class);
+        $container->method('get')->willReturn($objectService);
+
+        $activityService = $this->createMock(ActivityService::class);
+        $activityService->expects($this->once())->method('publishNoteAdded');
+
+        $service = $this->serviceWithResolvedSettings($container, $activityService);
+        $service->triggerNoteEvents(objectType: 'pipelinq_lead', objectId: 'lead-8');
+    }//end testJsonSerialisableEntityIsNormalised()
+
+    /**
+     * A value that is neither an array nor normalisable yields null, and
+     * nothing is published.
+     *
+     * @return void
+     */
+    public function testUnnormalisableEntityPublishesNothing(): void
+    {
+        $objectService = new class {
+            /**
+             * @param string $id       The object id.
+             * @param string $register The register slug.
+             * @param string $schema   The schema slug.
+             *
+             * @return object The stub entity with no normalisation surface.
+             */
+            public function find(string $id, string $register, string $schema): object
+            {
+                return new \stdClass();
+            }
+        };
+
+        $container = $this->createMock(ContainerInterface::class);
+        $container->method('get')->willReturn($objectService);
+
+        $activityService = $this->createMock(ActivityService::class);
+        $activityService->expects($this->never())->method('publishNoteAdded');
+
+        $service = $this->serviceWithResolvedSettings($container, $activityService);
+        $service->triggerNoteEvents(objectType: 'pipelinq_lead', objectId: 'lead-9');
+    }//end testUnnormalisableEntityPublishesNothing()
 }//end class


### PR DESCRIPTION
Two gates, measured full-tree at `origin/development` with gate package
`48c88ba1e0d049f8f38538c33e790d3e603c55d0`.

| Gate | Before | After |
|---|---|---|
| gate-49 controller-exception-translation | FAIL — 1 | **PASS** |
| gate-62 store-plane (ADR-080) | FAIL — 1 | **PASS** |

## gate-49 — a stack trace reachable unauthenticated

`PortalDocumentController::download()` reads the bound account through
`PortalObjectRepository::find()`, which throws when the account cannot be
read, and had neither a `try/catch` nor an `@throws`. The method is
`#[PublicPage]` — reachable **unauthenticated** — so an uncaught throw
returned a framework 500 **with a stack trace to an anonymous caller**.

It now catches `Throwable`, logs, and answers with the *same* opaque
`notFound`/404 the authorization failures already use, so a storage fault
cannot be distinguished from an unknown token by probing.

Catching `Throwable` rather than the one named class is deliberate, and is
the shape the gate's own rationale calls preferable: the narrower handler
would leave every other throw to become that same 500.

## gate-62 — an HTTP loopback to read a local object

`NoteEventService::fetchEntityData()` hand-built an OpenRegister objects-API
path and fetched it over HTTP through `IClientService` — a request that left
the instance and came back into it, carrying a CSRF token and
`allow_local_address`, purely to read an object **this very process can read
in memory**. Store discovery is OpenRegister's (ADR-080 D2/D3).

It now resolves `ObjectService` from the container and calls `find()` — the
pattern already used elsewhere in this app — with a `Throwable` guard so a
missing OpenRegister degrades to `null` rather than breaking class loading.

`IURLGenerator`, `IClientService` and `CsrfTokenManager` were used **only**
by that method and are gone from the constructor. That also drops the
`OC\Security\CSRF\CsrfTokenManager` internal-class dependency and the two
`psalm-suppress` lines it required. `NoteEventServiceTest` updated to match.

## Positive controls — both actually run

- **gate-49:** changing the catch to `\TypeError` returns `FAIL — 1`.
  ⚠️ Worth recording: `\LogicException` does **not** work as a control. The
  gate's regex matches the *substring* `Exception`, so any `*Exception` class
  satisfies it. My first control passed and was meaningless; the second one
  is the real test.
- **gate-62:** the gate matches raw file text, so re-adding the two literals
  `/apps/openregister/api/objects/` and `IClientService` inside a **comment**
  returns `FAIL — 1`. The explanatory comment in the diff is deliberately
  worded to avoid both — otherwise the fix would have been undone by its own
  documentation.

All 26 `<gate>.log.err` files were empty on every run.

## Not fixed here — gate-6 orphan-auth (3), left red with reasons

All three were already analysed in-tree by earlier work, and I confirmed
each rather than regressing it:

1. `ZgwCoexistenceValidator::validateWritePath` — wiring it would install a
   check **structurally incapable of rejecting anything**: the `stufEndpoint`
   schema moved to procest, so `activeStufWriters()` can only return `[]`.
   Deleting it discards an encoded REQ-ZGW-008 rule a prior change kept on
   purpose. Tracked in pipelinq#401.
2. `PortalTenantService::isSelfSignupAllowed` — there is no self-signup
   endpoint at all, so there is no unguarded surface. The correct fix is to
   build the flow and call this from it, **never to invent an
   account-creation endpoint just to give the predicate a caller**.
   Tracked in pipelinq#401.
3. `LogBerichtenboxAdapter::checkMailbox` — an interface method on the
   dormant no-op adapter. Giving it a caller means building Berichtenbox
   dispatch surface, which is out of scope: the message box is a Portaliq
   abstraction, not a leaf app's (portaliq#67, pipelinq#730).