### PR TITLE
fix(security): stop 7 admin-only endpoints declaring #[NoAdminRequired]

### DIFF
--- a/lib/Controller/CallbackController.php
+++ b/lib/Controller/CallbackController.php
@@ -267,13 +267,14 @@ class CallbackController extends Controller
     /**
      * Reassign a task to a different user or group.
      *
+     * @auth admin-only Moves a task onto another user or group; the body additionally enforces it with an isAdmin() check.
+     *
      * @param string $id The task object ID.
      *
      * @return JSONResponse The response with updated task data.
      *
      * @spec openspec/changes/callback-management/tasks.md#task-2.1
      */
-    #[NoAdminRequired]
     public function reassign(string $id): JSONResponse
     {
         $user = $this->userSession->getUser();

--- a/lib/Controller/CtiController.php
+++ b/lib/Controller/CtiController.php
@@ -286,16 +286,19 @@ class CtiController extends Controller
     /**
      * Read the current CTI singleton configuration.
      *
-     * Admin-only. Endpoint carries `#[NoAdminRequired]` so the NC SecurityMiddleware
-     * does not block authenticated non-admin requests at the framework layer; we
-     * gate the body with an `isAdmin($uid)` check (consistent with the rest of
-     * the pipelinq admin surface).
+     * Admin-only, and now enforced at BOTH layers. The endpoint used to carry
+     * #[NoAdminRequired] so SecurityMiddleware would let a non-admin through to
+     * a body that then returned 403 itself. That is fail-closed but it declares
+     * the opposite of what it does, and the declaration is what a reviewer
+     * reads. The attribute is gone, so the framework rejects a non-admin before
+     * the controller runs; the isAdmin() check below stays as defence in depth.
+     *
+     * @auth admin-only Returns the instance-wide CTI platform configuration; the body additionally enforces it with an isAdmin() check.
      *
      * @return JSONResponse Current config (credentials never returned).
      *
      * @spec openspec/changes/cti-screenpop-adapter/tasks.md#task-4.1
      */
-    #[NoAdminRequired]
     public function getConfig(): JSONResponse
     {
         $user = $this->userSession->getUser();
@@ -314,11 +317,12 @@ class CtiController extends Controller
      *
      * Admin-only — see {@see self::getConfig()} for the auth model.
      *
+     * @auth admin-only Writes the instance-wide CTI platform configuration and credentials reference; the body additionally enforces it with an isAdmin() check.
+     *
      * @return JSONResponse The saved configuration.
      *
      * @spec openspec/changes/cti-screenpop-adapter/tasks.md#task-4.1
      */
-    #[NoAdminRequired]
     public function updateConfig(): JSONResponse
     {
         $user = $this->userSession->getUser();
@@ -360,11 +364,12 @@ class CtiController extends Controller
     /**
      * Test platform connectivity (admin only).
      *
+     * @auth admin-only Opens an outbound connection using the stored CTI credentials; the body additionally enforces it with an isAdmin() check.
+     *
      * @return JSONResponse Test outcome.
      *
      * @spec openspec/changes/cti-screenpop-adapter/tasks.md#task-4.1
      */
-    #[NoAdminRequired]
     public function testConnection(): JSONResponse
     {
         $user = $this->userSession->getUser();
@@ -378,11 +383,12 @@ class CtiController extends Controller
     /**
      * Read the CTI webhook event log (admin only).
      *
+     * @auth admin-only Exposes the instance-wide CTI webhook event log; the body additionally enforces it with an isAdmin() check.
+     *
      * @return JSONResponse Event log entries (max 30-day retention).
      *
      * @spec openspec/changes/cti-screenpop-adapter/tasks.md#task-4.1
      */
-    #[NoAdminRequired]
     public function eventLog(): JSONResponse
     {
         $user = $this->userSession->getUser();

--- a/lib/Controller/KassakoppelingAuditController.php
+++ b/lib/Controller/KassakoppelingAuditController.php
@@ -213,17 +213,22 @@ class KassakoppelingAuditController extends Controller
     /**
      * Export a date-range slice as a Belastingdienst-ready file.
      *
-     * Admin-only at the application layer (the route would otherwise be a
-     * #[NoAdminRequired] sibling of the other endpoints, so the in-body
-     * IGroupManager::isAdmin check is what enforces REQ-AUDIT-005-03).
+     * Admin-only, now enforced at both layers. The route previously carried
+     * #[NoAdminRequired] as a sibling of the other endpoints on this
+     * controller, leaving the in-body IGroupManager::isAdmin check as the only
+     * thing enforcing REQ-AUDIT-005-03. That check remains, but the framework
+     * now rejects a non-admin first — this endpoint streams the full audit
+     * trail to the tax authority, and it is the one place on this controller
+     * where a mis-edit to the body would be worst.
      * Returns the XML / JSON file as a DataDownloadResponse with a
      * Belastingdienst-friendly filename.
+     *
+     * @auth admin-only Streams the complete Belastingdienst audit export for the instance; the body additionally enforces it with an isAdmin() check (REQ-AUDIT-005-03).
      *
      * @return DataDownloadResponse|JSONResponse The export, or an error.
      *
      * @spec openspec/changes/pos-kassakoppeling-audit/tasks.md#3.1
      */
-    #[NoAdminRequired]
     public function export(): DataDownloadResponse|JSONResponse
     {
         $uid = $this->requireUserId();

--- a/lib/Controller/NotesController.php
+++ b/lib/Controller/NotesController.php
@@ -329,11 +329,12 @@ class NotesController extends Controller
      * @param string $objectType The object type.
      * @param string $objectId   The object ID.
      *
+     * @auth admin-only Bulk-deletes every note on an entity the caller need not own; the body additionally enforces it with an isAdmin() check.
+     *
      * @return JSONResponse The response.
      *
      * @spec openspec/specs/entity-notes/spec.md
      */
-    #[NoAdminRequired]
     public function deleteAll(string $objectType, string $objectId): JSONResponse
     {
         $user = $this->userSession->getUser();

--- a/tests/Unit/Controller/NotesControllerTest.php
+++ b/tests/Unit/Controller/NotesControllerTest.php
@@ -261,4 +261,70 @@ class NotesControllerTest extends TestCase
 
         $this->assertSame(403, $response->getStatus());
     }//end testDeleteSingleReturns403OnPermissionError()
+
+    /**
+     * deleteAll must refuse a non-admin.
+     *
+     * This pins the half of the check that survives dropping
+     * #[NoAdminRequired] from the method. With the attribute gone,
+     * SecurityMiddleware rejects a non-admin before the controller is even
+     * reached — which is the point of that change — but middleware is not
+     * exercised by a unit test, so the in-body isAdmin() guard is what this
+     * asserts. If someone later removes the body check on the grounds that
+     * "the framework handles it", this test fails.
+     *
+     * deleteAll wipes every note on an entity the caller need not own, so it
+     * is the worst of the seven to get wrong.
+     *
+     * @return void
+     */
+    public function testDeleteAllRefusesNonAdmin(): void
+    {
+        $request     = $this->createMock(IRequest::class);
+        $userSession = $this->createMock(IUserSession::class);
+        $user        = $this->createMock(IUser::class);
+        $user->method('getUID')->willReturn('regular-user');
+        $userSession->method('getUser')->willReturn($user);
+
+        $l10n = $this->createMock(IL10N::class);
+        $l10n->method('t')->willReturnArgument(0);
+
+        $settingsService = $this->createMock(SettingsService::class);
+        $settingsService->method('getSettings')->willReturn(
+                [
+                    'register'      => 'reg-123',
+                    'client_schema' => 'schema-client',
+                ]
+                );
+
+        $ticketService = $this->createMock(TicketService::class);
+        $ticketService->method('getRegisterId')->willReturn('reg-123');
+        $ticketService->method('getSchemaId')->willReturn('schema-ticket');
+
+        // The notes service must never be reached: the guard has to reject
+        // BEFORE any delete is attempted. Asserting on the outcome alone
+        // would still pass if the guard ran after the wipe.
+        $notesService = $this->createMock(NotesService::class);
+        $notesService->expects($this->never())->method('deleteAllNotes');
+
+        $groupManager = $this->createMock(IGroupManager::class);
+        $groupManager->method('isAdmin')->willReturn(false);
+
+        $controller = new NotesController(
+            $request,
+            $notesService,
+            $this->createMock(NoteEventService::class),
+            $userSession,
+            $l10n,
+            $this->createMock(\Psr\Log\LoggerInterface::class),
+            $this->createMock(ContainerInterface::class),
+            $groupManager,
+            $settingsService,
+            $ticketService,
+        );
+
+        $response = $controller->deleteAll('pipelinq_client', 'obj-1');
+
+        $this->assertSame(403, $response->getStatus());
+    }//end testDeleteAllRefusesNonAdmin()
 }//end class


### PR DESCRIPTION
**gate-9 semantic-auth: FAIL — 7 → PASS.** Gate package `651e5c5`.

## I measured the FP rate here rather than assuming the fleet's

gate-9 is carried fleet-wide as a known false-positive class (**36 of 39**). In
pipelinq it is **0 of 7** — every finding is real.

Method: read each body and ask whether the admin check is **unconditional** or
opens an alternative path. All seven reject outright:

| Method | Body |
|---|---|
| `CtiController::getConfig` / `updateConfig` / `testConnection` / `eventLog` | `if ($user === null \|\| isAdmin(...) === false) → 403` |
| `CallbackController::reassign` | *"Only administrators may reassign tasks"* |
| `KassakoppelingAuditController::export` | admin-only, REQ-AUDIT-005-03 |
| `NotesController::deleteAll` | bulk-delete of notes on entities the caller need not own |

**None has an owner-or-admin branch** — which is exactly where this gate's
false positives normally live — so removing the attribute cannot break a
legitimate non-admin path.

## What changed

The old pattern was deliberate and documented: carry `#[NoAdminRequired]` so
`SecurityMiddleware` lets the request through, then reject in the body. That is
fail-closed, but **it declares the opposite of what it does**, and the
declaration is what a reviewer reads.

Both layers now agree — the framework rejects a non-admin *first*, and every
`isAdmin()` check stays exactly where it was as defence in depth. **Nothing was
removed from a body.**

Each method gains `@auth admin-only <reason>` (ConductionNL/.github#269), the
same instrument used in #737, so gate-5 keeps its posture declaration now that
the attribute is gone.

**Not `#[AuthorizedAdminSetting]`**: that authorizes on `isAdminUser()` **or** a
delegated settings grant, which would *widen* the check on CTI credentials, task
reassignment, note bulk-delete, and the Belastingdienst audit export.

## Measurement

| Gate | Before | After |
|---|---|---|
| gate-9 semantic-auth | FAIL — 7 | **PASS** |
| gate-5 route-auth | PASS | PASS |
| gate-14 route-reachability | PASS | PASS |

**Positive control:** restoring `#[NoAdminRequired]` on `deleteAll` alone takes
the helper from 0 findings to 1, naming that method. All `.err` files empty.