### PR TITLE
fix(spec): tag PortalDocumentController::download with the requirement it implements

### DIFF
--- a/lib/Controller/PortalDocumentController.php
+++ b/lib/Controller/PortalDocumentController.php
@@ -117,6 +117,8 @@ class PortalDocumentController extends PortalApiController
      * @NoAdminRequired
      * @NoCSRFRequired
      * @PublicPage
+     *
+     * @spec openspec/changes/customer-portal/specs.md#REQ-005
      */
     public function download(string $token)
     {


### PR DESCRIPTION
**I introduced this, and it is on `development` right now.**

#741 modified `download()` to catch `Throwable` and did not add a `@spec`, so
gate-16 fails on development:

```
[gate-16] spec-coverage: FAIL — 1 changed method(s) missing @spec
lib/Controller/PortalDocumentController.php::download — missing @spec
```

## How it got through, so it does not happen again

I merged #741 on the rule that its failing job **names** were a subset of
development's — `{E2E, Hydra Gates, Quality Report}`, an exact match. That rule
is necessary but **not sufficient**: the same job name can carry a *new*
finding. I checked the contents for #739 (its Hydra Gates failure was
pre-existing gate-32/34/40 findings pulled in by diff scope) and did **not**
check them for #741.

The correct check is: when a PR fails a job that development also fails, read
*why* each fails and confirm the finding sets are the same or narrower.

## The fix

`@spec openspec/changes/customer-portal/specs.md#REQ-005` — **REQ-005 "Download
Documents"**, which is what this method implements, and the same target the
class docblock already carries.

Deliberately **not** repointed at `openspec/specs/customer-portal/spec.md`: that
canonical spec declares exactly one requirement (the widget-mode origin
allow-list) and says nothing about signed document download. Pointing there
would produce a tag that *resolves* while describing the wrong thing — worse
than a dangling one, because nothing would ever flag it.

REQ-005 lives in the archived change, which `check_spec_anchors.py` resolves
through its archive index. Verified by running that helper against this file:
it reports nothing.

## Separately: Hydra Gates cannot currently pass in CI for any PR here

On #742 the job fails for a different reason — not findings, but **coverage**:

```
[gate-60] icon-vocabulary: SKIPPED (wiring) — vue-material-design-icons is not
installed, so icon names could NOT be verified to exist upstream
```

and `hydra-gates-require-full-coverage` then fails the run. The gates step does
not install frontend dependencies, so gate-60 can never report in CI. Locally it
runs once `node_modules` is present — which is how the `Timeline` icon bug in
#742 was caught at all. Worth fixing in the workflow so the icon vocabulary is
actually verified rather than permanently unreported.