### PR TITLE
style(controllers): put the @auth admin-only tags where phpcs expects them

### DIFF
--- a/lib/Controller/CallbackController.php
+++ b/lib/Controller/CallbackController.php
@@ -267,11 +267,12 @@ class CallbackController extends Controller
     /**
      * Reassign a task to a different user or group.
      *
-     * @auth admin-only Moves a task onto another user or group; the body additionally enforces it with an isAdmin() check.
-     *
      * @param string $id The task object ID.
      *
      * @return JSONResponse The response with updated task data.
+     *
+     * @auth admin-only Moves a task onto another user or group; the body
+     *       additionally enforces it with an isAdmin() check.
      *
      * @spec openspec/changes/callback-management/tasks.md#task-2.1
      */

--- a/lib/Controller/CtiController.php
+++ b/lib/Controller/CtiController.php
@@ -317,7 +317,9 @@ class CtiController extends Controller
      *
      * Admin-only — see {@see self::getConfig()} for the auth model.
      *
-     * @auth admin-only Writes the instance-wide CTI platform configuration and credentials reference; the body additionally enforces it with an isAdmin() check.
+     * @auth admin-only Writes the instance-wide CTI platform configuration and
+     *       credentials reference; the body additionally enforces it with an
+     *       isAdmin() check.
      *
      * @return JSONResponse The saved configuration.
      *

--- a/lib/Controller/KassakoppelingAuditController.php
+++ b/lib/Controller/KassakoppelingAuditController.php
@@ -223,7 +223,9 @@ class KassakoppelingAuditController extends Controller
      * Returns the XML / JSON file as a DataDownloadResponse with a
      * Belastingdienst-friendly filename.
      *
-     * @auth admin-only Streams the complete Belastingdienst audit export for the instance; the body additionally enforces it with an isAdmin() check (REQ-AUDIT-005-03).
+     * @auth admin-only Streams the complete Belastingdienst audit export for
+     *       the instance; the body additionally enforces it with an isAdmin()
+     *       check (REQ-AUDIT-005-03).
      *
      * @return DataDownloadResponse|JSONResponse The export, or an error.
      *

--- a/lib/Controller/PosPaymentController.php
+++ b/lib/Controller/PosPaymentController.php
@@ -113,11 +113,12 @@ class PosPaymentController extends Controller
     /**
      * GET /api/payment-providers/{name} — single provider config.
      *
-     * @auth admin-only Reads one payment provider's configuration; restricted to server administrators by the framework default.
-     *
      * @param string $name The provider name.
      *
      * @return JSONResponse
+     *
+     * @auth admin-only Reads one payment provider's configuration; restricted
+     *       to server administrators by the framework default.
      *
      * @spec openspec/changes/pos-payment-provider-adapter/specs/pos-payment-provider-adapter/spec.md#REQ-PAY-007
      */
@@ -135,11 +136,12 @@ class PosPaymentController extends Controller
     /**
      * PUT /api/payment-providers/{name} — update provider credentials + config.
      *
-     * @auth admin-only Writes payment-provider credentials for the instance; restricted to server administrators by the framework default.
-     *
      * @param string $name The provider name.
      *
      * @return JSONResponse
+     *
+     * @auth admin-only Writes payment-provider credentials for the instance;
+     *       restricted to server administrators by the framework default.
      *
      * @spec openspec/changes/pos-payment-provider-adapter/specs/pos-payment-provider-adapter/spec.md#REQ-PAY-002
      * @spec openspec/changes/pos-payment-provider-adapter/specs/pos-payment-provider-adapter/spec.md#REQ-PAY-007
@@ -159,11 +161,13 @@ class PosPaymentController extends Controller
     /**
      * POST /api/payment-providers/{name}/test — test provider connection.
      *
-     * @auth admin-only Opens an outbound connection using stored provider credentials; restricted to server administrators by the framework default.
-     *
      * @param string $name The provider name.
      *
      * @return JSONResponse
+     *
+     * @auth admin-only Opens an outbound connection using stored provider
+     *       credentials; restricted to server administrators by the framework
+     *       default.
      *
      * @spec openspec/changes/pos-payment-provider-adapter/specs/pos-payment-provider-adapter/spec.md#REQ-PAY-007
      */

--- a/lib/Controller/PosRoleController.php
+++ b/lib/Controller/PosRoleController.php
@@ -145,11 +145,12 @@ class PosRoleController extends Controller
     /**
      * Update a POS role (admin only).
      *
-     * @auth admin-only Rewrites a POS permission role; the body additionally enforces it with an explicit requireAdmin() guard.
-     *
      * @param string $id The role UUID.
      *
      * @return JSONResponse The updated role.
+     *
+     * @auth admin-only Rewrites a POS permission role; the body additionally
+     *       enforces it with an explicit requireAdmin() guard.
      *
      * @spec openspec/changes/pos-staff-pin-permissions/tasks.md#4.1
      */
@@ -173,11 +174,12 @@ class PosRoleController extends Controller
     /**
      * Delete a POS role (admin only).
      *
-     * @auth admin-only Deletes a POS permission role; the body additionally enforces it with an explicit requireAdmin() guard.
-     *
      * @param string $id The role UUID.
      *
      * @return JSONResponse Empty payload on success.
+     *
+     * @auth admin-only Deletes a POS permission role; the body additionally
+     *       enforces it with an explicit requireAdmin() guard.
      *
      * @spec openspec/changes/pos-staff-pin-permissions/tasks.md#4.1
      */

--- a/lib/Controller/PosStaffController.php
+++ b/lib/Controller/PosStaffController.php
@@ -104,11 +104,13 @@ class PosStaffController extends Controller
     /**
      * Get a single staff record (admin only). The bcrypt pinHash is stripped.
      *
-     * @auth admin-only Reads one POS staff record including its permission set; the body additionally enforces it with an explicit requireAdmin() guard.
-     *
      * @param string $id The staff UUID.
      *
      * @return JSONResponse The staff record.
+     *
+     * @auth admin-only Reads one POS staff record including its permission
+     *       set; the body additionally enforces it with an explicit
+     *       requireAdmin() guard.
      *
      * @spec openspec/changes/pos-staff-pin-permissions/tasks.md#4.2
      */
@@ -155,11 +157,13 @@ class PosStaffController extends Controller
     /**
      * Update a staff record (admin only).
      *
-     * @auth admin-only Rewrites a POS staff identity, including its PIN and permissions; the body additionally enforces it with an explicit requireAdmin() guard.
-     *
      * @param string $id The staff UUID.
      *
      * @return JSONResponse The updated staff record.
+     *
+     * @auth admin-only Rewrites a POS staff identity, including its PIN and
+     *       permissions; the body additionally enforces it with an explicit
+     *       requireAdmin() guard.
      *
      * @spec openspec/changes/pos-staff-pin-permissions/tasks.md#4.2
      */
@@ -184,11 +188,13 @@ class PosStaffController extends Controller
     /**
      * Delete a staff record (admin only).
      *
-     * @auth admin-only Removes a POS staff identity and revokes its till access; the body additionally enforces it with an explicit requireAdmin() guard.
-     *
      * @param string $id The staff UUID.
      *
      * @return JSONResponse Empty payload on success.
+     *
+     * @auth admin-only Removes a POS staff identity and revokes its till
+     *       access; the body additionally enforces it with an explicit
+     *       requireAdmin() guard.
      *
      * @spec openspec/changes/pos-staff-pin-permissions/tasks.md#4.2
      */


### PR DESCRIPTION
## What

Follow-up to #737, fixing a regression that PR introduced.

#737 closed gate-5 by declaring `@auth admin-only <reason>` on 17 routed endpoints — the right call, since the alternative (`#[AuthorizedAdminSetting]`) would have *widened* access to delegated admins. But it inserted the tag **above `@param`** and wrote each reason on a single line. Both are phpcs errors:

- `Parameter tags must be defined first in a doc comment` — 8 occurrences
- `Line exceeds maximum limit of 150 characters` — 6 occurrences

**14 errors across 6 controllers**, all introduced by #737. They are on `development` now.

## Fix

Each tag moves below `@return` and the reason wraps. The reason still begins on the tag line with well over the 20 characters gate-5 requires, and docblock-tag position is unchanged, so the declaration still counts.

## Measurement

phpcs run in the PHP 8.4 container against the repo's own `phpcs.xml` (local PHP is 8.2 and **dies on the platform check**, which silently reads as 'clean' — worth knowing):

| | errors |
|---|---|
| the 6 files at `development` | **14** |
| the 6 files after this change | **0** (exit 0, no warnings either) |

Gate package `5907a4df8cc097a21ec600d441da421ee26308f1`, full-tree, after this change:

- `[gate-5] route-auth: PASS` — the declarations still satisfy the gate
- `[gate-9] semantic-auth: PASS`

That second check is the one that mattered: moving the tag could have silently un-declared 17 endpoints.