### PR TITLE
fix(a11y): give the last 17 NcTextFields their own accessible name (gate-40)

### DIFF
--- a/src/views/clients/ClientForm.vue
+++ b/src/views/clients/ClientForm.vue
@@ -5,6 +5,7 @@
 			<NcTextField
 				id="client-name"
 				label-outside
+				:label="t('pipelinq', 'Name')"
 				:model-value="form.name"
 				:error="!!errors.name"
 				:helper-text="errors.name"
@@ -34,6 +35,7 @@
 				<NcTextField
 					id="client-email"
 					label-outside
+					:label="t('pipelinq', 'Email')"
 					:model-value="form.email"
 					:error="!!errors.email"
 					:helper-text="errors.email"
@@ -49,6 +51,7 @@
 				<NcTextField
 					id="client-phone"
 					label-outside
+					:label="t('pipelinq', 'Phone')"
 					:model-value="form.phone"
 					:error="!!errors.phone"
 					:helper-text="errors.phone"
@@ -60,6 +63,7 @@
 				<NcTextField
 					id="client-website"
 					label-outside
+					:label="t('pipelinq', 'Website')"
 					:model-value="form.website"
 					:error="!!errors.website"
 					:helper-text="errors.website"
@@ -73,6 +77,7 @@
 			<NcTextField
 				id="client-address"
 				label-outside
+				:label="t('pipelinq', 'Address')"
 				:model-value="form.address"
 				data-testid="client-address-input"
 				@update:model-value="v => form.address = v" />

--- a/src/views/contacts/ContactForm.vue
+++ b/src/views/contacts/ContactForm.vue
@@ -4,6 +4,8 @@
 			<label for="contact-name">{{ t('pipelinq', 'Name') }} *</label>
 			<NcTextField
 				id="contact-name"
+				label-outside
+				:label="t('pipelinq', 'Name')"
 				:model-value="form.name"
 				:error="!!errors.name"
 				:helper-text="errors.name"
@@ -33,6 +35,8 @@
 				<label for="contact-role">{{ t('pipelinq', 'Role') }}</label>
 				<NcTextField
 					id="contact-role"
+					label-outside
+					:label="t('pipelinq', 'Role')"
 					:model-value="form.role"
 					@update:model-value="v => form.role = v" />
 			</div>
@@ -40,6 +44,8 @@
 				<label for="contact-email">{{ t('pipelinq', 'Email') }}</label>
 				<NcTextField
 					id="contact-email"
+					label-outside
+					:label="t('pipelinq', 'Email')"
 					:model-value="form.email"
 					:error="!!errors.email"
 					:helper-text="errors.email"
@@ -52,6 +58,8 @@
 			<label for="contact-phone">{{ t('pipelinq', 'Phone') }}</label>
 			<NcTextField
 				id="contact-phone"
+				label-outside
+				:label="t('pipelinq', 'Phone')"
 				:model-value="form.phone"
 				:error="!!errors.phone"
 				:helper-text="errors.phone"

--- a/src/views/products/ProductForm.vue
+++ b/src/views/products/ProductForm.vue
@@ -5,6 +5,8 @@
 				<label for="product-name">{{ t('pipelinq', 'Name') }} *</label>
 				<NcTextField
 					id="product-name"
+					label-outside
+					:label="t('pipelinq', 'Name')"
 					:model-value="form.name"
 					:error="!!errors.name"
 					:helper-text="errors.name"
@@ -15,6 +17,8 @@
 				<label for="product-sku">{{ t('pipelinq', 'SKU') }}</label>
 				<NcTextField
 					id="product-sku"
+					label-outside
+					:label="t('pipelinq', 'SKU')"
 					:model-value="form.sku"
 					:maxlength="100"
 					@update:model-value="v => form.sku = v" />
@@ -51,6 +55,8 @@
 				<label for="product-unitPrice">{{ t('pipelinq', 'Unit Price') }} *</label>
 				<NcTextField
 					id="product-unitPrice"
+					label-outside
+					:label="t('pipelinq', 'Unit Price')"
 					:model-value="form.unitPrice"
 					:error="!!errors.unitPrice"
 					:helper-text="errors.unitPrice"
@@ -61,6 +67,8 @@
 				<label for="product-cost">{{ t('pipelinq', 'Cost') }}</label>
 				<NcTextField
 					id="product-cost"
+					label-outside
+					:label="t('pipelinq', 'Cost')"
 					:model-value="form.cost"
 					type="number"
 					@update:model-value="v => form.cost = v" />
@@ -72,6 +80,8 @@
 				<label for="product-unit">{{ t('pipelinq', 'Unit') }}</label>
 				<NcTextField
 					id="product-unit"
+					label-outside
+					:label="t('pipelinq', 'Unit')"
 					:model-value="form.unit"
 					:placeholder="t('pipelinq', 'e.g. piece, hour, license')"
 					@update:model-value="v => form.unit = v" />
@@ -80,6 +90,8 @@
 				<label for="product-taxRate">{{ t('pipelinq', 'Tax Rate (%)') }}</label>
 				<NcTextField
 					id="product-taxRate"
+					label-outside
+					:label="t('pipelinq', 'Tax Rate (%)')"
 					:model-value="form.taxRate"
 					:disabled="!!form.btwClass"
 					:helper-text="form.btwClass ? t('pipelinq', 'Derived from the selected BTW class') : ''"
@@ -106,6 +118,8 @@
 				<label for="product-barcode">{{ t('pipelinq', 'Barcode (EAN/UPC)') }}</label>
 				<NcTextField
 					id="product-barcode"
+					label-outside
+					:label="t('pipelinq', 'Barcode (EAN/UPC)')"
 					:model-value="form.barcode"
 					:maxlength="64"
 					@update:model-value="v => form.barcode = v" />
@@ -116,6 +130,8 @@
 			<label for="product-duration">{{ t('pipelinq', 'Duration (minutes)') }}</label>
 			<NcTextField
 				id="product-duration"
+				label-outside
+				:label="t('pipelinq', 'Duration (minutes)')"
 				:model-value="form.duration"
 				type="number"
 				@update:model-value="v => form.duration = v" />


### PR DESCRIPTION
## What

The remaining 17 gate-40 findings, across `ContactForm.vue` (4), `ClientForm.vue` (5) and `ProductForm.vue` (8).

## Why these were real, not the known gate-40 false-positive class

gate-40 accepts a sibling `<label for>` **only for native inputs** (`check_form_labels.py` matches `id` against `label_for` for `NATIVE` elements). For an NC component it requires the component's own label prop.

That distinction is the same one the project's `nc-input-labels` rule already makes: the manual `<label for>` points at an id the *component* owns, not at the inner `<input>` it renders, so the association is not guaranteed.

`ClientForm.vue` is the tell — it already carried `label-outside` and was still reported. `label-outside` suppresses the component's internal label but supplies no accessible name of its own.

## The change

Every field keeps its visible `<label>`, gains `label-outside` where it was missing (so nothing renders twice), and gains `:label` with the same translated string. No visual change; the accessible name stops depending on the id association.

## Measurement

Gate package `5907a4df8cc097a21ec600d441da421ee26308f1`, full-tree:

| gate | before | after |
|---|---|---|
| gate-40 form-label-association | **FAIL — 17** | **PASS — 0** |

## Proof it can fail

Deleting one `:label` line from a copy of `ProductForm.vue` reproduces exactly one `nctextfield-without-label-prop` finding — on a field that still carries `label-outside`, which is what rules out 'the checker simply stopped looking'.

No waiver, no `.skip`, no baseline entry, no threshold change.