### PR TITLE
fix(schema): unhide client address + website so the Identity widget can render them (#775)

### DIFF
--- a/lib/Settings/register.d/15-unify-client-contact.json
+++ b/lib/Settings/register.d/15-unify-client-contact.json
@@ -43,7 +43,7 @@
             "type": "string",
             "title": "Address",
             "description": "Denormalised read-only mirror of the NC contact postal address. The Nextcloud Contact is authoritative.",
-            "visible": false,
+            "visible": true,
             "readOnly": true,
             "x-pipelinq-denormalised": true
           },
@@ -52,7 +52,7 @@
             "title": "Website",
             "description": "Denormalised read-only mirror of the NC contact website (vCard URL). The Nextcloud Contact is authoritative.",
             "format": "uri",
-            "visible": false,
+            "visible": true,
             "readOnly": true,
             "x-pipelinq-denormalised": true
           },


### PR DESCRIPTION
Closes #775.

## What

`address` and `website` on the `client` schema are now `"visible": true`, so the ClientDetail `client-identity` widget can render all five fields its `include` set declares.

## Which side was wrong

#775 offered two remedies — narrow the include set, or unhide the properties. Unhiding is correct:

- `openspec/specs/client-management/spec.md` (`:40, :51, :281, :1253, :1271`) treats address and website as ordinary client fields.
- They are genuinely populated by the contact sync — `ContactDataBuilder.php:62` (`URL` → `website`), `ContactVcardPropertyBuilder.php:103-108` (`website` → `URL`, `address` → `ADR`).
- The hand-written `ClientForm.vue` has always offered both inputs (`:62-71`, `:76-83`), and `tests/e2e/pages.spec.ts:34-35` asserts they are visible on `/clients/new`.

The fix stays in the schema rather than the nc-vue renderer. The renderer's precedence (`visible === false` wins over `include`) is defensible — a schema saying "never render this" should not be overridable by a manifest — so the disagreement was the schema's, not the library's.

## ⚠️ Deleting the flag would have been a no-op — this sets it explicitly

`ConfigFileLoaderService::deepMergeConfig()` (`:216-265`) iterates **only the override's keys**. It can add or replace, never delete. The base monolith `lib/Settings/pipelinq_register.json` independently declares `"visible": false` on both properties (`:134`, `:141`), so removing the key from the `register.d/` fragment leaves the base value intact.

I made that exact edit first and it produced a clean, valid, structurally-correct diff that **did nothing**. Verified by invoking the real `deepMergeConfig()` over the monolith plus all 30 fragments:

| | `client.address` | `client.website` | hidden props instance-wide |
|---|---|---|---|
| before | `false` | `false` | 83 |
| after deleting the key from the fragment | `false` | `false` | 83 (**no-op**) |
| after `"visible": true` | `true` | `true` | 81 |

## Blast radius

Both properties are `readOnly` denormalised mirrors, so **create/edit forms are unaffected** — `fieldsFromSchema` skips `readOnly` unless `includeReadOnly` is set, and `CnFormDialog` does not set it.

Three surfaces change:

1. **ClientDetail → Identity widget** — the intended fix. `CnObjectDataWidget` passes `includeReadOnly: true`, so readOnly is not a second gate.
2. **Clients index sidebar** — `CnIndexSidebar.allColumns` derives from the schema with no include, so Address and Website appear as newly toggleable columns. The table's own `config.columns` is explicit and unchanged.
3. **Client cards** — `CnObjectCard.metadataFields` filters only `visible === false` then slices to `maxMetadata`, so cards gain both fields and **other metadata may be pushed out**. `tests/e2e/visual/pipelinq.visual.spec.ts:23-24` (`clients.png`) may need re-baselining if the card view is the captured mode, as may the five `/clients` captures in `docs-screenshots.spec.ts`.

## ⚠️ Follow-up required on another branch

The assertion #775 describes under "Test coverage" is **not on `development`**. `tests/e2e/spec-coverage/declarative-view-system.spec.ts` lives on **`fix/gate-19-e2e-coverage`** (commit `30b1ef8e9`), where `:605-612` asserts `Address` and `Website` render **zero** times. That branch must flip the assertion before it merges, or it will fail against this change. Concretely:

- move `Address`/`Website` from the absence loop (`:605-612`) into the positive loop (`:598-604`);
- rewrite the #775 comment block (`:573-597`);
- **tighten the fixture picker at `:505-513`** — it currently requires `c.address && c.email && c.phone`; it needs `&& c.website`, because `demo_seed_data.json` seeds five clients all with an address but **only one with a website**, and the widget omits valueless fields. Without this the new assertion flakes exactly as the old comment describes.

## Class-wide check (#775's "worth checking alongside") — reported, not fixed

Resolved every `type: "data"` widget's `include` against the **merged** schema. Beyond `client-identity`, **7 more dead include entries across 3 widgets**, plus one phantom key — each is a separate product call about which side is wrong, so none are touched here:

| widget | dead entries |
|---|---|
| `client-commercial` | `notes` (`visible: false`) — renders 2 of 3 |
| `lead-deal` | `probability` (`visible: false`); `winProbability` is **not declared on any schema** |
| `lead-qualification` | `stageOrder`, `stageEnteredAt`, `description`, `notes` — 4 of 8 can never render |

The 9 data widgets with no `include` render all-visible properties and are unaffected. A `manifest include` ↔ `schema visible` cross-check would catch this whole class mechanically — `scripts/check-manifest.js` and `tests/validate-manifest.js` currently do not perform one, and `effective-manifest-crossref` already validates related invariants.

## Verification

- Real `deepMergeConfig()` before/after, with a positive control confirming the probe still finds 81 other `visible: false` properties (so "clean" means the flag is gone, not that the lookup missed).
- JSON parses; diff is two lines.
- gate-57 unaffected (no `lib/Service` change): 5 findings before and after, and a planted `post*` true positive was detected (6) and removed (5), proving the gate can still fail.
