### PR TITLE
chore(deps): pin @conduction/nextcloud-vue to 2.2.0-vue3.9

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
 			"version": "0.1.0",
 			"license": "EUPL-1.2",
 			"dependencies": {
-				"@conduction/nextcloud-vue": "2.2.0-vue3.7",
+				"@conduction/nextcloud-vue": "2.2.0-vue3.9",
 				"@nextcloud/axios": "~2.5.2",
 				"@nextcloud/capabilities": "^1.2.1",
 				"@nextcloud/dialogs": "^7.4.1",
@@ -1816,9 +1816,9 @@
 			}
 		},
 		"node_modules/@conduction/nextcloud-vue": {
-			"version": "2.2.0-vue3.7",
-			"resolved": "https://registry.npmjs.org/@conduction/nextcloud-vue/-/nextcloud-vue-2.2.0-vue3.7.tgz",
-			"integrity": "sha512-x0aj0ACfLUDIak3/A51jVyxCPWPIFYfhv7FG2WIQA5+WKfxfJ2rzt8mIl65AmW646PZxsOz4iPo1pCm3EUeuIQ==",
+			"version": "2.2.0-vue3.9",
+			"resolved": "https://registry.npmjs.org/@conduction/nextcloud-vue/-/nextcloud-vue-2.2.0-vue3.9.tgz",
+			"integrity": "sha512-9HC1dhYfCqw7JeZ3mn4Zr260iBCWlWa/1slrPTdmIbODvbWlf82guAZEnMq17XvWmDJRcAVNBzYtIT2kWwZutA==",
 			"license": "EUPL-1.2",
 			"dependencies": {
 				"@ckpack/vue-color": "^1.6.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
 			"version": "0.1.0",
 			"license": "EUPL-1.2",
 			"dependencies": {
-				"@conduction/nextcloud-vue": "2.2.0-vue3.3",
+				"@conduction/nextcloud-vue": "2.2.0-vue3.7",
 				"@nextcloud/axios": "~2.5.2",
 				"@nextcloud/capabilities": "^1.2.1",
 				"@nextcloud/dialogs": "^7.4.1",
@@ -1816,9 +1816,9 @@
 			}
 		},
 		"node_modules/@conduction/nextcloud-vue": {
-			"version": "2.2.0-vue3.3",
-			"resolved": "https://registry.npmjs.org/@conduction/nextcloud-vue/-/nextcloud-vue-2.2.0-vue3.3.tgz",
-			"integrity": "sha512-kO6qtFPnQx1gNFZO/l5YVaSnpnsJspaqazWn5pWiwpma1DbTO9Oa6Jfk5svzFOfR85QB37HKqDqL0JnHpKiXJw==",
+			"version": "2.2.0-vue3.7",
+			"resolved": "https://registry.npmjs.org/@conduction/nextcloud-vue/-/nextcloud-vue-2.2.0-vue3.7.tgz",
+			"integrity": "sha512-x0aj0ACfLUDIak3/A51jVyxCPWPIFYfhv7FG2WIQA5+WKfxfJ2rzt8mIl65AmW646PZxsOz4iPo1pCm3EUeuIQ==",
 			"license": "EUPL-1.2",
 			"dependencies": {
 				"@ckpack/vue-color": "^1.6.0",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
 		"extends @nextcloud/browserslist-config"
 	],
 	"dependencies": {
-		"@conduction/nextcloud-vue": "2.2.0-vue3.3",
+		"@conduction/nextcloud-vue": "2.2.0-vue3.7",
 		"@nextcloud/axios": "~2.5.2",
 		"@nextcloud/capabilities": "^1.2.1",
 		"@nextcloud/dialogs": "^7.4.1",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
 		"extends @nextcloud/browserslist-config"
 	],
 	"dependencies": {
-		"@conduction/nextcloud-vue": "2.2.0-vue3.7",
+		"@conduction/nextcloud-vue": "2.2.0-vue3.9",
 		"@nextcloud/axios": "~2.5.2",
 		"@nextcloud/capabilities": "^1.2.1",
 		"@nextcloud/dialogs": "^7.4.1",


### PR DESCRIPTION
## What

Hard-pins `@conduction/nextcloud-vue` to exactly **`2.2.0-vue3.9`** (was `2.2.0-vue3.3`).

This PR opened at `2.2.0-vue3.7`. The `vue3` dist-tag moved **3.7 (07:37) → 3.8 (08:51) → 3.9 (09:18)** while it was in flight, because every merge to `feat/vue-3` cuts a publish. Pinned to **3.9 and frozen there**.

`^2.2.0` does **not** match `2.2.0-vue3.9` (caret ranges do not cross prerelease boundaries), and `latest`/`beta` are the **retired Vue 2 lineage**. Positive controls: `2.2.0-vue3.9` resolves; `3.0.0-*` returns **E404**.

## Lockfile control

Regenerating the lockfile with the pin **unchanged** is a **0-line diff** in this repo, so the whole `+5/-5` is the version move and nothing else. Never hand-edited.

## Verified

`2.2.0-vue3.9` was not pre-verified against our apps, so this run is the verification:

| | before | after |
|---|---|---|
| installed version (off disk, after real `npm ci`) | `2.2.0-vue3.3` | **`2.2.0-vue3.9`** — one copy, peer `vue ^3.5.0` |
| unit tests (`npm run test:unit`) | 45 passed / 6 files | 45 passed / 6 files |
| webpack build | 6 warnings, 0 errors | 6 warnings, 0 errors |
| bundle total | 42,563,172 B | 42,572,520 B (**+9,348 B, +0.02%**) |

No regression on 3.9.

## Re-checked for #750 against the 3.9 dist

`bb912e2` in 3.8/3.9 corrects `CnIndexPage`'s slot documentation, which is the area #750's dead-slot fix touches. The `CnDataTable` slot contract read directly off the **3.9** dist is:

| slot | scope |
|---|---|
| `#column-<key>` | `{ row, value }` — per-column cell override, wins over `CnCellRenderer` |
| `#row-actions` | `{ row }` — supplying it adds the trailing actions column |
| `#actions-header` | — header cell above the row-actions column |
| `#empty` | — empty-state content |
| `#footer` | `{ total, shown }` |

Two things this settles for #750:

- **`{ row, value }` is correct**, not `{ item }`. Confirmed in the compiled render function.
- **`#header-extra` does not exist in 3.9** — and that absence is positive-controlled, not inferred from one failed grep: searching the same `dist/` tree the same way finds `row-actions` in 45 files, `footer` in 161, and `cell-` in 55, but `header-extra` in **0**.
- The per-column slot is named **`#column-<key>`** (`renderSlot(_ctx.$slots, 'column-' + col.key, { row, value })`), so any `#cell-<key>` usage is inert.
