### PR TITLE
fix(register): give six relation properties a resolving canonical $ref

### DIFF
--- a/lib/Settings/pipelinq_register.json
+++ b/lib/Settings/pipelinq_register.json
@@ -1544,9 +1544,9 @@
           },
           "requestId": {
             "type": "string",
-            "description": "UUID reference to the associated request",
+            "description": "UUID reference to the associated request. Requests were folded into the `ticket` supertype by 99-unify-ticket-supertype, so this resolves to a ticket; the property keeps its stored name because renaming it would be a data migration.",
             "format": "uuid",
-            "$ref": "request",
+            "$ref": "ticket",
             "x-relation-filter": { "client": "@object.clientId" },
             "title": "Request"
           },

--- a/lib/Settings/pipelinq_register.json
+++ b/lib/Settings/pipelinq_register.json
@@ -817,7 +817,6 @@
             "items": {
               "type": "string",
               "format": "uuid",
-              "$ref": "Decision",
               "x-external-register": "decidesk"
             },
             "referenceType": "decision",
@@ -2731,6 +2730,7 @@
             "type": "string",
             "description": "Optional UUID of the owning organization for multi-tenant isolation",
             "format": "uuid",
+            "x-external-register": "openregister",
             "visible": false,
             "title": "Organization ID"
           }

--- a/lib/Settings/register.d/50-pos-end-of-day-bookkeeping.json
+++ b/lib/Settings/register.d/50-pos-end-of-day-bookkeeping.json
@@ -77,6 +77,7 @@
             "type": "string",
             "format": "uuid",
             "description": "Optional reference to a store/location entity (future use)",
+            "x-external-register": "openregister",
             "title": "Store"
           },
           "transactionIds": {

--- a/lib/Settings/register.d/99-unify-ticket-supertype.json
+++ b/lib/Settings/register.d/99-unify-ticket-supertype.json
@@ -255,7 +255,6 @@
             "items": {
               "type": "string",
               "format": "uuid",
-              "$ref": "Decision",
               "x-external-register": "decidesk"
             },
             "referenceType": "decision",
@@ -266,7 +265,6 @@
             "title": "Governing contract",
             "description": "The Shillinq contract that governs this ticket (drives its SLA tier / entitlements). References a Shillinq Contract object (ADR-066 cross-app reference); Shillinq owns contract lifecycle. Carried over from the retired `request` schema when it folded into this supertype.",
             "format": "uuid",
-            "$ref": "Contract",
             "x-external-register": "shillinq",
             "x-allow-create": true
           },
@@ -305,7 +303,8 @@
             "type": "string",
             "title": "Case Reference",
             "description": "UUID of the Procest case this request converted into (request only).",
-            "format": "uuid"
+            "format": "uuid",
+            "x-external-register": "procest"
           },
           "complaintCategory": {
             "type": "string",

--- a/lib/Settings/register.d/99-unify-ticket-supertype.json
+++ b/lib/Settings/register.d/99-unify-ticket-supertype.json
@@ -197,13 +197,15 @@
             "type": "string",
             "title": "Client",
             "description": "UUID reference to the associated client.",
-            "format": "uuid"
+            "format": "uuid",
+            "$ref": "client"
           },
           "contact": {
             "type": "string",
             "title": "Contact",
             "description": "UUID reference to the associated contact person.",
-            "format": "uuid"
+            "format": "uuid",
+            "$ref": "contact"
           },
           "assignee": {
             "type": "string",
@@ -243,7 +245,8 @@
             "type": "string",
             "title": "Parent Ticket",
             "description": "For a contactmoment: UUID of the parent request-ticket this interaction belongs to (migrated from contactmoment.request).",
-            "format": "uuid"
+            "format": "uuid",
+            "$ref": "ticket"
           },
           "decisions": {
             "type": "array",
@@ -277,7 +280,8 @@
             "title": "Pipeline",
             "description": "UUID reference to the pipeline this request is tracked in (request only).",
             "format": "uuid",
-            "visible": false
+            "visible": false,
+            "$ref": "pipeline"
           },
           "stage": {
             "type": "string",
@@ -294,7 +298,8 @@
             "type": "string",
             "title": "Queue",
             "description": "UUID reference to the routing queue (request only).",
-            "format": "uuid"
+            "format": "uuid",
+            "$ref": "queue"
           },
           "caseReference": {
             "type": "string",


### PR DESCRIPTION
**gate-54 relation-dialect: FAIL — 12 → FAIL — 6.** Measured full-tree with gate
package `651e5c5bb3ba8764903e5d6fc5bac5a208bd67fc`, `NODE_PATH` proven by
printing `require.resolve('ajv')` as an absolute path. All `.err` files empty.

## Fixed (6) — relations whose target really is a schema in this register set

| Property | Change |
|---|---|
| `ticket.client` | `+ $ref: client` |
| `ticket.contact` | `+ $ref: contact` |
| `ticket.parentTicket` | `+ $ref: ticket` (self-reference — a contactmoment hangs off its parent request-ticket) |
| `ticket.pipeline` | `+ $ref: pipeline` |
| `ticket.queue` | `+ $ref: queue` |
| `task.requestId` | `$ref: request` → **`ticket`** |

The last is a **dangling reference, not a style issue**: the `request` schema was
folded into the `ticket` supertype by `99-unify-ticket-supertype`, so
`$ref: "request"` pointed at a schema that no longer exists in any casing. The
property keeps its stored name because renaming it is a data migration.

## Left red, deliberately (6) — ADR-066 cross-app relations

gate-54 has **no dialect for a cross-app relation**, and ADR-066 explicitly
sanctions them. Rule (f) demands a `$ref` resolving inside *this* app's register
set; a cross-app target is by construction not in it. Rule (b) closes the other
exit — a `format: uuid` relation with **no** `$ref` is also a finding. So the
author can fail (f) by naming the foreign schema, or fail (b) by not naming it.

| Property | Owner |
|---|---|
| `lead.decisions`, `ticket.decisions` | decidesk `Decision` — decidesk owns the making and eIDAS signing |
| `ticket.contract` | Shillinq `Contract` — Shillinq owns the lifecycle |
| `ticket.caseReference` | Procest case |
| `receiptTemplate.organizationId` | organisation, an OpenRegister concept |
| `posZReport.store` | the store plane, which **ADR-080 D2/D3 assigns to OpenRegister** |

Each description already names its owner, so the intent is documented in-tree;
there is simply no machine-readable way to state it. Filed
**ConductionNL/.github#305** with a proposed `app:schema` form.

### The one-character fix I did not make

pipelinq **has** a local `contract` schema. So `$ref: "Contract"` →
`$ref: "contract"` turns gate-54 green in one character — and **silently
repoints a Shillinq relation at a different, local object**. A near-miss in
casing is exactly where this gate can be satisfied by making the data model
wrong, so it is called out here rather than quietly taken.

## Positive control — run twice, against the helper directly

Removing `ticket.queue`'s `$ref` and reverting `task.requestId` to `request`
takes the count **6 → 8** and reports those two by name, one per rule shape:

```
task.requestId — $ref 'request' does not resolve to a schema key in the register set (case-exact)
ticket.queue — relation-shaped property (format:uuid + relation description) lacks canonical $ref
```

Restoring returns **6**. The helper's exit code was read as a *status*, never as
a count; the finding count comes from its stdout/log only.