### PR TITLE
fix(leads): two LeadList slots named a slot that does not exist, so they never rendered

### DIFF
--- a/src/views/leads/LeadList.vue
+++ b/src/views/leads/LeadList.vue
@@ -28,7 +28,7 @@
 		:row-click-to-view="false"
 		@row-click="openLead"
 		@view="openLead">
-		<template #header-extra>
+		<template #header-actions>
 			<div class="lead-list__filters">
 				<NcCheckboxRadioSwitch
 					v-model="showStaleOnly"
@@ -45,11 +45,11 @@
 			</div>
 		</template>
 
-		<template #cell-expectedCloseDate="{ item }">
-			<span :class="{ 'overdue-cell': isLeadOverdue(item, stages) }">
-				{{ item.expectedCloseDate || '-' }}
-				<small v-if="isLeadOverdue(item, stages)" class="overdue-suffix">
-					{{ getOverdueDays(item, stages) }}d {{ t('pipelinq', 'late') }}
+		<template #column-expectedCloseDate="{ row }">
+			<span :class="{ 'overdue-cell': isLeadOverdue(row, stages) }">
+				{{ row.expectedCloseDate || '-' }}
+				<small v-if="isLeadOverdue(row, stages)" class="overdue-suffix">
+					{{ getOverdueDays(row, stages) }}d {{ t('pipelinq', 'late') }}
 				</small>
 			</span>
 		</template>


### PR DESCRIPTION
Not a gate finding — **no gate reports this class of defect.** Found by auditing
every `<template #name>` in `src/` against the slot names the receiving `Cn*`
component actually declares, prompted by the docudesk `#above-table` case.

A `<template #slot-name>` addressed to a slot that does not exist renders
**nothing**: no console error, no build warning, no failing check. Every
container-level assertion passes the whole time.

## What was invisible

`CnIndexPage` declares: `action-items`, `card`, `column-{key}`, `copy-dialog`,
`delete-dialog`, `empty`, `form-dialog`, `form-fields`, `header-actions`,
`import-fields`, `mass-actions`, `row-actions`.

`LeadList.vue` used two names that are not on that list.

| Was | Now | What the user lost |
|---|---|---|
| `#header-extra` | `#header-actions` | The **"Stale only (>{days}d)"** and **"Hide closed"** checkboxes. Users have never been able to filter the lead list — the controls were simply absent. |
| `#cell-expectedCloseDate` | `#column-expectedCloseDate` | The overdue treatment on the expected-close-date column — the red `overdue-cell` class and the **"{n}d late"** suffix. The column fell back to the default renderer, so **an overdue lead looked exactly like an on-time one.** |

The prefix is `column-`, not `cell-`; `grep cell- CnIndexPage.vue` returns
nothing.

## The scope was wrong too — the next silent failure

The declared scope for `column-{key}` is **`{ row, value }`**, not `{ item }`.
Renaming the slot alone would have made the template render with `item`
undefined — an empty cell — and still looked "done". Bound as `{ row }` with
the three `item.` references updated.

## Sweep

Audited all `<template #…>` names in `src/` against every `@slot` declared
across `@conduction/nextcloud-vue`, excluding the dynamic prefixes
(`column-`, `item-`, `field-`, `label-`, `widget-`, `step-`) and the standard
`@nextcloud/vue` slots. **LeadList was the only case** — no other dead slots of
this shape remain.