### PR TITLE
test(e2e): close 12 gate-19 findings in four toolchain/meta capabilities

### DIFF
--- a/openspec/specs/activity-stream-publishing/spec.md
+++ b/openspec/specs/activity-stream-publishing/spec.md
@@ -32,6 +32,7 @@ is a legitimate first-party API and MUST NOT be flagged by gate-27 Rule E.
 
 #### Scenario: Gate-27 does not flag the first-party Activity API
 
+- @e2e exclude this scenario's subject is A STATIC ANALYSER, not the application: its WHEN is "the gate-27 detector scans `lib/Service/ActivityService.php`". No Nextcloud is running when that happens and no browser is involved, so an e2e test could not observe the thing being asserted. It is also already enforced, on every PR and by the exact mechanism the scenario names — hydra gate-27 (`no-phantom-cross-app-rpc`) runs in the `Hydra Gates` job and currently reports PASS on this tree (measured at full scope: `[gate-27] no-phantom-cross-app-rpc: PASS`). A regression that made Rule E flag `$this->activityManager->publish()` would turn that job red, which is a stronger signal than any test here could give.
 - WHEN the gate-27 detector scans `lib/Service/ActivityService.php`
 - THEN it MUST NOT report any `phantom-foundation-call` finding for
   `$this->activityManager->publish()` or the internal `$this->publish()` helper

--- a/openspec/specs/activity-stream-publishing/spec.md
+++ b/openspec/specs/activity-stream-publishing/spec.md
@@ -32,7 +32,6 @@ is a legitimate first-party API and MUST NOT be flagged by gate-27 Rule E.
 
 #### Scenario: Gate-27 does not flag the first-party Activity API
 
-- @e2e exclude this scenario's subject is A STATIC ANALYSER, not the application: its WHEN is "the gate-27 detector scans `lib/Service/ActivityService.php`". No Nextcloud is running when that happens and no browser is involved, so an e2e test could not observe the thing being asserted. It is also already enforced, on every PR and by the exact mechanism the scenario names — hydra gate-27 (`no-phantom-cross-app-rpc`) runs in the `Hydra Gates` job and currently reports PASS on this tree (measured at full scope: `[gate-27] no-phantom-cross-app-rpc: PASS`). A regression that made Rule E flag `$this->activityManager->publish()` would turn that job red, which is a stronger signal than any test here could give.
 - WHEN the gate-27 detector scans `lib/Service/ActivityService.php`
 - THEN it MUST NOT report any `phantom-foundation-call` finding for
   `$this->activityManager->publish()` or the internal `$this->publish()` helper

--- a/openspec/specs/contract-renewal-tracking/spec.md
+++ b/openspec/specs/contract-renewal-tracking/spec.md
@@ -22,6 +22,7 @@ The system MUST register a `contract` schema in the pipelinq register with contr
 
 #### Scenario: Semantic kind declaration present
 
+- @e2e exclude asserts a STATIC DECLARATION in a register fragment, not a runtime behaviour: `lib/Settings/register.d/96-contract-renewal.json:30` carries `"https://openregister.app/ns#Contract"` in the ADR-051 dialect form (verified). Nothing a user can do in a browser changes what that file declares, and the declaration is imported verbatim — so an e2e test would be re-reading the same JSON through a longer pipe. Enforced mechanically instead by the register import and by hydra gate-54 (`relation-dialect`), both of which run on every PR.
 - WHEN the registered `contract` schema is inspected
 - THEN it MUST carry the `ns#Contract` implements declaration in the ADR-051 dialect form
 
@@ -208,6 +209,7 @@ The system MUST provide a "Send to invoicing" action on an `active` contract tha
 
 #### Scenario: Failed handoff leaves the contract untouched
 
+- @e2e exclude fault injection — the GIVEN is "an implementer whose target creation fails", and there is no way to make the handoff engine throw from a browser against a live instance without breaking the instance for every other spec in the suite. Covered by `SemanticHandoffServiceTest::testHandoffFailsOnEngineThrow` (the engine raises mid-handoff) and `::testHandoffFailsWhenEngineAbsent` (no implementer bound at all); both were opened and confirmed. The rollback invariant they assert — the contract row is left unchanged — is a service-layer property with no distinct UI surface beyond the generic error the user sees.
 - GIVEN an implementer whose target creation fails
 - WHEN the handoff is triggered
 - THEN the contract MUST remain unchanged and the failure MUST be reported to the user

--- a/openspec/specs/marketing-docs/spec.md
+++ b/openspec/specs/marketing-docs/spec.md
@@ -9,6 +9,16 @@ Documents the marketing blast feature in the CHANGELOG and a user guide. The use
 ## Requirements
 ### Requirement: Feature Documentation
 
+@e2e exclude both scenarios assert the CONTENT OF FILES IN THIS REPOSITORY — a
+CHANGELOG entry and `docs/user/marketing-blasts.md` — not any behaviour of a
+running instance. Nothing a browser can do to a Nextcloud changes what those
+files say, so an e2e test could not tell a documented feature from an
+undocumented one. Verified present rather than assumed: `docs/user/marketing-blasts.md`
+and `docs/user/marketing-blasts.nl.md` both exist (that pair IS the Dutch/English
+requirement), and `CHANGELOG.md` carries the marketing-blast entry including the
+revenue-attribution line. The honest enforcement for a documentation requirement
+is a file check in CI, not a browser.
+
 The marketing blast feature SHALL be documented in the CHANGELOG and a
 user guide.
 

--- a/openspec/specs/marketing-testing/spec.md
+++ b/openspec/specs/marketing-testing/spec.md
@@ -9,6 +9,17 @@ Defines the test coverage for the marketing blast services. PHPUnit unit tests c
 ## Requirements
 ### Requirement: Service Unit Test Coverage
 
+@e2e exclude these three scenarios are ABOUT THE UNIT SUITE ITSELF — each one's
+GIVEN is a named PHPUnit test class and its WHEN is "the suite runs". The thing
+required to exist IS a test, so demanding a browser test that the test exists
+is circular: it would assert a property of the repository, not of a running
+instance. All three classes were opened and confirmed before this was written —
+`tests/Unit/Service/SegmentServiceTest.php`,
+`tests/Unit/Service/ComplianceServiceTest.php`,
+`tests/Unit/Service/BlastServiceTest.php` — and they run in CI on every one of
+the PHPUnit matrix legs. The user-visible behaviour these services drive is
+covered separately by the `marketing-blast` and `marketing-ui` capabilities.
+
 The marketing services SHALL have PHPUnit unit tests covering rule
 validation/evaluation, consent gating + template validation + withdrawal,
 and send/dispatch/A-B/throttle behaviour.
@@ -32,6 +43,15 @@ and send/dispatch/A-B/throttle behaviour.
 - **THEN** it SHALL cover sendBlast (queue creation, fail on missing consent), createAbVariant, dispatchBlastDeliveries (openconnector call + rate limit), and updateBlastTotals
 
 ### Requirement: End-to-End Integration Test
+
+@e2e exclude the requirement is that an INTEGRATION TEST exists, and it does:
+`tests/Integration/BlastWorkflowTest.php` (opened and confirmed) drives segment
+creation → blast → send against the real `ObjectService` and asserts that
+`BlastDelivery` rows are created for compliant contacts and skipped for
+non-compliant ones. A Playwright test could not satisfy this requirement even in
+principle — "using the real ObjectService" is a statement about which PHP
+collaborator is in play, which is invisible from a browser, and the requirement
+names the integration tier specifically.
 
 There SHALL be an integration test covering segment creation through blast
 send using the real ObjectService.

--- a/openspec/specs/marketing-verification/spec.md
+++ b/openspec/specs/marketing-verification/spec.md
@@ -9,6 +9,21 @@ Defines the end-to-end verification and pre-merge checklist for the marketing bl
 ## Requirements
 ### Requirement: End-to-End Verification Passes
 
+@e2e exclude this is a PRE-MERGE VERIFICATION CHECKLIST, not a behavioural
+requirement — three of its four scenarios have "WHEN verification runs" or
+"WHEN `composer test` runs" as their trigger, i.e. their subject is the release
+process, and one ("Tests green with coverage") asserts a coverage percentage,
+which no browser can observe. The behaviour the remaining items re-state is
+already specified — and covered — in the capabilities that own it:
+`marketing-compliance` ("Send blocked with missing consent list", "Save
+rejected if unsubscribe token missing", "Withdrawal updates consent and skips
+queued deliveries"), `marketing-ui` ("Missing-consent modal on send"),
+`marketing-blast-delivery` (the unsubscribe webhook) and `marketing-analytics`
+(the significance test). All of those headings were read to confirm the overlap
+before this was written. Anchoring a second e2e test here would assert the same
+behaviour twice under a heading that is not its canonical home, and the two
+copies would drift.
+
 The marketing blast feature SHALL be verified end to end before the chain is
 considered complete.
 
@@ -39,6 +54,18 @@ considered complete.
 - **AND** the unsubscribe SHALL withdraw consent within 60 seconds and future sends SHALL skip the contact
 
 ### Requirement: Pre-Merge Security Checklist
+
+@e2e exclude the subject here is a CHECKLIST COMPLETED BEFORE A PR IS
+SUBMITTED — "the pre-merge checklist SHALL confirm …" — so the thing required
+to happen occurs outside any running instance and before the code is merged. A
+browser test cannot observe whether a reviewer ticked a box. The pattern
+invariants it lists are the ones already enforced mechanically on every PR by
+the hydra gate suite (ObjectService-only CRUD by gate-20 `or-objectservice-api`
+and gate-23 `or-abstraction-anti-patterns`; the auth posture of every route by
+gates 5, 7, 9; consent gating and template enforcement by the
+`marketing-compliance` capability's own scenarios) — enforcement that runs
+whether or not anyone remembers the checklist, which is strictly stronger than
+the checklist itself.
 
 The pre-merge checklist SHALL confirm the security and pattern invariants
 before the PR is submitted.

--- a/openspec/specs/navigation-ia/spec.md
+++ b/openspec/specs/navigation-ia/spec.md
@@ -3,6 +3,30 @@
 ## Purpose
 TBD - created by archiving change pipelinq-hr-moveout-and-admin-dedupe. Update Purpose after archive.
 ## Requirements
+
+@e2e exclude ⚠️ EVERY SCENARIO BELOW DESCRIBES NAVIGATION THAT NO LONGER EXISTS,
+and it was removed deliberately — so these cannot be closed by a test, and the
+right fix is to refresh this spec rather than to write one. Measured on the
+current tree: `grep -rn hrmq` over `src/`, `lib/` and `appinfo/` returns
+NOTHING, and `src/manifest.json` has no `Timesheet approval` or `Expenses`
+entry among its 25 menu entries. Git says why: this capability was implemented
+by `cd4788bf8` (archived change `2026-06-23-pipelinq-hr-moveout-and-admin-dedupe`)
+and then **superseded three weeks later** by `9ca45213c` (2026-07-03), *"chore(nav):
+drop Timesheet/Expenses/Restart-tutorial from the menu … these are static
+deep-links into the hrmq app; they don't belong in pipelinq's nav."* REQ-3's
+Settings list is stale for the same reason: the foldout is built from
+`src/menu-layout.json`, whose `settingsSection` is now
+`["Pipelines", "SettingsIntegrationsCaption", "ExportJobs"]`, and whose own
+`_settingsSectionNote` records the current rule — *"Only entries that are still
+app-side config live here"* — so `AVG-verzoeken`, `Master data`, `Data quality`
+and `Duplicates` are out by decision, not by accident. A test written against
+the text below would fail against three deliberate choices; an exclusion
+claiming coverage would be false. Filed for a spec refresh as
+[ConductionNL/pipelinq#765](https://github.com/ConductionNL/pipelinq/issues/765).
+(Two clauses DO still hold and are worth keeping when
+this is rewritten: there is no top-level `Administration` group, and pipelinq
+renders no expenses or timesheet-approval page of its own.)
+
 ### Requirement: Timesheet approval MUST deep-link to the hrmq app
 
 Pipelinq MUST NOT host a timesheet-approval surface. The left-nav MUST

--- a/openspec/specs/test-harness/spec.md
+++ b/openspec/specs/test-harness/spec.md
@@ -5,6 +5,19 @@ TBD - created by archiving change pipelinq-test-harness-or-stub-fix. Update Purp
 ## Requirements
 ### Requirement: Deterministic OpenRegister-stub precedence in the unit suite
 
+@e2e exclude both scenarios are about THE PHPUNIT SUITE'S OWN CLASS-LOADING —
+which file `OCA\OpenRegister\Service\ObjectService` resolves to inside a
+`phpunit` process, on a bare host versus inside a Nextcloud with the real
+OpenRegister enabled. That is a property of a test run, observed from inside
+that test run; a browser is not present in either mode and has no way to see
+which autoloader won. The stubs the scenarios name were confirmed to exist
+(`tests/Stubs/Db/ObjectEntity.php`, `tests/Stubs/Service/`), and BOTH run modes
+are genuinely exercised in CI: the `PHPUnit` matrix legs run inside a Nextcloud
+with OpenRegister installed via `additional-apps`, which is the second scenario,
+and the suite's own bootstrap is what the first one asserts. The honest
+enforcement here is the suite passing in both modes — which is what the matrix
+already measures — not a Playwright test.
+
 The pipelinq PHPUnit unit suite SHALL resolve its OpenRegister **stub** classes
 (`OCA\OpenRegister\Db\ObjectEntity`, `OCA\OpenRegister\Service\ObjectService`) deterministically,
 producing the same result whether or not a real OpenRegister app is autoloadable in-process. The
@@ -34,6 +47,17 @@ is unavailable is skipped, never fatal).
 - **AND** the real OpenRegister classes NOT stubbed by the suite SHALL remain loadable
 
 ### Requirement: OpenRegister stub override signatures stay declaration-compatible
+
+@e2e exclude this scenario asserts a PHP DECLARATION-COMPATIBILITY property of a
+test double — that an anonymous class extending `ObjectService` declares
+`findAll(array $config = [], bool $_rbac = true, bool $_multitenancy = true): array`.
+It is enforced by the language itself: an incompatible override is a fatal
+error at class-declaration time, so the suite cannot load, let alone pass. A
+browser test cannot observe a signature, and there is no running instance
+involved — the failure this guards against happens before any request exists.
+The `PHPUnit` matrix legs run with the real OpenRegister autoloadable, which is
+exactly the configuration in which an incompatible override would fatal, so the
+guard is live in CI.
 
 Any test double that `extends` a real OpenRegister class (rather than using a PHPUnit mock) SHALL
 declare method overrides whose signatures are compatible with BOTH the OpenRegister stub and the

--- a/tests/e2e/spec-coverage/settings-preferences-api.spec.ts
+++ b/tests/e2e/spec-coverage/settings-preferences-api.spec.ts
@@ -83,16 +83,27 @@ async function newIdentity(authenticated: boolean): Promise<APIRequestContext> {
  */
 async function assertCallerIs(ctx: APIRequestContext, expected: string | null): Promise<void> {
 	const res = await ctx.get('/ocs/v2.php/cloud/user?format=json')
+	const body = await res.json().catch(() => null)
+	// The OCS layer signals "not logged in" as HTTP 200 with
+	// `ocs.meta.statuscode: 997`, NOT as a 401 — so the HTTP status is the
+	// wrong channel to read here. An earlier revision of this helper asserted
+	// `status !== 200` and failed on CI against a correctly-anonymous context,
+	// which is the guard working and reporting the wrong reason. Read the
+	// resolved identity itself: absent uid means nobody is authenticated,
+	// whichever way this Nextcloud version chooses to say so.
+	const uid = body?.ocs?.data?.id ?? null
+
 	if (expected === null) {
 		expect(
-			res.status(),
-			'this context must NOT resolve to a Nextcloud session — if it does, a cookie leaked in and the 401 assertion below proves nothing',
-		).not.toBe(200)
+			uid,
+			'this context must NOT resolve to a Nextcloud user — if it does, a cookie leaked in from another identity and the refusal assertion below proves nothing',
+		).toBeNull()
 		return
 	}
-	expect(res.status(), `caller identity probe must succeed for ${expected}`).toBe(200)
-	const body = await res.json()
-	expect(body?.ocs?.data?.id, `this context must be acting as ${expected}`).toBe(expected)
+	expect(
+		uid,
+		`this context must be acting as ${expected}; a different uid (or none) means the jar is shared or the credentials did not authenticate, and the assertions below measure the wrong caller`,
+	).toBe(expected)
 }
 
 test.describe('settings/preferences documented operations', () => {

--- a/tests/e2e/spec-coverage/settings-preferences-api.spec.ts
+++ b/tests/e2e/spec-coverage/settings-preferences-api.spec.ts
@@ -1,0 +1,178 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Pipelinq Contributors
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * Gate-19 e2e coverage for the three `admin-settings` requirements that talk
+ * about "the documented operations" of the settings / preferences /
+ * configuration-loading layer rather than about a screen:
+ *
+ *   - Settings and configuration services — documented operations
+ *   - Settings and configuration services — results derived from current CRM state
+ *   - Settings and configuration services — defensive handling of absent or invalid input
+ *
+ * WHY A TEST AND NOT AN EXCLUSION
+ * -------------------------------
+ * The obvious exclusion for these — "covered by PHPUnit" — would have been
+ * FALSE. `getPreference` and `setPreference` are the operations the first
+ * requirement names, and `grep -rln "getPreference\|setPreference" tests/`
+ * returns NOTHING: no test in this repository references either. They are also
+ * routed HTTP endpoints (`appinfo/routes.php` → `GET`/`PUT
+ * /api/preferences/{key}`), so they are reachable end-to-end and there is no
+ * good reason not to reach them. An exclusion naming coverage that does not
+ * exist is worth less than the finding it closes.
+ *
+ * All three requirements are asserted by ONE round trip, deliberately:
+ *   - "the operation MUST execute and return a result consistent with the
+ *     current implementation" — the write and the read both answer the
+ *     documented `{value}` shape;
+ *   - "its output MUST change when the underlying data changes" — the same key
+ *     is read three times (unset → set → cleared) and answers differently each
+ *     time. Reading once and asserting a literal would pass against a
+ *     hard-coded response, which is the exact thing that requirement forbids;
+ *   - "MUST return a safe default or a validation result rather than crashing"
+ *     — a key that sanitises to empty answers 400 with a message, not a 500.
+ *
+ * ISOLATED COOKIE JAR PER IDENTITY
+ * --------------------------------
+ * The anonymous assertion is only worth its green if the request really is
+ * anonymous. Nextcloud resolves a session cookie BEFORE it looks at an
+ * Authorization header, so a context reused after an authenticated call runs as
+ * that user and a "401 for anonymous" test silently becomes a 200. Playwright's
+ * `request` fixture is one context for the whole test, so it is not used here;
+ * each identity gets a fresh jar, and `assertCallerIs()` proves — in the same
+ * chain, against `/ocs/v2.php/cloud/user` — who the server thinks is calling.
+ *
+ * @spec openspec/specs/admin-settings/spec.md
+ */
+
+import { test, expect, request as playwrightRequest, type APIRequestContext } from '@playwright/test'
+
+import { resolveBaseUrl } from '../base-url'
+
+const ADMIN_USER = process.env.ADMIN_USER ?? process.env.NC_ADMIN_USER ?? 'admin'
+const ADMIN_PASS = process.env.ADMIN_PASSWORD ?? process.env.NC_ADMIN_PASS ?? 'admin'
+
+const API_BASE = '/index.php/apps/pipelinq/api'
+
+/**
+ * A fresh APIRequestContext with its own cookie jar — one per identity, never
+ * shared. See the header note on why this is load-bearing.
+ *
+ * @param authenticated Whether to send admin HTTP Basic credentials.
+ * @return an isolated request context; the caller disposes it.
+ */
+async function newIdentity(authenticated: boolean): Promise<APIRequestContext> {
+	const headers: Record<string, string> = {
+		// Nextcloud's Request::passesCSRFCheck() short-circuits on this header.
+		// A Basic-auth request carries no session cookie, so the strict-cookie
+		// precondition holds and the PUT below is not rejected as a CSRF failure.
+		'OCS-APIRequest': 'true',
+		Accept: 'application/json',
+	}
+	if (authenticated) {
+		headers.Authorization = `Basic ${Buffer.from(`${ADMIN_USER}:${ADMIN_PASS}`).toString('base64')}`
+	}
+	return playwrightRequest.newContext({ baseURL: resolveBaseUrl(), extraHTTPHeaders: headers })
+}
+
+/**
+ * Prove, in the same request chain, who the server thinks is calling.
+ *
+ * @param ctx      The context to interrogate.
+ * @param expected The uid expected, or null for "must not be authenticated".
+ */
+async function assertCallerIs(ctx: APIRequestContext, expected: string | null): Promise<void> {
+	const res = await ctx.get('/ocs/v2.php/cloud/user?format=json')
+	if (expected === null) {
+		expect(
+			res.status(),
+			'this context must NOT resolve to a Nextcloud session — if it does, a cookie leaked in and the 401 assertion below proves nothing',
+		).not.toBe(200)
+		return
+	}
+	expect(res.status(), `caller identity probe must succeed for ${expected}`).toBe(200)
+	const body = await res.json()
+	expect(body?.ocs?.data?.id, `this context must be acting as ${expected}`).toBe(expected)
+}
+
+test.describe('settings/preferences documented operations', () => {
+
+	// @e2e openspec/specs/admin-settings/spec.md#documented-operations-are-available
+	// @e2e openspec/specs/admin-settings/spec.md#results-reflect-live-state
+	test('a preference round-trips, and the read changes when the stored value changes', async () => {
+		const ctx = await newIdentity(true)
+		try {
+			await assertCallerIs(ctx, ADMIN_USER)
+
+			// Namespaced per run so a re-run never reads a previous run's value —
+			// and lowercase/hyphen only, because sanitizeKey() strips everything
+			// outside [a-z0-9-] and a key that silently changed shape would make
+			// the read below miss for the wrong reason.
+			const key = `e2e-pref-${Date.now()}`
+			const value = `v-${Date.now()}`
+
+			// 1. Unset — the documented default is null, not an error and not ''.
+			const before = await ctx.get(`${API_BASE}/preferences/${key}`)
+			expect(before.status(), 'reading an unset preference is a normal read').toBe(200)
+			expect((await before.json()).value, 'an unset preference reads back as null').toBeNull()
+
+			// 2. Written.
+			const write = await ctx.put(`${API_BASE}/preferences/${key}`, { data: { value } })
+			expect(write.status()).toBe(200)
+			expect((await write.json()).value).toBe(value)
+
+			// 3. Read back through a FRESH request, so this asserts persisted
+			//    state rather than the echo of the write.
+			const after = await ctx.get(`${API_BASE}/preferences/${key}`)
+			expect(after.status()).toBe(200)
+			expect(
+				(await after.json()).value,
+				'the read must be derived from stored state — this is the "no hard-coded or stubbed responses" requirement',
+			).toBe(value)
+
+			// 4. Cleared. An empty value CLEARS rather than storing '', so a
+			//    cleared preference and a never-set one must read identically.
+			const clear = await ctx.put(`${API_BASE}/preferences/${key}`, { data: { value: '' } })
+			expect(clear.status()).toBe(200)
+			const afterClear = await ctx.get(`${API_BASE}/preferences/${key}`)
+			expect(
+				(await afterClear.json()).value,
+				'a cleared preference must read back as null, identical to one that was never set',
+			).toBeNull()
+		} finally {
+			await ctx.dispose()
+		}
+	})
+
+	// @e2e openspec/specs/admin-settings/spec.md#missing-input-does-not-crash-the-flow
+	test('an unusable key is a validation result, not a crash, and anonymous is refused', async () => {
+		const admin = await newIdentity(true)
+		const anon = await newIdentity(false)
+		try {
+			await assertCallerIs(admin, ADMIN_USER)
+			await assertCallerIs(anon, null)
+
+			// `sanitizeKey()` strips everything outside [a-z0-9-], so a key made
+			// entirely of punctuation sanitises to the empty string — the
+			// "absent or invalid input" case. It must be answered, not thrown on.
+			const unusable = encodeURIComponent('!!!')
+			for (const res of [
+				await admin.get(`${API_BASE}/preferences/${unusable}`),
+				await admin.put(`${API_BASE}/preferences/${unusable}`, { data: { value: 'x' } }),
+			]) {
+				expect(res.status(), 'an unusable key is a validation outcome (400), never a 500').toBe(400)
+				expect(res.status(), 'the surrounding flow must not crash').toBeLessThan(500)
+				expect((await res.json()).message).toBeTruthy()
+			}
+
+			// The endpoints are @NoAdminRequired, which means "any logged-in
+			// user" — not "anyone". Asserted from a jar that has never
+			// authenticated.
+			const res = await anon.get(`${API_BASE}/preferences/e2e-anon-probe`)
+			expect(res.status(), 'a per-user preference must not be readable without a session').not.toBe(200)
+		} finally {
+			await admin.dispose()
+			await anon.dispose()
+		}
+	})
+})

--- a/tests/e2e/spec-coverage/settings-preferences-api.spec.ts
+++ b/tests/e2e/spec-coverage/settings-preferences-api.spec.ts
@@ -72,7 +72,27 @@ async function newIdentity(authenticated: boolean): Promise<APIRequestContext> {
 	if (authenticated) {
 		headers.Authorization = `Basic ${Buffer.from(`${ADMIN_USER}:${ADMIN_PASS}`).toString('base64')}`
 	}
-	return playwrightRequest.newContext({ baseURL: resolveBaseUrl(), extraHTTPHeaders: headers })
+	return playwrightRequest.newContext({
+		baseURL: resolveBaseUrl(),
+		extraHTTPHeaders: headers,
+		// AN EMPTY JAR HAS TO BE ASKED FOR, EXPLICITLY.
+		//
+		// This project's playwright.config.ts sets `use.storageState` (written
+		// by globalSetup, which logs in as admin). A context created without
+		// naming `storageState` inherits it — so a context intended to be
+		// anonymous starts holding the ADMIN SESSION COOKIE, and since a valid
+		// cookie outranks a later Authorization header, it stays admin no
+		// matter what Basic credentials are sent.
+		//
+		// Measured, not assumed: the byte-identical helper passes in portaliq,
+		// whose config declares NO storageState, and failed here with
+		// `assertCallerIs(anon, null)` reading back `"admin"`. Same code, two
+		// repos, one difference. Without this line the "anonymous cannot read
+		// a per-user preference" assertion below would have been made BY THE
+		// ADMIN — the exact false green the identity guard exists to catch,
+		// and which it did catch.
+		storageState: { cookies: [], origins: [] },
+	})
 }
 
 /**


### PR DESCRIPTION
Part of clearing hydra **gate-19 (e2e-coverage)** on pipelinq. This branch takes a reserved slice of the finding list so it can run alongside the main gate-19 branch without collision; the two branches touch disjoint capabilities.

**Measured: gate-19 369 → 357.** Exactly 12, matching the four capabilities' scenario counts.

## What is in here

Four capabilities whose scenarios are not about a running instance at all, so none of them can be closed by a browser test. Each carries a reason-bearing `@e2e exclude`, and **every artefact a reason cites was opened and confirmed before the sentence was written** — a reason naming a test that does not exist is worth less than no reason at all.

| capability | n | why no browser can observe it | verified |
|---|---|---|---|
| `marketing-docs` | 2 | asserts the content of `CHANGELOG.md` and `docs/user/marketing-blasts.md` | both files present, incl. `.nl.md` — that pair **is** the Dutch/English requirement |
| `marketing-testing` | 4 | every GIVEN is a PHPUnit class and every WHEN is "the suite runs"; requiring a browser test that a test exists is circular | `SegmentServiceTest`, `ComplianceServiceTest`, `BlastServiceTest`, `Integration/BlastWorkflowTest` all opened |
| `test-harness` | 3 | which file `OCA\OpenRegister\Service\ObjectService` resolves to inside a `phpunit` process, and whether an override signature is declaration-compatible | stubs present; an incompatible override fatals **before any request exists**, and both run modes are already exercised by the PHPUnit matrix |
| `navigation-ia` | 3 | describes a left-nav that was deliberately removed — see below | `git log -S` |

## `navigation-ia` is spec drift, not a coverage gap

All three scenarios are unsatisfiable, and each because of a *deliberate later decision*:

```
$ grep -rn "hrmq" --include=*.js --include=*.json --include=*.vue --include=*.php src/ lib/ appinfo/
(nothing)
```

None of the 25 manifest menu entries is `Timesheet approval` or `Expenses`. The capability was implemented by `cd4788bf8` and **superseded three weeks later** by `9ca45213c` (2026-07-03):

> chore(nav): drop Timesheet/Expenses/Restart-tutorial from the menu — these are static deep-links into the hrmq app; **they don't belong in pipelinq's nav.**

REQ-3's Settings list is stale the same way: that foldout is built from `src/menu-layout.json`, whose `settingsSection` is now `["Pipelines", "SettingsIntegrationsCaption", "ExportJobs"]` and whose own `_settingsSectionNote` records the current rule — *"Only entries that are still app-side config live here."*

A test written against the current text would fail against three deliberate choices; an exclusion claiming coverage would be false. The exclusion says exactly that, names the superseding commit, and flags the two clauses still worth keeping in a rewrite (no top-level `Administration` group; pipelinq renders no expenses or timesheet-approval page of its own). Filed for a spec refresh as **#765**.

## Deliberately NOT closed

`commercial-dashboard`'s two findings — `date range is a compact pills control` and `charts sit directly below the KPI rows` — are genuinely browser-observable and deserve real tests. I did not write them because **the first would have failed**: `CnDashboardPage` in the pinned `@conduction/nextcloud-vue@2.2.0-vue3.9` gates the pill row on `dateRange?.control === 'pills'`, and `grep -n '"control"' src/manifest.json` returns nothing, so the pills never render. Filed as **#766**.

They are left as open gate-19 findings rather than closed with an exclusion. "The feature is not wired" is not a reason a coverage exclusion should ever record.

## A trap worth writing down

The shared checkout's `node_modules` carries `@conduction/nextcloud-vue@1.0.0-beta.197` while `package.json` pins `2.2.0-vue3.9` — a different major line with different markup. Selectors read from the installed tree were wrong (the beta still ships the old `cn-date-range-picker-preset` *select* that the spec says must be gone). `npm pack` the pinned version into a scratch dir and read `package/src/` instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Update — second commit

**gate-19 on this branch: 369 → 346 (23 closed).** Every number read from the gate's own stdout on a quiesced tree.

### A real test where the obvious exclusion would have been a lie

`admin-settings`' three "documented operations" requirements name `getPreference` and `setPreference`. The natural exclusion — *"covered by PHPUnit"* — is **false**:

```
$ grep -rln "getPreference\|setPreference" tests/
(nothing)
```

No test in this repository references either, and they are routed HTTP endpoints (`GET`/`PUT /api/preferences/{key}`). So they got a test instead: `tests/e2e/spec-coverage/settings-preferences-api.spec.ts`, two tests covering all three scenarios.

- One round trip reads the **same key three times** — unset → set → cleared — and asserts it answers differently each time. That is what makes it a test of *"results derived from current CRM state"*; reading once and asserting a literal would pass against exactly the hard-coded response that requirement forbids.
- A key of pure punctuation (`sanitizeKey` strips everything outside `[a-z0-9-]`) must answer **400 with a message, not 500** — the "absent or invalid input" requirement — and an anonymous jar must not read a per-user preference.

Isolated cookie jar per identity, with `assertCallerIs()` proving against `/ocs/v2.php/cloud/user` who the server thinks is calling: Nextcloud resolves a session cookie **before** the `Authorization` header, so a shared context turns "401 for anonymous" into a silent 200.

### Eight more exclusions, each naming something opened first

| capability | n | reason family |
|---|---|---|
| `contract-renewal-tracking` | 2 | a static `ns#Contract` declaration verified at `register.d/96-contract-renewal.json:30`; a fault-injection rollback covered by `SemanticHandoffServiceTest::testHandoffFailsOnEngineThrow` / `::testHandoffFailsWhenEngineAbsent` |
| `activity-stream-publishing` | 1 | the scenario's subject is a **static analyser** — *"WHEN the gate-27 detector scans…"*. No instance is running. Already enforced: gate-27 measured `PASS` on this tree |
| `marketing-verification` | 5 | a pre-merge **checklist**; three of five trigger on "WHEN verification runs" / "WHEN `composer test` runs", one asserts a coverage percentage. The behaviour the rest restate is owned by `marketing-compliance`, `marketing-ui`, `marketing-blast-delivery`, `marketing-analytics` — headings read to confirm the overlap |

Left open deliberately: `activity-stream-publishing`'s other scenario — *"the published activity MUST appear in the `oc_activity` stream"* is genuinely observable and deserves a real test.

### On measurement discipline

An intermediate reading came out **350** where I had predicted 354. Rather than accept it, I read the gate's own detail log scenario by scenario: seven exclusions had landed before the scan, the eighth after — I had been editing while it ran. Re-measured on a quiesced tree: **349**, then **346** after the preferences test. Both exactly as predicted.

Playwright collects **216 tests in 44 files** (was 214 in 43).

**A harness note:** `npx --package=@playwright/test … --list` fails here with *"Playwright Test did not expect test.describe() to be called here"* — pipelinq already carries `@playwright/test` in `node_modules`, so forcing a second copy via `NODE_PATH` produces a dual-package clash that looks like a syntax error in every spec file. Plain `npx playwright test --list` works.
