### PR TITLE
fix(spec): point 10 dangling @spec tags at their canonical spec homes (gate-46)

### DIFF
--- a/tests/Unit/BackgroundJob/EmailMatchJobTest.php
+++ b/tests/Unit/BackgroundJob/EmailMatchJobTest.php
@@ -14,7 +14,7 @@
  *
  * @link https://pipelinq.nl
  *
- * @spec openspec/changes/email-calendar-sync/specs/email-calendar-sync/spec.md#req-crm-email-matching
+ * @spec openspec/specs/email-calendar-sync/spec.md#requirement-emails-must-be-automatically-linked-to-crm-contacts
  *
  * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
  * SPDX-License-Identifier: EUPL-1.2

--- a/tests/Unit/Controller/EmailSyncControllerTest.php
+++ b/tests/Unit/Controller/EmailSyncControllerTest.php
@@ -14,7 +14,7 @@
  *
  * @link https://pipelinq.nl
  *
- * @spec openspec/changes/email-calendar-sync/specs/email-calendar-sync/spec.md#req-per-user-matching-settings
+ * @spec openspec/specs/email-calendar-sync/spec.md#requirement-email-sync-must-be-configurable-per-user
  *
  * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
  * SPDX-License-Identifier: EUPL-1.2

--- a/tests/Unit/ProjectTaskHierarchyTest.php
+++ b/tests/Unit/ProjectTaskHierarchyTest.php
@@ -24,7 +24,7 @@
  *
  * @link https://pipelinq.nl
  *
- * @spec openspec/changes/project-task-hierarchy/specs/project-task-hierarchy/spec.md
+ * @spec openspec/changes/archive/2026-06-14-project-task-hierarchy/specs.md
  */
 
 declare(strict_types=1);

--- a/tests/Unit/Service/BusinessHoursCalculatorTest.php
+++ b/tests/Unit/Service/BusinessHoursCalculatorTest.php
@@ -14,7 +14,7 @@
  *
  * @link https://pipelinq.nl
  *
- * @spec openspec/changes/sla-engine-and-escalation/specs/sla-engine-and-escalation/spec.md#REQ-002
+ * @spec openspec/specs/sla-engine-and-escalation/spec.md#requirement-holiday-aware-deadline-calculation
  */
 
 declare(strict_types=1);

--- a/tests/Unit/Service/EmailMatchServiceTest.php
+++ b/tests/Unit/Service/EmailMatchServiceTest.php
@@ -14,7 +14,7 @@
  *
  * @link https://pipelinq.nl
  *
- * @spec openspec/changes/email-calendar-sync/specs/email-calendar-sync/spec.md#req-crm-email-matching
+ * @spec openspec/specs/email-calendar-sync/spec.md#requirement-emails-must-be-automatically-linked-to-crm-contacts
  *
  * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
  * SPDX-License-Identifier: EUPL-1.2

--- a/tests/Unit/Service/HolidayCalendarServiceTest.php
+++ b/tests/Unit/Service/HolidayCalendarServiceTest.php
@@ -14,8 +14,8 @@
  *
  * @link https://pipelinq.nl
  *
- * @spec openspec/changes/sla-engine-and-escalation/specs/sla-engine-and-escalation/spec.md#REQ-002
- * @spec openspec/changes/sla-engine-and-escalation/specs/sla-engine-and-escalation/spec.md#REQ-010
+ * @spec openspec/specs/sla-engine-and-escalation/spec.md#requirement-holiday-aware-deadline-calculation
+ * @spec openspec/specs/sla-engine-and-escalation/spec.md#requirement-holiday-calendar-pluggability
  */
 
 declare(strict_types=1);

--- a/tests/Unit/Service/SlaEngineServiceTest.php
+++ b/tests/Unit/Service/SlaEngineServiceTest.php
@@ -14,9 +14,9 @@
  *
  * @link https://pipelinq.nl
  *
- * @spec openspec/changes/sla-engine-and-escalation/specs/sla-engine-and-escalation/spec.md#REQ-001
- * @spec openspec/changes/sla-engine-and-escalation/specs/sla-engine-and-escalation/spec.md#REQ-002
- * @spec openspec/changes/sla-engine-and-escalation/specs/sla-engine-and-escalation/spec.md#REQ-004
+ * @spec openspec/specs/sla-engine-and-escalation/spec.md#requirement-policy-resolution-at-object-creation
+ * @spec openspec/specs/sla-engine-and-escalation/spec.md#requirement-holiday-aware-deadline-calculation
+ * @spec openspec/specs/sla-engine-and-escalation/spec.md#requirement-escalation-chain-execution
  */
 
 declare(strict_types=1);


### PR DESCRIPTION
## What was red

Hydra gate-46 (`spec-anchor-existence`) at **full scope**:

```
[gate-46] spec-anchor-existence: FAIL — 10 unresolved @spec finding(s) from 7 distinct target(s)
```

## Root cause — one cause, not ten

All 10 findings came from tags addressing `openspec/changes/<name>/...`. Those change dirs were **archived** to `openspec/changes/archive/<date>-<name>/`.

The gate's resolver *follows* that move, so it found the archived `spec.md` and then failed on the **anchor**: the requirement ids the tags cite (`#REQ-001`, `#req-crm-email-matching`) are headings in each change's `context-brief.md` — they were never in `spec.md` at all. So this was never "the file is missing"; it was "the anchor does not exist in any spelling of the target".

This is exactly what this repo's own `SpecTagSniff` already documents: tags written against a change dir *"dangle by construction"*.

## What changed

Every one of these capabilities already has a canonical home under `openspec/specs/`. The tags now point there, using the `#requirement-<slug>` form that sniff prescribes — which is also the anchor GitHub publishes for a `### Requirement: ...` heading, so these links now resolve in a browser as well as in the gate.

| old anchor | new canonical anchor |
|---|---|
| `#REQ-001` | `#requirement-policy-resolution-at-object-creation` |
| `#REQ-002` | `#requirement-holiday-aware-deadline-calculation` |
| `#REQ-004` | `#requirement-escalation-chain-execution` |
| `#REQ-010` | `#requirement-holiday-calendar-pluggability` |
| `#req-crm-email-matching` | `#requirement-emails-must-be-automatically-linked-to-crm-contacts` |
| `#req-per-user-matching-settings` | `#requirement-email-sync-must-be-configurable-per-user` |

Each mapping was checked semantically, not just mechanically — e.g. `EmailSyncControllerTest` covers per-user sync settings CRUD, and now cites the per-user requirement.

`ProjectTaskHierarchyTest` is the one finding with **no** canonical home: `project-task-hierarchy` was archived without its spec being synced to `openspec/specs/`, and the archived change stores it as a flat `specs.md` rather than `specs/<capability>/spec.md`, so no spelling resolved. It now addresses the archived file directly.

## Both directions proven

Using the gate's own checker (`check_spec_anchors.py`):

| arm | findings |
|---|---|
| before | **10** |
| after | **0** |
| planted true positive (`#requirement-planted-true-positive-anchor`) | **1**, naming that exact tag |
| reverted | **0** |

Full-scope gate run in an isolated clone carrying only this patch confirms `[gate-46]` no longer appears in the FAIL list, and **no other gate's count moved**.

## No gate was weakened

No tag removed, no `@spec exclude` added, no threshold touched. Every new target was verified to exist *and* to contain its anchor.

## Flagged for a human — deliberately NOT done here

- **2246 `@spec` tags across 128 change dirs still point at `openspec/changes/…`** (of 3116 total; 812 already canonical). These are *not* currently gate failures — the resolver handles archived dirs — so this PR does **not** mass-rewrite them. That remains an open decision.
- **`project-task-hierarchy` has no canonical spec.** Promoting the archived `specs.md` to `openspec/specs/` would add **39 Scenario blocks** to gate-19's full-scope backlog, so it is left for a deliberate decision.
- Several dormant-code docblocks cite **`pipelinq#401`** as their tracking issue, but that issue is *"Implement: Proposal: crm-workflow-automation"* — an unrelated reference.