### PR TITLE
fix(manifest): close gate-53, gate-55 and gate-60

### DIFF
--- a/src/manifest.d/45-prospects.json
+++ b/src/manifest.d/45-prospects.json
@@ -15,6 +15,7 @@
 			"type": "custom",
 			"title": "Prospects",
 			"component": "ProspectsView",
+			"_note": "No declarative type fits: the page owns client-side sort state (setSort/sortedProspects/sortIndicator) and score colour-banding (scoreClass), and its row action convertToLead creates a DIFFERENT entity from the one listed. A type:index page renders manifest-declared columns over one register/schema; this list is served by useProspectStore against a custom enrichment API (KvK/OpenCorporates), so it has no register/schema to declare.",
 			"config": {
 				"_note": "Full-page expansion of ProspectWidget; lib gap: no declarative type for a scored-prospect list with external-source (KvK/OpenCorporates) enrichment. Data comes from useProspectStore (custom API), not an OpenRegister register/schema — so no config.register/schema."
 			}

--- a/src/manifest.d/65-project-task-hierarchy.json
+++ b/src/manifest.d/65-project-task-hierarchy.json
@@ -52,6 +52,7 @@
 			"type": "custom",
 			"title": "Project",
 			"component": "ProjectDetail",
+			"_note": "Renders through CnDetailPage/CnDetailCard already, but a type:detail page describes ONE object and this hosts three nested editable child entities — phase, task and activity — each with its own CnFormDialog and save handler (onPhaseSaved / onTaskSaved / onActivitySaved) writing back into the WBS tree. It also resolves the client name across registers and probes ledger webhook status. Decomposing it would need a declarative primitive for child-entity create/edit within a parent detail, which the lib does not have.",
 			"config": {
 				"register": "pipelinq",
 				"schema": "project"
@@ -63,6 +64,7 @@
 			"type": "custom",
 			"title": "Tijdregistraties",
 			"component": "ProjectActivityList",
+			"_note": "A type:index page lists stored fields; this page's whole purpose is DERIVED values it must compute client-side — minutesToHours, formatDuration, resolveBillable and a totals rollup that sums billable vs non-billable time across the project's activities. None of those exist as properties on the activity schema, so there is nothing for a declarative column to bind to.",
 			"config": {
 				"register": "pipelinq",
 				"schema": "projectActivity"

--- a/src/manifest.d/70-loyalty-program.json
+++ b/src/manifest.d/70-loyalty-program.json
@@ -24,6 +24,7 @@
 			"type": "custom",
 			"title": "Loyalty enrollment",
 			"component": "LoyaltyAccountCreationView",
+			"_note": "Neither an index nor a detail: it is an enrolment form that CREATES a loyalty account against a programme chosen from a second collection (programmeOptions, loaded separately), behind a terms-acceptance gate (termsUrl + canSubmit) that must be satisfied before the write is allowed. The declarative page types render or edit an existing object; none models a create form whose options come from another collection and whose submit is gated on accepting external terms.",
 			"config": { "register": "pipelinq", "schema": "klantLoyaltyAccount" }
 		}
 	]

--- a/src/manifest.d/75-marketing-blasts.json
+++ b/src/manifest.d/75-marketing-blasts.json
@@ -56,6 +56,7 @@
 			"type": "custom",
 			"title": "New blast",
 			"component": "BlastFormView",
+			"_note": "A multi-step wizard with a compliance gate, which no declarative type expresses. Advancing is conditional (canAdvance), the audience can be split into an A/B pair (abEnabled), and before a blast may be sent the page runs preflightCompliance + validateTemplate and blocks on awaitConsentDecision — the lawful-basis and unsubscribe-footer checks from the marketing-compliance spec. A declarative form submits; it cannot hold a send back pending a compliance verdict.",
 			"config": {
 				"register": "pipelinq",
 				"schema": "blast"
@@ -79,6 +80,7 @@
 			"type": "custom",
 			"title": "Blast monitor",
 			"component": "BlastMonitorView",
+			"_note": "Declarative pages render a snapshot; this one is live. It owns a polling lifecycle (startPolling / stopPolling / clearInterval on unmount) and derives send progress from it — progressPercent, processed, audienceTotal, etaLabel and a buildTimeline series — plus an in-flight cancel action guarded by canCancel. There is no declarative primitive for a page that must keep refetching and be torn down cleanly.",
 			"config": {
 				"register": "pipelinq",
 				"schema": "blast"

--- a/src/manifest.d/80-appointment-booking-admin.json
+++ b/src/manifest.d/80-appointment-booking-admin.json
@@ -69,6 +69,7 @@
 			"type": "custom",
 			"title": "Service",
 			"component": "ServiceDetailView",
+			"_note": "Uses CnDetailPage/CnDetailCard, but a type:detail page cannot carry the SIDE EFFECT this one owes: every save calls invalidateAvailability, because changing a service's duration or required skills invalidates the cached booking-availability windows computed from it. Stale windows would offer slots that can no longer be honoured. It also derives display-only labels (formatDuration, formatCurrency, requiredSkillsLabel) that are not schema properties.",
 			"config": {
 				"register": "pipelinq",
 				"schema": "service"
@@ -114,6 +115,7 @@
 			"type": "custom",
 			"title": "Resource",
 			"component": "ResourceDetailView",
+			"_note": "Same reason as ServiceDetail: a type:detail page cannot own the post-save invalidateAvailability side effect, and a resource's skills or working hours changing must expire the cached availability windows or the booking flow will offer slots this resource can no longer serve. It additionally holds a live useObjectSubscription so a concurrently edited resource updates in place, which declarative detail pages do not do.",
 			"config": {
 				"register": "pipelinq",
 				"schema": "resource"

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -471,13 +471,13 @@
 					] } },
 					{ "id": "client-email", "type": "integration", "integrationId": "email", "title": "Emails", "icon": "Email" },
 					{ "id": "client-files", "type": "integration", "integrationId": "files", "title": "Files", "icon": "FolderOutline" },
-					{ "id": "client-summary-open-tickets", "type": "stat", "title": "Open matters", "content": { "label": "Open matters", "caption": "requests + complaints + contactmomenten", "icon": "TicketOutline", "format": { "style": "number", "decimals": 0 }, "source": { "kind": "endpoint", "url": "/apps/pipelinq/api/customer-360/summary", "path": "openTicketCount", "params": { "clientId": "@objectId" } } } },
-					{ "id": "client-summary-sla-breached", "type": "stat", "title": "SLA breached", "content": { "label": "SLA breached", "caption": "open tickets past their deadline", "icon": "AlertOutline", "valueColor": "var(--color-error)", "format": { "style": "number", "decimals": 0 }, "source": { "kind": "endpoint", "url": "/apps/pipelinq/api/customer-360/summary", "path": "sla.breached", "params": { "clientId": "@objectId" } } } },
-					{ "id": "client-summary-sla-at-risk", "type": "stat", "title": "SLA at risk", "content": { "label": "SLA at risk", "caption": "deadline within 24h", "icon": "ClockAlertOutline", "valueColor": "var(--color-warning)", "format": { "style": "number", "decimals": 0 }, "source": { "kind": "endpoint", "url": "/apps/pipelinq/api/customer-360/summary", "path": "sla.atRisk", "params": { "clientId": "@objectId" } } } },
-					{ "id": "client-summary-queues", "type": "stat", "title": "Active queues", "content": { "label": "Active queues", "caption": "on open tickets", "icon": "FormatListBulletedSquare", "format": { "style": "number", "decimals": 0 }, "source": { "kind": "endpoint", "url": "/apps/pipelinq/api/customer-360/summary", "path": "queueCount", "params": { "clientId": "@objectId" } } } },
+					{ "id": "client-summary-open-tickets", "type": "stat", "title": "Open matters", "content": { "label": "Open matters", "caption": "requests + complaints + contactmomenten", "icon": "ClipboardCheckOutline", "format": { "style": "number", "decimals": 0 }, "source": { "kind": "endpoint", "url": "/apps/pipelinq/api/customer-360/summary", "path": "openTicketCount", "params": { "clientId": "@objectId" } } } },
+					{ "id": "client-summary-sla-breached", "type": "stat", "title": "SLA breached", "content": { "label": "SLA breached", "caption": "open tickets past their deadline", "icon": "AlertCircleOutline", "valueColor": "var(--color-error)", "format": { "style": "number", "decimals": 0 }, "source": { "kind": "endpoint", "url": "/apps/pipelinq/api/customer-360/summary", "path": "sla.breached", "params": { "clientId": "@objectId" } } } },
+					{ "id": "client-summary-sla-at-risk", "type": "stat", "title": "SLA at risk", "content": { "label": "SLA at risk", "caption": "deadline within 24h", "icon": "History", "valueColor": "var(--color-warning)", "format": { "style": "number", "decimals": 0 }, "source": { "kind": "endpoint", "url": "/apps/pipelinq/api/customer-360/summary", "path": "sla.atRisk", "params": { "clientId": "@objectId" } } } },
+					{ "id": "client-summary-queues", "type": "stat", "title": "Active queues", "content": { "label": "Active queues", "caption": "on open tickets", "icon": "FolderOutline", "format": { "style": "number", "decimals": 0 }, "source": { "kind": "endpoint", "url": "/apps/pipelinq/api/customer-360/summary", "path": "queueCount", "params": { "clientId": "@objectId" } } } },
 					{ "id": "client-summary-last-activity", "type": "stat", "title": "Last activity", "content": { "label": "Last activity", "caption": "most recent interaction", "icon": "History", "source": { "kind": "endpoint", "url": "/apps/pipelinq/api/customer-360/summary", "path": "lastActivityAt", "params": { "clientId": "@objectId" } } } },
 					{ "id": "client-notes", "type": "integration", "integrationId": "notes", "title": "Notes", "icon": "NoteTextOutline" },
-					{ "id": "client-quick-requests", "type": "object-list", "title": "Requests", "icon": "TicketOutline", "content": {
+					{ "id": "client-quick-requests", "type": "object-list", "title": "Requests", "icon": "ClipboardCheckOutline", "content": {
 						"register": "pipelinq", "schema": "ticket",
 						"filter": { "client": "@objectId", "ticketType": "request" },
 						"sort": { "field": "occurredAt", "dir": "desc" },
@@ -711,6 +711,12 @@
 					{ "id": "ticket-data", "type": "data", "title": "Ticket details", "icon": "FileDocument", "content": { "columns": 2, "hideEmpty": true } },
 					{ "id": "ticket-related", "type": "related", "title": "Related", "icon": "LinkVariant" },
 					{ "id": "ticket-decisions", "type": "integration", "integrationId": "decidesk-decisions", "title": "Besluitvorming", "icon": "Gavel" }
+				],
+				"_layoutNote": "A declared widgets[] replaces the auto-body, and the auto-body was also what used to place them — so without an explicit layout every widget mapped to 0 grid cells (ADR-062 rule 8) and the page rendered its widgets unplaced. One cell per widget, in reading order: the two-column data block spans the full 12-column width, then Related and Besluitvorming sit side by side beneath it.",
+				"layout": [
+					{ "id": "1", "widgetId": "ticket-data", "gridX": 0, "gridY": 0, "gridWidth": 12, "gridHeight": 4 },
+					{ "id": "2", "widgetId": "ticket-related", "gridX": 0, "gridY": 4, "gridWidth": 6, "gridHeight": 3 },
+					{ "id": "3", "widgetId": "ticket-decisions", "gridX": 6, "gridY": 4, "gridWidth": 6, "gridHeight": 3 }
 				]
 			}
 		},


### PR DESCRIPTION
Measured full-tree with gate package `651e5c5bb3ba8764903e5d6fc5bac5a208bd67fc`.
`NODE_PATH` proven by printing `require.resolve('ajv')` as an **absolute path**
(`.../node_modules/ajv/dist/ajv.js`, ajv 8.20.0) — without it gates 22/53 fail
as **wiring**, not as findings. All 26 `<gate>.log.err` files were empty on
every run.

| Gate | Before | After |
|---|---|---|
| gate-55 detail-page-discipline | FAIL — 8 | **PASS** |
| gate-60 icon-vocabulary | FAIL — 1 | **PASS** |
| gate-53 effective-manifest-crossref | FAIL — 8 | **PASS** (1 advisory WARN, non-blocking) |
| gate-22 manifest-validation | PASS | PASS |

## gate-55 — icons that render `?`, and widgets that render nowhere

Four `ClientDetail` widget icons were not in the shared registry and rendered
the `?` fallback:

| Was | Now |
|---|---|
| `TicketOutline` | `ClipboardCheckOutline` |
| `AlertOutline` | `AlertCircleOutline` |
| `ClockAlertOutline` | `History` |
| `FormatListBulletedSquare` | `FolderOutline` |

`TicketDetail` declared three widgets and no `layout`. A declared `widgets[]`
replaces the auto-body — and the auto-body was also what *placed* them — so all
three mapped to **0 grid cells** and the page rendered its widgets unplaced.
Added one cell per widget in reading order.

## gate-60 — self-inflicted, and the most useful thing here

My first pick for the queues stat was `Timeline`. It **is** in nc-vue's
`widgetIcons.js` and **is** in gate-55's hardcoded mirror of it — but it is
**not** registered in this app's own `src/icons.js`.

There are **two** registries and an icon must be in both: gate-55 checks the
lib's, gate-60 checks the app's, and an icon in the first but not the second
renders with **no icon at all** — worse than the `?` fallback it replaced.
Replaced with `FolderOutline`, verified present in all three sets (nc-vue
registry, gate mirror, `src/icons.js`) before committing.

This only surfaced because `node_modules` was made available to the run.
gate-60 had been **`SKIPPED (wiring)`** for want of `vue-material-design-icons`,
so a broken icon would have shipped under a green board.

### Related: the gate's icon mirror has drifted

`check_detail_page_discipline.py` hardcodes a mirror of nc-vue's registry. The
mirror lists **`ClipboardList`**; the real registry exports
**`ClipboardListOutline`**. So gate-55 would *accept* an icon that renders `?`
and *reject* the correct one. Not exploited here — every replacement was chosen
from the intersection of all three sets — but it means gate-55 alone cannot be
trusted for icon correctness without gate-60 also running.

## gate-53 — eight custom pages with no stated justification

Eight `type:custom` pages backed by host-app SFCs carried no **page-level**
`_note`. The schema requires one documenting why a standard page type was not
feasible. `Prospects` had that reasoning but nested inside `config`, where the
schema does not look for it.

Each note states the specific blocking reason, established by **reading the
component**, not by pattern-matching:

| Page | Why it cannot be declarative |
|---|---|
| `Prospects` | owns client-side sort state and a row action that creates a *different* entity; data is a custom enrichment API, so there is no register/schema to declare |
| `ProjectDetail` | hosts three nested editable child entities (phase/task/activity), each with its own form dialog and save handler |
| `ProjectActivities` | exists to compute derived billable-hour totals that are not schema properties |
| `LoyaltyEnrollment` | create form gated on terms acceptance, options loaded from a second collection |
| `BlastNew` | multi-step wizard whose send is held pending a compliance verdict |
| `BlastMonitor` | owns a polling lifecycle and derives live progress/ETA |
| `ServiceDetail` | post-save `invalidateAvailability` side effect — stale windows would offer unhonourable slots |
| `ResourceDetail` | same, plus a live object subscription |

The remaining gate-53 finding is a **WARN (advisory, non-blocking)** and is left
as such deliberately — pre-existing-orphan behaviour is advisory by design
(#250/#260/#280), and deleting working code to silence an advisory would be the
wrong trade.

## Checks performed and found clean (not fixed, because nothing was broken)

- `registerIcons(appIcons)` **is** called (`src/main.js:57`) — pipelinq does not
  have launchpad's unregistered-vocabulary problem.
- All **23** menu entries resolve to real page routes — no `/dashboards`-style
  dangling menu target.