### PR TITLE
fix(booking): defer the walk-in queue rebalance to its background job

### DIFF
--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -67,7 +67,6 @@ use OCA\Pipelinq\Service\BsnValidationService;
 use OCA\Pipelinq\Service\Gdpr\PipelinqApRegulatorEscalateProvider;
 use OCA\Pipelinq\Service\Gdpr\PipelinqBsnIdentityVerifyProvider;
 use OCA\Pipelinq\Service\HaalCentraalClient;
-use OCA\Pipelinq\Service\WalkInQueueService;
 use Throwable;
 use OCP\App\IAppManager;
 use OCP\AppFramework\App;
@@ -805,7 +804,6 @@ class Application extends App implements IBootstrap
     {
         $this->registerCommentResolvers(server: $server);
         $this->wireAppointmentEmailSeam();
-        $this->wireBookingWalkInRebalance();
         $this->wireAppointmentCalendarSeam();
         $this->wireAppointmentPaymentSeam();
         $this->wireGdprSeamProviders();
@@ -843,24 +841,6 @@ class Application extends App implements IBootstrap
         }//end try
 
     }//end registerCommentResolvers()
-
-    /**
-     * Wire the walk-in queue rebalance seam into the booking lifecycle, so a
-     * Booking completion fires WalkInQueueService::rebalance.
-     *
-     * @return void
-     */
-    private function wireBookingWalkInRebalance(): void
-    {
-        try {
-            $bookingService     = $this->getContainer()->get(BookingService::class);
-            $walkInQueueService = $this->getContainer()->get(WalkInQueueService::class);
-            $bookingService->setWalkInQueueRebalance(service: $walkInQueueService);
-        } catch (\Exception $e) {
-            // Booking / walk-in surfaces not available — leave rebalance seam unset.
-        }
-
-    }//end wireBookingWalkInRebalance()
 
     /**
      * Read the SPA manifest's declared app dependencies, as a flat id list.

--- a/lib/BackgroundJob/WalkInQueueRebalanceJob.php
+++ b/lib/BackgroundJob/WalkInQueueRebalanceJob.php
@@ -30,20 +30,25 @@ namespace OCA\Pipelinq\BackgroundJob;
 
 use OCA\Pipelinq\Service\WalkInQueueService;
 use OCP\AppFramework\Utility\ITimeFactory;
-use OCP\BackgroundJob\Job;
+use OCP\BackgroundJob\QueuedJob;
 use Psr\Log\LoggerInterface;
 
 /**
  * On-demand background job that rebalances walk-in ticket ETAs.
  *
- * Extends `OCP\BackgroundJob\Job` (NOT TimedJob) — runs only when explicitly
- * scheduled by BookingService::completeBooking via the JobList. Each invocation
- * delegates to {@see WalkInQueueService::rebalance()} and logs the touched
- * ticket count.
+ * Extends `OCP\BackgroundJob\QueuedJob` (NOT TimedJob, and NOT a plain Job) —
+ * it runs only when explicitly scheduled by BookingService::completeBooking via
+ * `IJobList::add()`, and removes itself from the job list once it has run. A
+ * plain `Job` added to the list would re-run on every cron tick forever, which
+ * is the opposite of "on-demand"; this job is deliberately never listed as a
+ * `<job>` in appinfo/info.xml, because that channel registers PERIODIC work.
+ *
+ * Each invocation delegates to {@see WalkInQueueService::rebalance()} and logs
+ * the touched ticket count.
  *
  * @spec openspec/specs/appointment-booking/spec.md
  */
-class WalkInQueueRebalanceJob extends Job
+class WalkInQueueRebalanceJob extends QueuedJob
 {
     /**
      * Constructor.
@@ -68,7 +73,7 @@ class WalkInQueueRebalanceJob extends Job
      *
      * @return void
      *
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter) $argument is required by TimedJob::run().
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter) $argument is required by QueuedJob::run().
      *
      * @spec openspec/specs/appointment-booking/spec.md
      */

--- a/lib/Service/BookingService.php
+++ b/lib/Service/BookingService.php
@@ -33,7 +33,9 @@ use DateTimeImmutable;
 use DateTimeZone;
 use InvalidArgumentException;
 use OCA\Pipelinq\AppInfo\Application;
+use OCA\Pipelinq\BackgroundJob\WalkInQueueRebalanceJob;
 use OCA\Pipelinq\Service\Lifecycle\SchemaLifecycleGraph;
+use OCP\BackgroundJob\IJobList;
 use OCP\IAppConfig;
 use OCP\IUserSession;
 use Psr\Container\ContainerInterface;
@@ -148,17 +150,6 @@ class BookingService
     private ?object $emailProvider = null;
 
     /**
-     * Optional walk-in queue rebalance seam (member 09).
-     *
-     * Invoked from {@see completeBooking()} so the walk-in queue ETAs are
-     * recomputed as scheduled appointments finish. Implementations expose
-     * `rebalance(): int` (the WalkInQueueService satisfies this contract).
-     *
-     * @var object|null
-     */
-    private ?object $walkInQueueRebalance = null;
-
-    /**
      * Optional calendar seam (member 10).
      *
      * Implementations expose `pushBookingEvent(string $bookingId): void`. Called
@@ -179,6 +170,7 @@ class BookingService
      * @param AvailabilityService $availabilityService Member 02 — invalidated on every write.
      * @param EligibilityService  $eligibilityService  Member 03 — skill-eligible resource filter.
      * @param LoggerInterface     $logger              The logger.
+     * @param IJobList            $jobList             The background-job list (member 09 rebalance is deferred to it).
      */
     public function __construct(
         private ContainerInterface $container,
@@ -187,6 +179,7 @@ class BookingService
         private AvailabilityService $availabilityService,
         private EligibilityService $eligibilityService,
         private LoggerInterface $logger,
+        private IJobList $jobList,
     ) {
     }//end __construct()
 
@@ -217,23 +210,6 @@ class BookingService
     {
         $this->emailProvider = $provider;
     }//end setEmailProvider()
-
-    /**
-     * Inject the walk-in queue rebalance seam (member 09).
-     *
-     * Wired by Application bootstrap to the WalkInQueueService instance so
-     * that {@see completeBooking()} fires the rebalance on completion.
-     *
-     * @param object|null $service Provider exposing `rebalance(): int`.
-     *
-     * @return void
-     *
-     * @spec openspec/specs/appointment-booking/spec.md
-     */
-    public function setWalkInQueueRebalance(?object $service): void
-    {
-        $this->walkInQueueRebalance = $service;
-    }//end setWalkInQueueRebalance()
 
     /**
      * Inject a calendar provider seam (member 10).
@@ -692,12 +668,28 @@ class BookingService
     }//end completeBooking()
 
     /**
-     * Fire the walk-in queue rebalance seam (member 09).
+     * Schedule the walk-in queue rebalance (member 09).
      *
      * The rebalance recomputes ETAs for every waiting walk-in ticket so the
-     * queue panel reflects the freshly freed slot. Errors are swallowed —
-     * the booking completion already succeeded and the walk-in panel
-     * auto-refreshes regardless.
+     * queue panel reflects the freshly freed slot. It is DEFERRED to
+     * {@see WalkInQueueRebalanceJob}, which is what
+     * `openspec/specs/appointment-booking/spec.md` ("Queue rebalances as
+     * appointments complete") requires: *the WalkInQueueRebalanceJob MUST
+     * recalculate `estimatedReadyAt` for all waiting tickets*.
+     *
+     * It used to call `WalkInQueueService::rebalance()` inline. That walked up
+     * to `WalkInQueueService::QUEUE_PAGE_SIZE` (200) waiting tickets and did an
+     * availability computation plus a `saveObject()` for EACH — up to 200
+     * object writes inside the HTTP request that completes one booking, with
+     * every error swallowed. Request latency scaled with queue depth and a
+     * total failure of the rebalance was invisible to the caller. That is the
+     * openregister#2420 family: a synchronous write fan-out on a request path.
+     *
+     * `IJobList::add()` is idempotent for an identical (class, argument) pair,
+     * so N completions in one cron window collapse to ONE queued rebalance —
+     * which is also strictly more correct, since the rebalance is a whole-queue
+     * recomputation and running it once after the last completion produces the
+     * same ETAs as running it after each.
      *
      * @return void
      *
@@ -705,19 +697,16 @@ class BookingService
      */
     private function rebalanceWalkInQueue(): void
     {
-        if ($this->walkInQueueRebalance === null) {
-            return;
-        }
-
-        if (method_exists($this->walkInQueueRebalance, 'rebalance') === false) {
-            return;
-        }
-
         try {
-            // @phpstan-ignore-next-line dynamic provider seam
-            $this->walkInQueueRebalance->rebalance();
+            $this->jobList->add(WalkInQueueRebalanceJob::class);
         } catch (\Throwable $e) {
-            $this->logger->warning('Pipelinq: walk-in queue rebalance failed');
+            // Enqueueing is best-effort: the booking completion has already
+            // been persisted and must not be rolled back because the ETA
+            // refresh could not be scheduled.
+            $this->logger->warning(
+                'Pipelinq: could not schedule the walk-in queue rebalance',
+                ['exception' => $e->getMessage()]
+            );
         }
     }//end rebalanceWalkInQueue()
 

--- a/tests/Unit/Service/BookingServiceTest.php
+++ b/tests/Unit/Service/BookingServiceTest.php
@@ -30,9 +30,11 @@ use DateTimeImmutable;
 use DateTimeZone;
 use InvalidArgumentException;
 use OCA\OpenRegister\Service\ObjectService;
+use OCA\Pipelinq\BackgroundJob\WalkInQueueRebalanceJob;
 use OCA\Pipelinq\Service\AvailabilityService;
 use OCA\Pipelinq\Service\BookingService;
 use OCA\Pipelinq\Service\EligibilityService;
+use OCP\BackgroundJob\IJobList;
 use OCP\IAppConfig;
 use OCP\IUser;
 use OCP\IUserSession;
@@ -96,14 +98,16 @@ class BookingServiceTest extends TestCase
      * @param AvailabilityService|null $availability  Optional pre-built AvailabilityService mock.
      * @param EligibilityService|null  $eligibility   Optional pre-built EligibilityService mock.
      * @param IUserSession|null        $userSession   Optional pre-built user session mock.
+     * @param IJobList|null            $jobList       Optional pre-built background-job list mock.
      *
-     * @return array{0: BookingService, 1: ObjectService, 2: AvailabilityService, 3: EligibilityService}
+     * @return array{0: BookingService, 1: ObjectService, 2: AvailabilityService, 3: EligibilityService, 4: IJobList}
      */
     private function buildService(
         ?ObjectService $objectService=null,
         ?AvailabilityService $availability=null,
         ?EligibilityService $eligibility=null,
         ?IUserSession $userSession=null,
+        ?IJobList $jobList=null,
     ): array {
         $objectService = ($objectService ?? $this->createMock(originalClassName: ObjectService::class));
         $availability  = ($availability ?? $this->createMock(originalClassName: AvailabilityService::class));
@@ -134,7 +138,8 @@ class BookingServiceTest extends TestCase
             $userSession->method('getUser')->willReturn($user);
         }
 
-        $logger = $this->createMock(originalClassName: LoggerInterface::class);
+        $logger  = $this->createMock(originalClassName: LoggerInterface::class);
+        $jobList = ($jobList ?? $this->createMock(originalClassName: IJobList::class));
 
         $service = new BookingService(
             container: $container,
@@ -142,10 +147,11 @@ class BookingServiceTest extends TestCase
             userSession: $userSession,
             availabilityService: $availability,
             eligibilityService: $eligibility,
-            logger: $logger
+            logger: $logger,
+            jobList: $jobList
         );
 
-        return [$service, $objectService, $availability, $eligibility];
+        return [$service, $objectService, $availability, $eligibility, $jobList];
     }//end buildService()
 
     /**
@@ -752,7 +758,7 @@ class BookingServiceTest extends TestCase
         $service->assertTransitionAllowed(from: 'pending-deposit', to: 'confirmed');
         $service->assertTransitionAllowed(from: 'confirmed', to: 'completed');
         $service->assertTransitionAllowed(from: 'confirmed', to: 'cancelled-by-business');
-        $this->addToAssertionCount(3);
+        $this->addToAssertionCount(count: 3);
 
         // Out of a terminal state: completed has an empty target list, so any
         // target is an invalid transition.
@@ -966,12 +972,6 @@ class BookingServiceTest extends TestCase
     }//end testGetAvailableSlotsDelegatesToAvailabilityService()
 
     /**
-     * Confirms completeBooking rejects transitions from already-terminal
-     * statuses (here: completed) and never persists.
-     *
-     * @return void
-     */
-    /**
      * A confirmed-from-creation Booking pushes a VEVENT through the calendar
      * seam (member 10). Pending-deposit bookings MUST NOT push — the calendar
      * mirror only mirrors actually-confirmed appointments.
@@ -1089,7 +1089,7 @@ class BookingServiceTest extends TestCase
     }//end testPendingDepositBookingSkipsCalendarPushSeam()
 
     /**
-     * confirmBooking (pending-deposit → confirmed) fires the calendar seam,
+     * The confirmBooking (pending-deposit → confirmed) path fires the calendar seam,
      * mirroring the freshly-confirmed booking to the staff calendar.
      *
      * @return void
@@ -1151,6 +1151,12 @@ class BookingServiceTest extends TestCase
 
     }//end testConfirmBookingFiresCalendarPushSeam()
 
+    /**
+     * Confirms completeBooking rejects transitions from already-terminal
+     * statuses (here: completed) and never persists.
+     *
+     * @return void
+     */
     public function testCompleteBookingRejectsTransitionFromTerminalStatus(): void
     {
         $booking = [
@@ -1177,16 +1183,13 @@ class BookingServiceTest extends TestCase
     }//end testCompleteBookingRejectsTransitionFromTerminalStatus()
 
     /**
-     * completeBooking fires the walk-in queue rebalance seam (member 09) so
-     * the queue panel refreshes ETAs for waiting tickets.
+     * A confirmed booking fixture ready to be completed.
      *
-     * @spec openspec/changes/appointment-booking-09-walkin-queue/specs/appointment-booking/spec.md#req-apt-012
-     *
-     * @return void
+     * @return array<string, mixed> The booking row.
      */
-    public function testCompleteBookingFiresWalkInQueueRebalanceSeam(): void
+    private function completableBooking(): array
     {
-        $booking = [
+        return [
             '@self'         => ['id' => 'b-finish'],
             'customerId'    => 'cust-1',
             'serviceId'     => 'svc-haircut',
@@ -1196,38 +1199,87 @@ class BookingServiceTest extends TestCase
             'statusHistory' => [],
             'depositAmount' => 0.0,
         ];
+    }//end completableBooking()
 
+    /**
+     * The completeBooking path SCHEDULES the walk-in queue rebalance (member 09) rather
+     * than running it inline, so the queue panel refreshes ETAs for waiting
+     * tickets without the completing request paying for the whole queue.
+     *
+     * @spec openspec/changes/appointment-booking-09-walkin-queue/specs/appointment-booking/spec.md#req-apt-012
+     *
+     * @return void
+     */
+    public function testCompleteBookingSchedulesWalkInQueueRebalanceJob(): void
+    {
         $object = $this->createMock(originalClassName: ObjectService::class);
-        $object->method('find')->willReturn($booking);
+        $object->method('find')->willReturn($this->completableBooking());
         $object->method('saveObject')->willReturn(['@self' => ['id' => 'b-finish']]);
 
-        $rebalance = new class {
+        $jobList = $this->createMock(originalClassName: IJobList::class);
+        $jobList->expects($this->once())
+            ->method('add')
+            ->with(WalkInQueueRebalanceJob::class);
 
-            /**
-             * Number of rebalance invocations seen by the seam.
-             *
-             * @var int
-             */
-            public int $calls = 0;
-
-            /**
-             * Capture rebalance call.
-             *
-             * @return int Tickets touched (irrelevant for assertion).
-             */
-            public function rebalance(): int
-            {
-                $this->calls++;
-                return 0;
-            }//end rebalance()
-        };
-
-        [$service] = $this->buildService(objectService: $object);
-        $service->setWalkInQueueRebalance(service: $rebalance);
+        [$service] = $this->buildService(objectService: $object, jobList: $jobList);
 
         $service->completeBooking(bookingId: 'b-finish');
 
-        $this->assertSame(expected: 1, actual: $rebalance->calls);
+    }//end testCompleteBookingSchedulesWalkInQueueRebalanceJob()
 
-    }//end testCompleteBookingFiresWalkInQueueRebalanceSeam()
+    /**
+     * The completing request must write exactly ONE object through this
+     * service's ObjectService — the booking itself. Before the rebalance was
+     * deferred, completeBooking() reached WalkInQueueService::rebalance(),
+     * which fans out to one saveObject() per waiting ticket (measured at
+     * QUEUE_PAGE_SIZE = 200 by
+     * WalkInQueueServiceTest::testRebalanceFansOutOneSaveObjectPerWaitingTicket).
+     *
+     * This pins the write budget of the completion path. It constrains any
+     * re-introduced fan-out that goes through the container-resolved
+     * ObjectService; it cannot see one routed through a separately-injected
+     * collaborator, which is why the enqueue itself is asserted separately.
+     *
+     * @spec openspec/changes/appointment-booking-09-walkin-queue/specs/appointment-booking/spec.md#req-apt-012
+     *
+     * @return void
+     */
+    public function testCompleteBookingWritesOnlyTheBookingItself(): void
+    {
+        $object = $this->createMock(originalClassName: ObjectService::class);
+        $object->method('find')->willReturn($this->completableBooking());
+        $object->expects($this->once())
+            ->method('saveObject')
+            ->willReturn(['@self' => ['id' => 'b-finish']]);
+
+        [$service] = $this->buildService(objectService: $object);
+
+        $service->completeBooking(bookingId: 'b-finish');
+
+    }//end testCompleteBookingWritesOnlyTheBookingItself()
+
+    /**
+     * A job list that cannot accept the rebalance must not fail the booking:
+     * the completion is already persisted, so the enqueue is best-effort.
+     *
+     * @spec openspec/changes/appointment-booking-09-walkin-queue/specs/appointment-booking/spec.md#req-apt-012
+     *
+     * @return void
+     */
+    public function testCompleteBookingSurvivesAnUnavailableJobList(): void
+    {
+        $object = $this->createMock(originalClassName: ObjectService::class);
+        $object->method('find')->willReturn($this->completableBooking());
+        $object->method('saveObject')->willReturn(['@self' => ['id' => 'b-finish']]);
+
+        $jobList = $this->createMock(originalClassName: IJobList::class);
+        $jobList->method('add')->willThrowException(new \RuntimeException('job list down'));
+
+        [$service] = $this->buildService(objectService: $object, jobList: $jobList);
+
+        $service->completeBooking(bookingId: 'b-finish');
+
+        $this->addToAssertionCount(count: 1);
+
+    }//end testCompleteBookingSurvivesAnUnavailableJobList()
 }//end class

--- a/tests/Unit/Service/WalkInQueueServiceTest.php
+++ b/tests/Unit/Service/WalkInQueueServiceTest.php
@@ -491,4 +491,88 @@ class WalkInQueueServiceTest extends TestCase
         $this->assertSame(expected: 0, actual: $walkIn->rebalance());
 
     }//end testRebalanceWithNoWaitingTickets()
+
+    /**
+     * Pins the SIZE of the rebalance fan-out, which is why it may not run on a
+     * request path.
+     *
+     * `rebalance()` reads every waiting ticket (capped at
+     * WalkInQueueService::QUEUE_PAGE_SIZE) and, per ticket, performs a service
+     * read, a resource read, an availability computation and a `saveObject()`.
+     * With a full queue that is QUEUE_PAGE_SIZE object writes and
+     * QUEUE_PAGE_SIZE availability computations in one call — the reason
+     * BookingService::completeBooking() schedules WalkInQueueRebalanceJob
+     * instead of calling this inline (openregister#2420 family).
+     *
+     * @return void
+     */
+    public function testRebalanceFansOutOneSaveObjectPerWaitingTicket(): void
+    {
+        $queueDepth = WalkInQueueService::QUEUE_PAGE_SIZE;
+
+        $waiting = [];
+        for ($i = 0; $i < $queueDepth; $i++) {
+            $waiting[] = [
+                '@self'            => ['id' => 'ticket-'.$i],
+                'status'           => 'waiting',
+                'serviceId'        => 'svc-haircut',
+                'displayName'      => 'Walk-in '.$i,
+                'estimatedReadyAt' => '',
+            ];
+        }
+
+        $resources = [
+            ['@self' => ['id' => 'res-a'], 'type' => 'staff', 'status' => 'active', 'bookable' => true],
+        ];
+
+        $object = $this->createMock(originalClassName: ObjectService::class);
+        $object->method('find')->willReturn(
+            [
+                '@self'                 => ['id' => 'svc-haircut'],
+                'durationMinutes'       => 30,
+                'requiredResourceTypes' => ['staff'],
+            ]
+        );
+        $object->method('findAll')->willReturnCallback(
+            static function (array $config) use ($waiting, $resources): array {
+                if (($config['schema'] ?? '') === 'walkInTicket') {
+                    return $waiting;
+                }
+
+                return $resources;
+            }
+        );
+
+        $writes = 0;
+        $object->method('saveObject')->willReturnCallback(
+            function (
+                array|object $payload,
+                ?array $extend=[],
+                string|int|null $register=null,
+                string|int|null $schema=null,
+                ?string $uuid=null,
+            ) use (&$writes): array {
+                $writes++;
+                return ['@self' => ['id' => (string) $uuid]];
+            }
+        );
+
+        $availabilityCalls = 0;
+        $availability      = $this->createMock(originalClassName: AvailabilityService::class);
+        $availability->method('computeAvailability')->willReturnCallback(
+            static function (string $resourceId, string $date, int $duration) use (&$availabilityCalls): array {
+                $availabilityCalls++;
+                return [['startTime' => '11:00', 'endTime' => '11:30', 'durationMinutes' => 30]];
+            }
+        );
+
+        [$walkIn] = $this->buildService(objectService: $object, availability: $availability);
+
+        $touched = $walkIn->rebalance();
+
+        $this->assertSame(expected: $queueDepth, actual: $touched);
+        $this->assertSame(expected: $queueDepth, actual: $writes);
+        $this->assertSame(expected: $queueDepth, actual: $availabilityCalls);
+
+    }//end testRebalanceFansOutOneSaveObjectPerWaitingTicket()
 }//end class

--- a/tests/Unit/Service/WalkInQueueServiceTest.php
+++ b/tests/Unit/Service/WalkInQueueServiceTest.php
@@ -504,6 +504,20 @@ class WalkInQueueServiceTest extends TestCase
      * BookingService::completeBooking() schedules WalkInQueueRebalanceJob
      * instead of calling this inline (openregister#2420 family).
      *
+     * ⚠️ SCOPE OF THIS MEASUREMENT — READ BEFORE QUOTING THE NUMBER.
+     * The ObjectService double below resolves register/schema context from the
+     * TOP LEVEL of the findAll() config, which is how `listByStatus()` supplies
+     * it today. The real OpenRegister reads that context ONLY from
+     * `$config['filters']` (`ObjectService::prepareFindAllConfig`), so on a live
+     * instance the ticket read currently resolves no context and
+     * `MagicMapper::findAll()` returns an empty array.
+     *
+     * So this test measures the fan-out THE LOOP PERFORMS PER WAITING TICKET.
+     * It does NOT claim that 200 writes happen in production today: while the
+     * query stays mis-keyed the queue reads empty and the fan-out is LATENT.
+     * It becomes live the moment that separate defect is fixed — which is
+     * exactly why the rebalance must already be off the request path by then.
+     *
      * @return void
      */
     public function testRebalanceFansOutOneSaveObjectPerWaitingTicket(): void


### PR DESCRIPTION
## What

`BookingService::completeBooking()` called `WalkInQueueService::rebalance()` **synchronously**, inside the HTTP request that completes a booking. This PR defers it to `WalkInQueueRebalanceJob`, which already existed and which the spec already names.

## The measurement, not an estimate

`rebalance()` reads every waiting walk-in ticket (capped at `QUEUE_PAGE_SIZE = 200`) and, per ticket, does a service read, a resource read, an availability computation and a `saveObject()`.

A new test seeds a full queue and pins the fan-out:

| | measured |
|---|---|
| `saveObject()` calls per `rebalance()` at full queue | **200** |
| availability computations per `rebalance()` at full queue | **200** |

`WalkInQueueServiceTest::testRebalanceFansOutOneSaveObjectPerWaitingTicket`.

All of that sits on the request path, and **every error was swallowed** at the seam (`BookingService.php:718` on `206db4be`), so a total failure of the rebalance was invisible to the caller while request latency scaled with queue depth. This is the openregister#2420 family — the same shape that serialised every object write on a live instance for over two hours on 11 August.

### 🔴 Correction to my own first draft — the fan-out is LATENT, not live

I originally wrote that the 200 writes "ran on the request path". **That overstates what I measured.**

`WalkInQueueService::listByStatus()` (`:556-562`) and `fetchResourceRows()` (`:727-733`) supply `register`/`schema` at the **top level** of the `findAll()` config. The real OpenRegister reads that context **only** from `$config['filters']` — `ObjectService::prepareFindAllConfig()`, verified against `openregister@a4dd9067` — and `MagicMapper::findAll()` (`:8681`) then returns `[]` with a warning log. So the ticket read currently comes back empty.

| | |
|---|---|
| what `rebalance()` does per waiting ticket, at `QUEUE_PAGE_SIZE` | **200 `saveObject()` + 200 availability computations** — measured |
| what a booking completion writes **today** | **1** (the booking), because the queue read is mis-keyed |
| what it writes **the moment that mis-keying is fixed**, without this PR | **201** |

The number came from **a double I wrote**, which keys off the top level and therefore does not reproduce the upstream contract — it measures the loop, not production. The test docblock now says so (`3386729de`).

**This makes the PR more load-bearing, not less.** The mis-keying is a separate defect at **11 call sites** (pipelinq#793, root-caused upstream as openregister#2426). Whoever fixes it converts a latent 201-write request into a live one — **so this must land first, or that fix ships a performance incident with it.**

⚠️ Worth stating explicitly: **gate-61 structurally cannot see this.** It inspects post-event *listeners*; this is a *service seam* invoked from a controller. A clean gate-61 says nothing about it. (And gate-61 is dead on every `--full` run anyway — `.github#347`.)

## No spec was authored for this

`openspec/specs/appointment-booking/spec.md`, scenario *"Queue rebalances as appointments complete"*, already reads:

> **THEN** the **WalkInQueueRebalanceJob** MUST recalculate `estimatedReadyAt` for all waiting tickets

and `WalkInQueueRebalanceJob`'s own docblock already said it runs *"only when explicitly scheduled by `BookingService::completeBooking` via the JobList"*. **Nothing ever scheduled it.** The deferred path was built and never switched on, and the synchronous path was carrying the load. This PR moves the code onto a requirement that was already written; no spec file is touched.

## Changes

- `BookingService` takes `IJobList` and enqueues `WalkInQueueRebalanceJob` instead of running the fan-out inline. `IJobList::add()` is idempotent for an identical `(class, argument)` pair, so N completions in one cron window collapse to **one** rebalance — which is also strictly more correct, since the rebalance is a whole-queue recomputation and running it once after the last completion produces the same ETAs as running it after each.
- `WalkInQueueRebalanceJob` now extends `QueuedJob` rather than `Job`, so an enqueued instance runs once and removes itself from the job list. A plain `Job` on the list would re-run on every cron tick.
  - It is deliberately **not** added as a `<job>` in `appinfo/info.xml`. That channel registers **periodic** work; this job is on-demand. "The job exists but is unregistered" is true, but `info.xml` is the wrong registration for it.
- The `setWalkInQueueRebalance()` seam and its bootstrap wiring in `Application::bootNonPageSurfaces()` are **removed**, not kept alongside the job. That wiring also resolved `BookingService` **and** `WalkInQueueService` out of the container on every non-page request.

`WalkInQueueRebalanceJob::run()` is now the only caller of `rebalance()` anywhere in `lib/` or `src/` — verified with a positive control on the same grep, because "no callers" is an absence claim.

## Verification

| check | result |
|---|---|
| PHPUnit `Unit Tests` | **1639 tests, 5150 assertions, 0 failures** |
| phpcs | clean on all touched files |
| phpmd | clean |
| phpstan | `No errors` |
| psalm | `No errors found!` |

Also fixed **seven pre-existing phpcs errors** in `BookingServiceTest.php` encountered on the way — one of which was a docblock that had become **detached** from `testCompleteBookingRejectsTransitionFromTerminalStatus` and was sitting in front of an unrelated test, leaving that test undocumented.

## What this PR does not claim

The write-budget test (`testCompleteBookingWritesOnlyTheBookingItself`) constrains a re-introduced fan-out that goes through the container-resolved `ObjectService`. It **cannot** see one routed through a separately-injected collaborator — which is why the enqueue itself is asserted separately rather than inferred from the write count.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
