### PR TITLE
fix(pos): repair the two live money-path outages — settlement webhooks were discarded at 200, settle 409'd every transaction (#799)

### DIFF
--- a/lib/Controller/PosPaymentController.php
+++ b/lib/Controller/PosPaymentController.php
@@ -285,6 +285,12 @@ class PosPaymentController extends Controller
      * (the AppointmentPaymentWebhookController + BlastWebhookController
      * already follow this rule).
      *
+     * Status → HTTP mapping (see PosPaymentService::handleWebhook()):
+     *   ok | duplicate | ignored → 200 (the delivery is consumed or can never
+     *                                   be consumed, so a retry is pointless)
+     *   invalid                  → 400
+     *   unmatched                → 503, so the provider redelivers
+     *
      * @param string $provider The provider name.
      *
      * @return JSONResponse
@@ -322,6 +328,22 @@ class PosPaymentController extends Controller
             return new JSONResponse(
                 ['error' => $this->l10n->t('Invalid webhook signature')],
                 Http::STATUS_BAD_REQUEST
+            );
+        }
+
+        if ($status === 'unmatched') {
+            // A signed settlement this instance could not match to a
+            // transaction. NOTHING was persisted, so the delivery must not be
+            // acknowledged: all four supported providers (Mollie, CCV, Adyen,
+            // Stripe) stop redelivering on any 2xx and redeliver on 5xx, so a
+            // 200 here loses the settlement permanently (pipelinq#799).
+            // 503 rather than 500 because the condition is genuinely transient
+            // — a webhook can outrun the transaction write, and an
+            // unconfigured register/schema is repaired by an operator, not by
+            // the provider.
+            return new JSONResponse(
+                $result,
+                Http::STATUS_SERVICE_UNAVAILABLE
             );
         }
 

--- a/lib/Service/PosPaymentService.php
+++ b/lib/Service/PosPaymentService.php
@@ -613,11 +613,23 @@ class PosPaymentService
      * Signature failure returns `{ status: invalid }` → controller maps to
      * STATUS_BAD_REQUEST (gate-9 webhook convention).
      *
+     * The status vocabulary is the controller's HTTP contract, so each value
+     * states whether the delivery was consumed:
+     *   - `ok` / `duplicate` — consumed, answered 2xx, provider stops.
+     *   - `invalid`          — the delivery is not ours (bad signature or an
+     *                          unknown provider); 400, never retried.
+     *   - `ignored`          — well-formed but carries no session id, so there
+     *                          is nothing to match and a redelivery of the same
+     *                          bytes can never succeed; 2xx by design.
+     *   - `unmatched`        — signed, carries a session id, and nothing was
+     *                          persisted. MUST be answered with a retryable
+     *                          5xx (pipelinq#799).
+     *
      * @param string $providerName The provider name.
      * @param string $rawPayload   The raw request body.
      * @param string $signature    The signature header value.
      *
-     * @return array<string, mixed> { status: ok|invalid|ignored|duplicate, transactionId?, error? }
+     * @return array<string, mixed> { status: ok|invalid|ignored|unmatched|duplicate, transactionId?, error? }
      *
      * @spec openspec/changes/pos-payment-provider-adapter/specs/pos-payment-provider-adapter/spec.md#REQ-PAY-006
      */
@@ -697,14 +709,19 @@ class PosPaymentService
     {
         $transaction = $this->findTransactionBySessionId(sessionId: $sessionId);
         if ($transaction === null) {
-            $this->logger->info(
-                'Pipelinq POS payment: webhook for unknown transaction',
+            // NOT `ignored`. The provider sent a signed settlement for a
+            // session this instance cannot match, so nothing was persisted.
+            // `unmatched` is answered with a retryable 5xx by the controller
+            // so the provider redelivers; a 2xx here tells the provider the
+            // settlement is booked and the money is lost (pipelinq#799).
+            $this->logger->error(
+                'Pipelinq POS payment: webhook for unmatched transaction; asking the provider to retry',
                 [
                     'provider' => $providerName,
                     'session'  => $sessionId,
                 ]
             );
-            return ['status' => 'ignored'];
+            return ['status' => 'unmatched'];
         }
 
         // Idempotency — last processed event id stored on the transaction.
@@ -1163,6 +1180,19 @@ class PosPaymentService
     /**
      * Find a transaction by paymentSessionId.
      *
+     * `register` / `schema` MUST sit inside `filters`. OpenRegister's
+     * `ObjectService::prepareFindAllConfig()` reads the query context from
+     * `$config['filters']['register']` / `['schema']` and from nowhere else,
+     * even though `findAll()`'s own docblock lists them as top-level keys. A
+     * top-level pair leaves `currentRegister` / `currentSchema` untouched and
+     * `MagicMapper::findAll()` then logs a warning and returns `[]`
+     * (pipelinq#793) — which this method reported as `null`, i.e. as the
+     * ordinary "no such transaction" outcome, so every settlement webhook was
+     * discarded (pipelinq#799).
+     *
+     * `limit: 2` exists to detect a duplicate `paymentSessionId`; the second
+     * row is now actually inspected instead of being silently dropped.
+     *
      * @param string $sessionId The session id.
      *
      * @return array<string, mixed>|null
@@ -1188,19 +1218,47 @@ class PosPaymentService
         try {
             $result = $objectService->findAll(
                 config: [
-                    'filters'  => ['paymentSessionId' => $sessionId],
-                    'register' => $register,
-                    'schema'   => $schema,
-                    'limit'    => 2,
+                    'filters' => [
+                        'paymentSessionId' => $sessionId,
+                        'register'         => $register,
+                        'schema'           => $schema,
+                    ],
+                    'limit'   => 2,
                 ]
             );
         } catch (Throwable $e) {
+            $this->logger->error(
+                'Pipelinq POS payment: transaction lookup by session id failed',
+                [
+                    'session'   => $sessionId,
+                    'class'     => get_class($e),
+                    'exception' => $e->getMessage(),
+                ]
+            );
             return null;
-        }
+        }//end try
 
         $rows = $this->resultToArray(result: $result);
         if ($rows === []) {
             return null;
+        }
+
+        if (count($rows) > 1) {
+            // Two transactions carrying one provider session id is data
+            // corruption on the money path: the settlement would land on
+            // whichever row the store happened to return first. Surface it.
+            $this->logger->error(
+                'Pipelinq POS payment: paymentSessionId is not unique; settling the first match',
+                [
+                    'session' => $sessionId,
+                    'matches' => array_map(
+                        static function (array $row): string {
+                            return (string) ($row['@self']['id'] ?? ($row['id'] ?? ''));
+                        },
+                        $rows
+                    ),
+                ]
+            );
         }
 
         return $rows[0];

--- a/lib/Service/PosTenderService.php
+++ b/lib/Service/PosTenderService.php
@@ -323,7 +323,8 @@ class PosTenderService
         [$register, $schema] = $this->config(schemaKey: 'posTenderType_schema');
 
         try {
-            $this->getObjectService()->deleteObject(id: $id, register: $register, schema: $schema);
+            // The parameter is `$uuid`; `id:` is `Error: Unknown named parameter`.
+            $this->getObjectService()->deleteObject(uuid: $id, register: $register, schema: $schema);
         } catch (Throwable $e) {
             $this->logger->warning(
                 'Pipelinq POS tender: failed to delete tender type',
@@ -339,6 +340,20 @@ class PosTenderService
 
     /**
      * List all tenders attached to a transaction, sorted by sortOrder.
+     *
+     * `register` / `schema` MUST sit inside `filters`. OpenRegister's
+     * `ObjectService::prepareFindAllConfig()` resolves the query context from
+     * `$config['filters']['register']` / `['schema']` and from nowhere else,
+     * even though `findAll()`'s own docblock lists them as top-level keys. A
+     * top-level pair leaves `currentRegister` / `currentSchema` untouched, so
+     * `MagicMapper::findAll()` logs a warning and returns `[]` (pipelinq#793).
+     *
+     * That made this one line behave differently per endpoint: reached through
+     * `addTender()` a preceding `saveObject()` had already pinned the posTender
+     * context and the read worked, while `settle` — which is preceded only by a
+     * `find()`, and `find()` restores the context it borrowed — read nothing,
+     * so `assertBalancedForSettle()` saw `tenderSum = 0` and rejected every
+     * non-zero transaction with a 409 underpayment (pipelinq#799).
      *
      * @param string $transactionId The posTransaction UUID.
      *
@@ -357,9 +372,11 @@ class PosTenderService
         try {
             $results = $this->getObjectService()->findAll(
                 config: [
-                    'filters'  => ['transaction' => $transactionId],
-                    'register' => $register,
-                    'schema'   => $schema,
+                    'filters' => [
+                        'transaction' => $transactionId,
+                        'register'    => $register,
+                        'schema'      => $schema,
+                    ],
                 ]
             );
         } catch (Throwable $e) {
@@ -509,7 +526,8 @@ class PosTenderService
         [$register, $schema] = $this->config(schemaKey: 'posTender_schema');
 
         try {
-            $this->getObjectService()->deleteObject(id: $tenderId, register: $register, schema: $schema);
+            // The parameter is `$uuid`; `id:` is `Error: Unknown named parameter`.
+            $this->getObjectService()->deleteObject(uuid: $tenderId, register: $register, schema: $schema);
         } catch (Throwable $e) {
             $this->logger->warning(
                 'Pipelinq POS tender: failed to delete tender',

--- a/tests/Unit/Controller/PosPaymentControllerTest.php
+++ b/tests/Unit/Controller/PosPaymentControllerTest.php
@@ -311,14 +311,42 @@ class PosPaymentControllerTest extends TestCase
     }//end testWebhookReplayIsReportedAsDuplicateNotAsFreshSettlement()
 
     /**
-     * A payload the provider sent for a session this instance does not know is
-     * acknowledged (so the provider stops retrying) but reports `ignored`.
+     * A signed settlement for a session this instance could not match MUST NOT
+     * be acknowledged.
+     *
+     * ⚠️ This test previously asserted `Http::STATUS_OK` and passed — it pinned
+     * pipelinq#799 rather than guarding against it. Nothing is persisted on
+     * this branch, and all four supported providers (Mollie, CCV, Adyen,
+     * Stripe) stop redelivering on any 2xx, so a 200 loses the settlement
+     * permanently. The contract is a retryable 5xx.
      *
      * @return void
      */
-    public function testWebhookForUnknownSessionIsIgnored(): void
+    public function testWebhookForAnUnmatchedSessionIsNotAcknowledged(): void
     {
         $this->withBody(['id' => 'tr_unknown']);
+        $this->withHeaders(['X-Mollie-Signature' => 'good-signature']);
+
+        $this->service->method('handleWebhook')->willReturn(['status' => 'unmatched']);
+
+        $response = $this->controller->webhook(provider: 'mollie');
+
+        $this->assertSame(Http::STATUS_SERVICE_UNAVAILABLE, $response->getStatus());
+        $this->assertGreaterThanOrEqual(500, $response->getStatus());
+        $this->assertSame('unmatched', $response->getData()['status']);
+    }//end testWebhookForAnUnmatchedSessionIsNotAcknowledged()
+
+    /**
+     * A payload carrying no session id at all is a different case: there is
+     * nothing to match and a redelivery of the same bytes can never succeed,
+     * so it stays acknowledged at 200 and reports `ignored`. Keeping the two
+     * apart is the point — one is retryable, the other is not.
+     *
+     * @return void
+     */
+    public function testWebhookWithNoSessionIdStaysAcknowledged(): void
+    {
+        $this->withBody(['unrelated' => 'payload']);
         $this->withHeaders(['X-Mollie-Signature' => 'good-signature']);
 
         $this->service->method('handleWebhook')->willReturn(['status' => 'ignored']);
@@ -328,7 +356,7 @@ class PosPaymentControllerTest extends TestCase
         $this->assertSame(Http::STATUS_OK, $response->getStatus());
         $this->assertSame('ignored', $response->getData()['status']);
         $this->assertArrayNotHasKey('transactionId', $response->getData());
-    }//end testWebhookForUnknownSessionIsIgnored()
+    }//end testWebhookWithNoSessionIdStaysAcknowledged()
 
     /**
      * The controller must call the verification path exactly once per delivery.

--- a/tests/Unit/Service/PosPaymentServiceTest.php
+++ b/tests/Unit/Service/PosPaymentServiceTest.php
@@ -40,6 +40,222 @@ use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
 
 /**
+ * In-memory fake of the OR ObjectService that models OpenRegister's
+ * REGISTER/SCHEMA CONTEXT RESOLUTION, not merely its method names.
+ *
+ * A PHPUnit `createMock(ObjectService::class)` cannot see pipelinq#799 at all:
+ * `willReturn([$tx])` returns the row whatever the config looked like, so the
+ * mis-keyed query and the correct one are indistinguishable to it. That is why
+ * a settlement outage that has existed since 2026-06-08 sat under a green
+ * suite. This fake reproduces, from `openregister@a4dd9067`:
+ *
+ *   - `ObjectService::prepareFindAllConfig()` (:1011-1035) sets the query
+ *     context ONLY from `$config['filters']['register']` / `['schema']`;
+ *   - `findAll()` then hands `$this->currentRegister` / `$this->currentSchema`
+ *     to the handler and never restores them;
+ *   - `MagicMapper::findAll()` (:8681) logs a warning and returns `[]` — no
+ *     exception — when either is null;
+ *   - `find()` snapshots and restores the sticky context (BUG-OBJ-13 /
+ *     openregister#1520).
+ *
+ * @SuppressWarnings(PHPMD.UnusedFormalParameter) Mirrors the real ObjectService signature.
+ */
+class PaymentFakeObjectService
+{
+
+    /**
+     * Rows, keyed by schema then by uuid.
+     *
+     * @var array<string, array<string, array<string, mixed>>>
+     */
+    public array $store = [];
+
+    /**
+     * Sticky register context.
+     *
+     * @var string
+     */
+    public string $currentRegister = '';
+
+    /**
+     * Sticky schema context.
+     *
+     * @var string
+     */
+    public string $currentSchema = '';
+
+    /**
+     * Every findAll() config, in call order.
+     *
+     * @var array<int, array<string, mixed>>
+     */
+    public array $queries = [];
+
+    /**
+     * Every saveObject() payload, in call order.
+     *
+     * @var array<int, array<string, mixed>>
+     */
+    public array $saves = [];
+
+    /**
+     * Seed one row.
+     *
+     * @param string               $schema The schema slug.
+     * @param string               $uuid   The row uuid.
+     * @param array<string, mixed> $data   The row body.
+     *
+     * @return void
+     */
+    public function seed(string $schema, string $uuid, array $data): void
+    {
+        $data['id']                = $uuid;
+        $data['@self']             = ['id' => $uuid];
+        $this->store[$schema][$uuid] = $data;
+    }//end seed()
+
+    /**
+     * Read one row; snapshots and restores the sticky context.
+     *
+     * @param integer|string  $id       Object id.
+     * @param array|null      $_extend  Extend list.
+     * @param boolean         $files    Include files.
+     * @param string|int|null $register Register context.
+     * @param string|int|null $schema   Schema context.
+     *
+     * @return array<string, mixed>|null
+     */
+    public function find(
+        int | string $id,
+        ?array $_extend=[],
+        bool $files=false,
+        string | int | null $register=null,
+        string | int | null $schema=null
+    ): ?array {
+        $snapshotRegister = $this->currentRegister;
+        $snapshotSchema   = $this->currentSchema;
+
+        $row = ($this->store[(string) $schema][(string) $id] ?? null);
+
+        $this->currentRegister = $snapshotRegister;
+        $this->currentSchema   = $snapshotSchema;
+
+        return $row;
+    }//end find()
+
+    /**
+     * Query rows. Context comes from `filters` only.
+     *
+     * @param array<string, mixed> $config        Query config.
+     * @param boolean              $_rbac         RBAC posture.
+     * @param boolean              $_multitenancy Tenancy posture.
+     *
+     * @return array<int, array<string, mixed>>
+     */
+    public function findAll(array $config=[], bool $_rbac=true, bool $_multitenancy=true): array
+    {
+        $this->queries[] = $config;
+
+        $filters = (array) ($config['filters'] ?? []);
+
+        if (empty($filters['register']) === false && is_array($filters['register']) === false) {
+            $this->currentRegister = (string) $filters['register'];
+        }
+
+        if (empty($filters['schema']) === false && is_array($filters['schema']) === false) {
+            $this->currentSchema = (string) $filters['schema'];
+        }
+
+        if ($this->currentRegister === '' || $this->currentSchema === '') {
+            return [];
+        }
+
+        $rows = array_values($this->store[$this->currentSchema] ?? []);
+        unset($filters['register'], $filters['schema']);
+
+        $matched = array_values(
+            array_filter(
+                $rows,
+                static function (array $row) use ($filters): bool {
+                    foreach ($filters as $key => $value) {
+                        if (($row[$key] ?? null) !== $value) {
+                            return false;
+                        }
+                    }
+
+                    return true;
+                }
+            )
+        );
+
+        $limit = (int) ($config['limit'] ?? 0);
+        if ($limit > 0) {
+            $matched = array_slice($matched, 0, $limit);
+        }
+
+        return $matched;
+    }//end findAll()
+
+    /**
+     * Write a row; sets the sticky context and does not restore it.
+     *
+     * @param array<string, mixed> $object   The payload.
+     * @param array|null           $extend   Extend list.
+     * @param string|int|null      $register Register context.
+     * @param string|int|null      $schema   Schema context.
+     * @param string|null          $uuid     Uuid for an update.
+     *
+     * @return array<string, mixed>
+     */
+    public function saveObject(
+        array $object,
+        ?array $extend=[],
+        string | int | null $register=null,
+        string | int | null $schema=null,
+        ?string $uuid=null
+    ): array {
+        $this->currentRegister = (string) $register;
+        $this->currentSchema   = (string) $schema;
+
+        $object['id']    = (string) $uuid;
+        $object['@self'] = ['id' => (string) $uuid];
+
+        $this->store[(string) $schema][(string) $uuid] = $object;
+        $this->saves[] = $object;
+
+        return $object;
+    }//end saveObject()
+}//end class
+
+/**
+ * Capturing fake of the OR WebhookService.
+ */
+class PaymentFakeWebhookService
+{
+
+    /**
+     * Dispatched event names, in call order.
+     *
+     * @var array<int, string>
+     */
+    public array $events = [];
+
+    /**
+     * Capture a dispatched CloudEvent.
+     *
+     * @param object               $_event    The framework event.
+     * @param string               $eventName The event name.
+     * @param array<string, mixed> $payload   The payload.
+     *
+     * @return void
+     */
+    public function dispatchEvent(object $_event, string $eventName, array $payload): void
+    {
+        $this->events[] = $eventName;
+    }//end dispatchEvent()
+}//end class
+
+/**
  * Tests for PosPaymentService.
  *
  * Tests focus on the orchestration concerns the unit can drive without
@@ -65,21 +281,34 @@ class PosPaymentServiceTest extends TestCase
     /**
      * Build a service with overridable mocks.
      *
-     * @param ObjectService|null $object   The ObjectService mock.
-     * @param array<string, mixed> $opts   Optional knobs: isManager (bool).
+     * `$object` is typed `object`, not `ObjectService`, so a test can supply
+     * the contract-faithful `PaymentFakeObjectService` above instead of a
+     * PHPUnit mock. A mock stubbed with `willReturn()` answers the same rows
+     * whatever the query config held, which makes a correctly-keyed query and
+     * a mis-keyed one indistinguishable — the reason pipelinq#799 survived a
+     * green suite for two months.
+     *
+     * @param object|null          $object The ObjectService double.
+     * @param array<string, mixed> $opts   Optional knobs: isManager (bool), webhooks (object), logger (LoggerInterface).
      *
      * @return PosPaymentService
      */
-    private function buildService(?ObjectService $object=null, array $opts=[]): PosPaymentService
+    private function buildService(?object $object=null, array $opts=[]): PosPaymentService
     {
-        $object = ($object ?? $this->createMock(originalClassName: ObjectService::class));
+        $object   = ($object ?? $this->createMock(originalClassName: ObjectService::class));
+        $webhooks = ($opts['webhooks'] ?? null);
 
         $container = $this->createMock(originalClassName: ContainerInterface::class);
         $container->method('get')->willReturnCallback(
-            callback: function (string $id) use ($object): mixed {
+            callback: function (string $id) use ($object, $webhooks): mixed {
                 if ($id === 'OCA\\OpenRegister\\Service\\ObjectService') {
                     return $object;
                 }
+
+                if ($id === 'OCA\\OpenRegister\\Service\\WebhookService' && $webhooks !== null) {
+                    return $webhooks;
+                }
+
                 throw new \RuntimeException('container: '.$id);
             }
         );
@@ -117,7 +346,7 @@ class PosPaymentServiceTest extends TestCase
         $groupMgr->method('isAdmin')->willReturn(false);
         $groupMgr->method('isInGroup')->willReturn($isManager);
 
-        $logger = $this->createMock(originalClassName: LoggerInterface::class);
+        $logger = ($opts['logger'] ?? $this->createMock(originalClassName: LoggerInterface::class));
 
         // The broker's ownership guard needs an identity to check the credential against.
         $user = $this->createMock(originalClassName: IUser::class);
@@ -206,18 +435,32 @@ class PosPaymentServiceTest extends TestCase
         $this->assertSame('ENC:whsec_xyz', $this->configStore['payment_provider.mollie.webhookSecret']);
     }//end testUpdateProviderRefusesTheRetiredApiKeyAndStoresTheCredentialReference()
 
+    /**
+     * A masked or empty resubmission must not overwrite the stored secret.
+     *
+     * ⚠️ This test used to read `payment_provider.mollie.apiKey`, a key the
+     * service stopped writing when the api key moved to the credential broker
+     * — the sibling test above asserts that key is ABSENT. All three reads
+     * were therefore `null`, all three assertions compared `null` to `null`,
+     * and the test was green while measuring nothing (it emitted three
+     * "Undefined array key" warnings per run). Re-pointed at the secret the
+     * service does still hold itself: the webhook secret.
+     *
+     * @return void
+     */
     public function testUpdateProviderKeepsStoredSecretWhenMaskOrEmpty(): void
     {
         $service = $this->buildService();
 
-        $service->updateProvider(name: 'mollie', data: ['apiKey' => 'sk_live_original']);
-        $first = $this->configStore['payment_provider.mollie.apiKey'];
+        $service->updateProvider(name: 'mollie', data: ['webhookSecret' => 'whsec_original']);
+        $first = $this->configStore['payment_provider.mollie.webhookSecret'];
+        $this->assertSame('ENC:whsec_original', $first);
 
-        $service->updateProvider(name: 'mollie', data: ['apiKey' => PosPaymentService::MASK]);
-        $this->assertSame($first, $this->configStore['payment_provider.mollie.apiKey']);
+        $service->updateProvider(name: 'mollie', data: ['webhookSecret' => PosPaymentService::MASK]);
+        $this->assertSame($first, $this->configStore['payment_provider.mollie.webhookSecret']);
 
-        $service->updateProvider(name: 'mollie', data: ['apiKey' => '']);
-        $this->assertSame($first, $this->configStore['payment_provider.mollie.apiKey']);
+        $service->updateProvider(name: 'mollie', data: ['webhookSecret' => '']);
+        $this->assertSame($first, $this->configStore['payment_provider.mollie.webhookSecret']);
     }//end testUpdateProviderKeepsStoredSecretWhenMaskOrEmpty()
 
     public function testUpdateProviderRejectsUnknownProviderName(): void
@@ -318,7 +561,16 @@ class PosPaymentServiceTest extends TestCase
         $this->assertSame('duplicate', $result['status']);
     }//end testHandleSettlementIsIdempotentOnSameEventId()
 
-    public function testHandleSettlementIgnoresUnknownSession(): void
+    /**
+     * A session this instance cannot match is `unmatched`, NOT `ignored`.
+     *
+     * `ignored` is answered 2xx by the controller, which tells the provider
+     * the settlement is booked. Nothing was persisted here, so the delivery
+     * must stay un-acknowledged and be redelivered (pipelinq#799).
+     *
+     * @return void
+     */
+    public function testHandleSettlementReportsAnUnknownSessionAsUnmatched(): void
     {
         $object = $this->createMock(originalClassName: ObjectService::class);
         $object->method('findAll')->willReturn([]);
@@ -333,8 +585,161 @@ class PosPaymentServiceTest extends TestCase
             eventId: 'evt-1'
         );
 
-        $this->assertSame('ignored', $result['status']);
-    }//end testHandleSettlementIgnoresUnknownSession()
+        $this->assertSame('unmatched', $result['status']);
+        $this->assertNotSame('ignored', $result['status']);
+    }//end testHandleSettlementReportsAnUnknownSessionAsUnmatched()
+
+    // -----------------------------------------------------------------
+    // pipelinq#799 — the settlement webhook, against a contract-faithful store
+    // -----------------------------------------------------------------
+
+    /**
+     * THE #799 REGRESSION GUARD for the webhook path.
+     *
+     * `findTransactionBySessionId()` keyed `register` / `schema` at the TOP
+     * LEVEL of the `findAll()` config. `ObjectService::prepareFindAllConfig()`
+     * resolves the query context only from `$config['filters']`, so the query
+     * ran with no context, `MagicMapper::findAll()` returned `[]`, the lookup
+     * reported `null`, and `handleSettlement()` discarded the delivery — at
+     * HTTP 200, which no provider retries.
+     *
+     * The assertion is on the SEEDED transaction and its persisted patch, not
+     * on a row count: an unscoped read and a scoped one look identical to a
+     * count.
+     *
+     * @return void
+     */
+    public function testSettlementWebhookMatchesTheSeededTransactionAndPersistsIt(): void
+    {
+        $store = new PaymentFakeObjectService();
+        $store->seed(
+            schema: 'posTransaction',
+            uuid: 'tx-live-1',
+            data: [
+                'reference'        => 'TXN-0007',
+                'paymentSessionId' => 'tr_live_1',
+                'paymentStatus'    => 'pending',
+                'total'            => 27.59,
+            ],
+        );
+        // A second transaction with a different session must not be touched.
+        $store->seed(
+            schema: 'posTransaction',
+            uuid: 'tx-live-2',
+            data: [
+                'reference'        => 'TXN-0008',
+                'paymentSessionId' => 'tr_live_2',
+                'paymentStatus'    => 'pending',
+                'total'            => 10.00,
+            ],
+        );
+
+        $webhooks = new PaymentFakeWebhookService();
+        $service  = $this->buildService(object: $store, opts: ['webhooks' => $webhooks]);
+
+        // Nothing has written first — this is the webhook request, which is
+        // the whole request. There is no sticky context to inherit.
+        $this->assertSame('', $store->currentRegister);
+        $this->assertSame('', $store->currentSchema);
+
+        $result = $service->handleSettlement(
+            providerName: 'mollie',
+            sessionId: 'tr_live_1',
+            paymentStatus: 'settled',
+            eventId: 'evt-live-1'
+        );
+
+        $this->assertSame('ok', $result['status']);
+        $this->assertSame('tx-live-1', $result['transactionId']);
+
+        $persisted = $store->store['posTransaction']['tx-live-1'];
+        $this->assertSame('settled', $persisted['paymentStatus']);
+        $this->assertSame('evt-live-1', $persisted['paymentWebhookEventId']);
+        $this->assertArrayHasKey('settledAt', $persisted);
+        $this->assertSame('TXN-0007', $persisted['reference']);
+
+        // The neighbour is untouched.
+        $this->assertSame('pending', $store->store['posTransaction']['tx-live-2']['paymentStatus']);
+
+        // And the downstream settled CloudEvent actually fired.
+        $this->assertSame(['pipelinq.PosPayment.settled'], $webhooks->events);
+    }//end testSettlementWebhookMatchesTheSeededTransactionAndPersistsIt()
+
+    /**
+     * The session lookup must carry its context INSIDE `filters`.
+     *
+     * `findAll()`'s own docblock advertises `register` / `schema` as top-level
+     * config keys and never reads them there — which is how eleven sites in
+     * this app came to be written the wrong way (#793). Pinning the emitted
+     * query shape makes a regression fail here by name.
+     *
+     * @return void
+     */
+    public function testSessionLookupQueriesWithContextInsideFiltersOnly(): void
+    {
+        $store = new PaymentFakeObjectService();
+        $store->seed(
+            schema: 'posTransaction',
+            uuid: 'tx-1',
+            data: ['paymentSessionId' => 'tr_1', 'paymentStatus' => 'pending'],
+        );
+
+        $service = $this->buildService(object: $store, opts: ['webhooks' => new PaymentFakeWebhookService()]);
+        $service->handleSettlement(
+            providerName: 'mollie',
+            sessionId: 'tr_1',
+            paymentStatus: 'settled',
+            eventId: 'evt-1'
+        );
+
+        $this->assertNotSame([], $store->queries);
+        $config = $store->queries[0];
+
+        $this->assertSame('tr_1', $config['filters']['paymentSessionId']);
+        $this->assertSame('pipelinq', $config['filters']['register']);
+        $this->assertSame('posTransaction', $config['filters']['schema']);
+        $this->assertArrayNotHasKey('register', $config);
+        $this->assertArrayNotHasKey('schema', $config);
+        // `limit: 2` is the duplicate probe and must survive the re-keying.
+        $this->assertSame(2, $config['limit']);
+    }//end testSessionLookupQueriesWithContextInsideFiltersOnly()
+
+    /**
+     * `limit: 2` exists to detect a duplicate `paymentSessionId`; the second
+     * row was never counted, so the implied check did not exist. Two rows
+     * sharing a session id is data corruption on the money path and must be
+     * logged at error level, not silently resolved to whichever row came back
+     * first.
+     *
+     * @return void
+     */
+    public function testDuplicatePaymentSessionIdIsReportedAtErrorLevel(): void
+    {
+        $store = new PaymentFakeObjectService();
+        $store->seed(schema: 'posTransaction', uuid: 'tx-a', data: ['paymentSessionId' => 'tr_dup', 'paymentStatus' => 'pending']);
+        $store->seed(schema: 'posTransaction', uuid: 'tx-b', data: ['paymentSessionId' => 'tr_dup', 'paymentStatus' => 'pending']);
+
+        $messages = [];
+        $logger   = $this->createMock(originalClassName: LoggerInterface::class);
+        $logger->method('error')->willReturnCallback(
+            callback: function (string|\Stringable $message, array $context=[]) use (&$messages): void {
+                $messages[] = (string) $message;
+            }
+        );
+
+        $service = $this->buildService(object: $store, opts: ['logger' => $logger]);
+
+        $result = $service->handleSettlement(
+            providerName: 'mollie',
+            sessionId: 'tr_dup',
+            paymentStatus: 'settled',
+            eventId: 'evt-dup'
+        );
+
+        $this->assertSame('ok', $result['status']);
+        $this->assertNotSame([], $messages);
+        $this->assertStringContainsString('paymentSessionId is not unique', implode("\n", $messages));
+    }//end testDuplicatePaymentSessionIdIsReportedAtErrorLevel()
 
     /**
      * An unconfigured register/posTransaction_schema refuses the read AND

--- a/tests/Unit/Service/PosTenderServiceTest.php
+++ b/tests/Unit/Service/PosTenderServiceTest.php
@@ -46,8 +46,27 @@ use Psr\Log\LoggerInterface;
 /**
  * In-memory fake of the OR ObjectService for the tender tests.
  *
- * Keyed by schema then by uuid; findAll filters on the optional `filters`
- * entry; saveObject auto-assigns a uuid when empty.
+ * Keyed by schema then by uuid; saveObject auto-assigns a uuid when empty.
+ *
+ * ⚠️ This fake models OpenRegister's REGISTER/SCHEMA CONTEXT RESOLUTION, not
+ * just its method names, because that resolution is what pipelinq#793 / #799
+ * are about. The previous version resolved the schema from
+ * `$config['schema']` — the TOP-LEVEL key — which is precisely the key the
+ * real `ObjectService::prepareFindAllConfig()` never reads. It was therefore
+ * shaped to the (broken) caller rather than to the collaborator, and it kept
+ * this suite green over a live outage.
+ *
+ * The rules mirrored here, from `openregister@a4dd9067`:
+ *   - `findAll()` resolves context ONLY from `$config['filters']['register']`
+ *     and `['schema']` (`ObjectService::prepareFindAllConfig()` :1011-1035);
+ *     it then passes `$this->currentRegister` / `$this->currentSchema` to the
+ *     handler and NEVER restores them.
+ *   - With either still null, `MagicMapper::findAll()` (:8681) logs a warning
+ *     and returns `[]` — no exception.
+ *   - `saveObject()` sets the sticky context and does not restore it, so a
+ *     preceding write makes a later mis-keyed read appear to work.
+ *   - `find()` snapshots and restores the sticky context (BUG-OBJ-13 /
+ *     openregister#1520), so it leaves nothing behind for a later read.
  *
  * @SuppressWarnings(PHPMD.UnusedFormalParameter) Mirrors the real ObjectService signature.
  */
@@ -70,23 +89,120 @@ class TenderFakeObjectService
     public bool $throwOnSave = false;
 
     /**
+     * Sticky register context, as left behind by the last call that set it.
+     *
+     * @var string
+     */
+    public string $currentRegister = '';
+
+    /**
+     * Sticky schema context, as left behind by the last call that set it.
+     *
+     * @var string
+     */
+    public string $currentSchema = '';
+
+    /**
+     * Every findAll() config, in call order.
+     *
+     * @var array<int, array<string, mixed>>
+     */
+    public array $queries = [];
+
+    /**
+     * Opt-in switch that makes the fake ALSO honour a register/schema supplied
+     * at the TOP LEVEL of the config array. Real OpenRegister does not.
+     *
+     * ⚠️ It exists for exactly one reason: `PosTenderService` still has three
+     * mis-keyed `findAll()` sites that pipelinq#793 sequences behind guards
+     * this change deliberately does not build —
+     *   `listTenderTypes()`      (:155, flips the endpoint permissive→rejecting)
+     *   `listUnpostedTenders()`  (:828, unbounded whole-table read on a 5-min
+     *                             cron, one outbound GL CloudEvent per row)
+     *   `countTendersForType()`  (:921, makes any ever-used tender type
+     *                             permanently undeletable)
+     * A test that sets this flag is therefore declaring "the site under me is
+     * a KNOWN-BROKEN #793 site"; it still asserts the domain rule around it.
+     * When those three are repaired the flag comes off and the tests must
+     * still pass. Any NEW usage is a bug being pinned — do not add one.
+     *
+     * @var boolean
+     */
+    public bool $acceptTopLevelContext = false;
+
+    /**
+     * Read one object. Snapshots and restores the sticky context, exactly as
+     * `ObjectService::find()` does — so it leaves nothing behind for a later
+     * mis-keyed `findAll()` to inherit.
+     *
+     * @param integer|string  $id       Object id.
+     * @param array|null      $_extend  Extend list.
+     * @param boolean         $files    Include files.
+     * @param string|int|null $register Register context.
+     * @param string|int|null $schema   Schema context.
+     *
      * @return array<string, mixed>|null
      */
-    public function find(string $id, string $register, string $schema): ?array
-    {
-        return $this->store[$schema][$id] ?? null;
+    public function find(
+        int | string $id,
+        ?array $_extend=[],
+        bool $files=false,
+        string | int | null $register=null,
+        string | int | null $schema=null
+    ): ?array {
+        $snapshotRegister = $this->currentRegister;
+        $snapshotSchema   = $this->currentSchema;
+
+        $row = ($this->store[(string) $schema][(string) $id] ?? null);
+
+        $this->currentRegister = $snapshotRegister;
+        $this->currentSchema   = $snapshotSchema;
+
+        return $row;
     }//end find()
 
     /**
-     * @param array<string, mixed> $config
+     * Query objects. Context comes from `filters` only; anything left in the
+     * sticky properties by a previous call is inherited.
+     *
+     * @param array<string, mixed> $config Query config.
      *
      * @return array<int, array<string, mixed>>
      */
     public function findAll(array $config): array
     {
+        $this->queries[] = $config;
+
         $filters = (array) ($config['filters'] ?? []);
-        $schema  = (string) ($config['schema'] ?? '');
-        $rows    = array_values($this->store[$schema] ?? []);
+
+        // prepareFindAllConfig(): filters ONLY, and only when non-empty.
+        if (empty($filters['register']) === false && is_array($filters['register']) === false) {
+            $this->currentRegister = (string) $filters['register'];
+        }
+
+        if (empty($filters['schema']) === false && is_array($filters['schema']) === false) {
+            $this->currentSchema = (string) $filters['schema'];
+        }
+
+        if ($this->acceptTopLevelContext === true) {
+            if (empty($config['register']) === false) {
+                $this->currentRegister = (string) $config['register'];
+            }
+
+            if (empty($config['schema']) === false) {
+                $this->currentSchema = (string) $config['schema'];
+            }
+        }
+
+        if ($this->currentRegister === '' || $this->currentSchema === '') {
+            // MagicMapper::findAll(): warning + empty list, never an exception.
+            return [];
+        }
+
+        $rows = array_values($this->store[$this->currentSchema] ?? []);
+
+        // register/schema are context, not property filters.
+        unset($filters['register'], $filters['schema']);
 
         if ($filters === []) {
             return $rows;
@@ -109,17 +225,34 @@ class TenderFakeObjectService
     }//end findAll()
 
     /**
-     * @param array<string, mixed> $object
+     * Write an object. Sets the sticky context and does NOT restore it.
+     *
+     * @param array<string, mixed> $object   The payload.
+     * @param array|null           $extend   Extend list.
+     * @param string|int|null      $register Register context.
+     * @param string|int|null      $schema   Schema context.
+     * @param string|null          $uuid     Uuid for an update.
      *
      * @return array<string, mixed>
      */
-    public function saveObject(array $object, array $extend, string $register, string $schema, string $uuid): array
-    {
+    public function saveObject(
+        array $object,
+        ?array $extend=[],
+        string | int | null $register=null,
+        string | int | null $schema=null,
+        ?string $uuid=null
+    ): array {
         if ($this->throwOnSave === true) {
             throw new \RuntimeException('fake save error');
         }
 
-        if ($uuid === '') {
+        $register = (string) $register;
+        $schema   = (string) $schema;
+
+        $this->currentRegister = $register;
+        $this->currentSchema   = $schema;
+
+        if ((string) $uuid === '') {
             $this->seq++;
             $uuid = $schema.'-'.$this->seq;
         }
@@ -129,9 +262,23 @@ class TenderFakeObjectService
         return $object;
     }//end saveObject()
 
-    public function deleteObject(string $id, string $register, string $schema): void
+    /**
+     * Delete an object. The real parameter is `$uuid`; a caller spelling it
+     * `id:` gets `Error: Unknown named parameter $id`, which is what
+     * `deleteTenderType()` and `removeTender()` shipped with.
+     *
+     * @param string          $uuid     The object uuid.
+     * @param string|int|null $register Register context.
+     * @param string|int|null $schema   Schema context.
+     *
+     * @return void
+     */
+    public function deleteObject(string $uuid, string | int | null $register=null, string | int | null $schema=null): void
     {
-        unset($this->store[$schema][$id]);
+        $this->currentRegister = (string) $register;
+        $this->currentSchema   = (string) $schema;
+
+        unset($this->store[(string) $schema][$uuid]);
     }//end deleteObject()
 }//end class
 
@@ -335,10 +482,17 @@ class PosTenderServiceTest extends TestCase
     // -----------------------------------------------------------------
 
     /**
+     * ⚠️ `listTenderTypes()` (:155) is still a mis-keyed #793 site — pipelinq#793
+     * sequences it behind a product decision (it flips the endpoint from
+     * permissive to rejecting), so this change does not repair it. The flag
+     * restores the store's reachability so the sort rule is still asserted.
+     *
      * @return void
      */
     public function testListTenderTypesReturnsAllSortedBySortOrder(): void
     {
+        $this->objects->acceptTopLevelContext = true;
+
         $this->seedTenderType(['id' => 't1', 'code' => 'CASH', 'sortOrder' => 2]);
         $this->seedTenderType(['id' => 't2', 'code' => 'CARD', 'sortOrder' => 1]);
         $this->seedTenderType(['id' => 't3', 'code' => 'OFF',  'sortOrder' => 3, 'isActive' => false]);
@@ -352,10 +506,14 @@ class PosTenderServiceTest extends TestCase
     }//end testListTenderTypesReturnsAllSortedBySortOrder()
 
     /**
+     * ⚠️ Same known-broken site as above: `listTenderTypes()` (:155), #793.
+     *
      * @return void
      */
     public function testListTenderTypesActiveOnlyFiltersDeactivated(): void
     {
+        $this->objects->acceptTopLevelContext = true;
+
         $this->seedTenderType(['id' => 't1', 'code' => 'CASH']);
         $this->seedTenderType(['id' => 't2', 'code' => 'OFF', 'isActive' => false]);
 
@@ -409,10 +567,15 @@ class PosTenderServiceTest extends TestCase
     }//end testCreateTenderTypeRequiresGlAccount()
 
     /**
+     * ⚠️ The uniqueness check reads through `listTenderTypes()` (:155), a
+     * known-broken #793 site this change does not repair.
+     *
      * @return void
      */
     public function testCreateTenderTypeRejectsDuplicateCode(): void
     {
+        $this->objects->acceptTopLevelContext = true;
+
         $this->seedTenderType(['id' => 't1', 'code' => 'CASH']);
 
         $this->expectException(OCSBadRequestException::class);
@@ -458,10 +621,16 @@ class PosTenderServiceTest extends TestCase
     }//end testUpdateTenderTypePreservesCode()
 
     /**
+     * ⚠️ The active-reference guard reads through `countTendersForType()`
+     * (:921), a known-broken #793 site this change does not repair (fixing it
+     * would make any ever-used tender type permanently undeletable).
+     *
      * @return void
      */
     public function testDeleteTenderTypeWithActiveReferencesRejects(): void
     {
+        $this->objects->acceptTopLevelContext = true;
+
         $this->seedTenderType(['id' => 't1', 'code' => 'CASH']);
         $this->seedTender(['tenderType' => 't1']);
 
@@ -718,6 +887,149 @@ class PosTenderServiceTest extends TestCase
     }//end testGetTendersForEmptyIdReturnsEmpty()
 
     // -----------------------------------------------------------------
+    // pipelinq#799 — the settle path, with NO preceding write
+    // -----------------------------------------------------------------
+
+    /**
+     * THE #799 REGRESSION GUARD.
+     *
+     * `POST /api/pos-transactions/{id}/settle` reaches
+     * `getTendersForTransaction()` with nothing having written first:
+     * `fetchTransaction()` is an `ObjectService::find()`, and `find()`
+     * snapshots and restores the sticky register/schema context, so it leaves
+     * none behind. With `register`/`schema` keyed at the top level of the
+     * `findAll()` config — where OpenRegister never reads them — the query
+     * resolved no context at all, returned `[]`, and `assertBalancedForSettle()`
+     * saw `tenderSum = 0` and rejected every non-zero transaction with a 409
+     * "Underpayment" that was arithmetically true and factually wrong.
+     *
+     * The assertion is on the SEEDED AMOUNTS, not on "more than zero rows":
+     * a scoped read and an unscoped one are indistinguishable to a count.
+     *
+     * @return void
+     */
+    public function testSettleReadsTheSeededTendersWithNoPrecedingWrite(): void
+    {
+        $this->seedTenderType(['id' => 't1']);
+        $this->seedTransaction(['id' => 'tx-settle', 'total' => 25.00]);
+        $this->seedTender(['id' => 'a', 'transaction' => 'tx-settle', 'amount' => 10.00, 'sortOrder' => 1]);
+        $this->seedTender(['id' => 'b', 'transaction' => 'tx-settle', 'amount' => 15.00, 'sortOrder' => 2]);
+        $this->seedTender(['id' => 'other', 'transaction' => 'tx-elsewhere', 'amount' => 99.00]);
+
+        // The control that makes this the SETTLE path and not the addTender
+        // path: no write has run, so there is no sticky context to inherit.
+        $this->assertSame('', $this->objects->currentRegister);
+        $this->assertSame('', $this->objects->currentSchema);
+
+        $validation = $this->service->validateTenderSum(transactionId: 'tx-settle');
+
+        $this->assertSame(25.00, $validation['tenderSum']);
+        $this->assertSame(25.00, $validation['transactionTotal']);
+        $this->assertSame(0.00, $validation['variance']);
+        $this->assertTrue($validation['balanced']);
+
+        // And the settle guard itself lets the transaction through.
+        $this->service->assertBalancedForSettle(transactionId: 'tx-settle');
+        $this->addToAssertionCount(1);
+    }//end testSettleReadsTheSeededTendersWithNoPrecedingWrite()
+
+    /**
+     * The context keys must travel INSIDE `filters`.
+     *
+     * `ObjectService::prepareFindAllConfig()` reads
+     * `$config['filters']['register']` / `['schema']` and nothing else, while
+     * `findAll()`'s own docblock advertises them as top-level keys — which is
+     * how eleven sites in this app came to be written the wrong way (#793).
+     * Asserting the emitted query shape pins the contract directly, so a
+     * future edit that moves them back out fails here by name.
+     *
+     * @return void
+     */
+    public function testGetTendersQueriesWithContextInsideFiltersOnly(): void
+    {
+        $this->seedTransaction(['id' => 'tx1', 'total' => 10.00]);
+        $this->seedTender(['id' => 'a', 'transaction' => 'tx1', 'amount' => 10.00]);
+
+        $this->service->getTendersForTransaction(transactionId: 'tx1');
+
+        $this->assertCount(1, $this->objects->queries);
+        $config = $this->objects->queries[0];
+
+        $this->assertSame('reg', $config['filters']['register']);
+        $this->assertSame('posTender', $config['filters']['schema']);
+        $this->assertArrayNotHasKey('register', $config);
+        $this->assertArrayNotHasKey('schema', $config);
+    }//end testGetTendersQueriesWithContextInsideFiltersOnly()
+
+    /**
+     * One line, two call orders, one answer.
+     *
+     * The defect's signature was that `getTendersForTransaction()` WORKED when
+     * reached through `addTender()` — whose preceding `saveObject()` had
+     * already pinned the posTender context that the mis-keyed query then
+     * inherited — and FAILED when reached through settle. Whoever tested
+     * addTender saw it work. This asserts the two orders now agree.
+     *
+     * @return void
+     */
+    public function testAddTenderAndSettleOrdersAgreeOnTheSameTenderSum(): void
+    {
+        $this->seedTenderType(['id' => 't1', 'code' => 'CASH', 'allowsChange' => false]);
+        $this->seedTransaction(['id' => 'tx1', 'total' => 12.50]);
+
+        // Order A — through addTender(), which writes first.
+        $this->service->addTender(
+            transactionId: 'tx1',
+            payload: ['tenderType' => 't1', 'amount' => 12.50],
+        );
+        $afterWrite = $this->service->validateTenderSum(transactionId: 'tx1');
+
+        // Order B — settle, on a service instance with no sticky context.
+        $this->objects->currentRegister = '';
+        $this->objects->currentSchema   = '';
+        $afterRestore = $this->service->validateTenderSum(transactionId: 'tx1');
+
+        $this->assertSame(12.50, $afterWrite['tenderSum']);
+        $this->assertSame(12.50, $afterRestore['tenderSum']);
+        $this->assertSame($afterWrite['tenderSum'], $afterRestore['tenderSum']);
+    }//end testAddTenderAndSettleOrdersAgreeOnTheSameTenderSum()
+
+    /**
+     * `deleteObject()`'s first parameter is `$uuid`. `removeTender()` shipped
+     * calling it `id:`, which is `Error: Unknown named parameter $id` at
+     * runtime — swallowed by the surrounding `catch (Throwable)` and reported
+     * as an ordinary "Failed to remove tender". The previous fake DECLARED the
+     * parameter as `$id`, mirroring the broken caller instead of the real
+     * collaborator, so the suite was green over a guaranteed fatal.
+     *
+     * @return void
+     */
+    public function testRemoveTenderActuallyDeletesTheRow(): void
+    {
+        $this->seedTenderType(['id' => 't1']);
+        $this->seedTransaction(['id' => 'tx1', 'total' => 10.00]);
+        $this->seedTender(['id' => 'tnd1', 'transaction' => 'tx1', 'amount' => 10.00]);
+
+        $this->service->removeTender(transactionId: 'tx1', tenderId: 'tnd1');
+
+        $this->assertArrayNotHasKey('tnd1', $this->objects->store['posTender']);
+    }//end testRemoveTenderActuallyDeletesTheRow()
+
+    /**
+     * Same defect on the tender-type delete path (`deleteTenderType()`).
+     *
+     * @return void
+     */
+    public function testDeleteTenderTypeActuallyDeletesTheRow(): void
+    {
+        $this->seedTenderType(['id' => 't1', 'code' => 'CASH']);
+
+        $this->service->deleteTenderType(id: 't1');
+
+        $this->assertArrayNotHasKey('t1', $this->objects->store['posTenderType']);
+    }//end testDeleteTenderTypeActuallyDeletesTheRow()
+
+    // -----------------------------------------------------------------
     // validateTenderSum + assertBalancedForSettle (REQ-PST-004)
     // -----------------------------------------------------------------
 
@@ -879,10 +1191,17 @@ class PosTenderServiceTest extends TestCase
     }//end testMarkTenderGlPostedFlipsTheFlag()
 
     /**
+     * ⚠️ `listUnpostedTenders()` (:828) is still a mis-keyed #793 site — an
+     * unbounded whole-table read on a five-minute cron that emits one outbound
+     * GL CloudEvent per row, so it needs a limit and a batch cap before it may
+     * be switched on. This change does not repair it.
+     *
      * @return void
      */
     public function testListUnpostedTendersIncludesAttemptedNotConfirmed(): void
     {
+        $this->objects->acceptTopLevelContext = true;
+
         $this->seedTender(['id' => 'a', 'glPosted' => false, 'glPostAttempts' => 1]);
         $this->seedTender(['id' => 'b', 'glPosted' => true,  'glPostAttempts' => 2]);
         $this->seedTender(['id' => 'c', 'glPosted' => false, 'glPostAttempts' => 0]);


### PR DESCRIPTION
Closes #799. Refs #793, #784.

Two of the eleven mis-keyed `findAll()` sites from #793 are **live outages on the money path**, not dormant features. Both shipped broken on 2026-06-08, so **nothing regressed** — no test could have gone green → red, and the reconciliation window is the whole life of the feature.

## The mechanism

`ObjectService::prepareFindAllConfig()` (`openregister@a4dd9067`, `:1011-1035`) resolves the query context **only** from `$config['filters']['register']` / `['schema']`, while `findAll()`'s own docblock advertises them as top-level keys. A top-level pair leaves `currentRegister` / `currentSchema` untouched, and `MagicMapper::findAll()` (`:8681`) then logs a warning and returns `[]` — no exception. **The API documents an input it ignores**, which is why eleven sites in one app made the same mistake.

## 1 — every settlement webhook was discarded at HTTP 200

`PosPaymentService::findTransactionBySessionId()` → `[]` → `null` → `handleSettlement()` returned `['status' => 'ignored']` → `PosPaymentController::webhook()` returned it as `new JSONResponse($result)` = **200**. A provider that receives 200 does not retry: money moved at the provider, the settlement never landed, and the only trace was an `info` log line.

**Response semantics, and why 503.** The status vocabulary is the controller's HTTP contract, so it now says whether the delivery was *consumed*:

| status | meaning | HTTP |
|---|---|---|
| `ok` / `duplicate` | consumed (the duplicate branch is the idempotency hit — it *was* applied) | 200 |
| `invalid` | not ours: bad signature or unknown provider | 400 (unchanged) |
| `ignored` | well-formed but **carries no session id**, so there is nothing to match and a redelivery of the same bytes can never succeed | 200 (unchanged, by design) |
| **`unmatched`** | signed, carries a session id, **nothing was persisted** | **503** |

**How the code was read to pick this.** Separating what is in the repo from what is not:

- **In the repo (evidence).** The four adapters — `MollieAdapter`, `CcvAdapter`, `AdyenAdapter`, `StripeAdapter` — carry no inbound retry policy of their own; `PaymentProviderInterface::validateWebhook()` returns a bool and the status decision is the controller's alone. What the repo *does* state, twice, is the rule this PR applies: `PosPaymentController::webhook()`'s own comment says *"providers will retry on 5xx"* (and then returned 200 anyway), and #784 ships a committed test, `testWebhookDoesNotAcknowledgeAnUnprocessedDelivery`, asserting `>= 500` for an unprocessed delivery. So 5xx-for-unprocessed is the contract the codebase already wrote down and did not implement.
- **Not in the repo (general provider behaviour, stated as such).** Mollie, Stripe, Adyen and CCV all stop redelivering on a 2xx and redeliver on a 5xx. I have not verified this against a live provider account, and no test here can — it is the premise the issue rests on (*"a provider that receives 200 does not retry"*), not something this PR measured.

503 rather than 500 because the condition is genuinely **transient and retry-resolvable**: a webhook can outrun the transaction write, and an unconfigured register/schema is repaired by an operator, not by the provider. Any 5xx satisfies the contract; 503 is the most accurate one.

Splitting `unmatched` out of `ignored` is the load-bearing part: **one of the two is retryable and the other is not**, and they were the same value.

Two co-located defects in the same method, per the issue's sequencing note:
- `limit: 2` is there to detect a duplicate `paymentSessionId` and the second row was never counted. It is now inspected: two rows sharing one session id is data corruption on the money path and is logged at `error`, not silently resolved to whichever row came back first.
- the blanket `catch (Throwable) { return null; }` now logs the exception class. That catch is what let a *fatal signature error* ship in June and survive a rewrite, because "not found" is also a legitimate business outcome here. The two are now distinguishable in the log.

## 2 — POS settle 409'd for every non-zero transaction

`PosTenderService::getTendersForTransaction()` returned `[]` on the settle path, so `assertBalancedForSettle()` saw `tenderSum = 0`, `variance = total`, and threw `InvalidTenderException(409)` with an underpayment message that was arithmetically true and factually wrong.

⚠️ **The same line had two outcomes decided by call order.** Through `addTender()` a preceding `saveObject()` had already pinned the `posTender` sticky context, which the mis-keyed query inherited — so it *worked*. Through `settle` nothing precedes it (`fetchTransaction()` is a `find()`, and `find()` snapshots and restores), so it read nothing. Whoever tested `addTender` saw it work. The new guard covers the **settle** path with **no preceding write**, and asserts that fact explicitly before calling.

## 3 — two fatal named arguments, found by the audit this PR was asked to run

The `RequireNamedParameters` sniff checks a named argument is **present**, not that the name **exists on the callee** — the defect that manufactured #799 in the first place. Auditing every named argument in `lib/` against the real signatures found `PosTenderService` calling `ObjectService::deleteObject(id: ...)`. The parameter is **`$uuid`**, so both sites raise `Error: Unknown named parameter $id`, swallowed by the surrounding `catch` and surfaced as *"Failed to remove tender"* / *"Failed to delete tender type"*. **Neither delete has ever worked.** Positive-controlled directly: `uuid:` → `bool(true)`, `id:` → `Error: Unknown named parameter $id`.

Four more instances outside these files are reported separately rather than fixed here, to keep this PR narrow.

## Why the suite was green over all of this

`TenderFakeObjectService::findAll()` read **`$config['schema']` — the top-level key OpenRegister never reads** — and `TenderFakeObjectService::deleteObject()` declared **`string $id`**. Both were shaped to the broken **caller** rather than to the real **collaborator**, so the double inverted the exact predicate under test. `PosPaymentServiceTest` used `createMock(ObjectService::class)` with `willReturn([$tx])`, which answers the same rows whatever the config held — a mock cannot see this class of bug at all.

Both doubles now model, from the OpenRegister source: `prepareFindAllConfig()`'s filters-only resolution; `MagicMapper`'s warning-and-empty-list return; and the sticky-context asymmetry (`saveObject()` sets and never restores, `find()` snapshots and restores). **Layer covered: the pipelinq PHP service and controller against a double that mirrors OpenRegister's documented context resolution.** It is not a live-instance measurement, and the `503` figures below are the controller's own `JSONResponse::getStatus()`.

## Negative controls — each expected number stated before the run

| control | predicted | measured |
|---|---|---|
| revert the tender keying | 10 | **10** (8 failures + 2 errors) |
| revert the payment keying | 3 | **3** |
| revert the 503 mapping | 1 | **1** |
| revert `deleteObject(uuid:)` → `id:` | 2 | **4** |

The tender control reproduces the issue **verbatim**:

```
InvalidTenderException: Tender sum (€0.00) does not equal transaction total (€50.00). Underpayment: €50.00
```

and `testSettleReadsTheSeededTendersWithNoPrecedingWrite` fails with `Failed asserting that 0.0 is identical to 25.0`.

⚠️ Under that same control, **`testAssertBalancedForSettleRejectsUnderpayment` stays GREEN** — a zero-tender read *is* arithmetically an underpayment. That is exactly why the outage was invisible, and it is why the guards assert the **seeded amounts** rather than a row count: `assertGreaterThan(0, $n)` cannot tell a scoped result from an unscoped one.

The last control is the honest correction: I predicted 2 and measured **4**. Two *pre-existing* tests (`testRemoveTenderDeletesValidTender`, `testDeleteTenderTypeNoReferencesSucceeds`) also go red once the double declares the real parameter name — they had been green only because the fake mirrored the broken caller.

The status-code control is the before/after on the money path: **`Failed asserting that 200 is identical to 503`**.

## Switch-on analysis — what becomes reachable when each query starts returning rows

A silently-empty query is load-bearing by accident, so repairing one is a **switch-on**, not an improvement. Per site, what runs on a NON-empty result:

**`findTransactionBySessionId()` → `handleSettlement()` — bounded at 1 write, ≤1 event, per delivery.**
1. idempotency check against `paymentWebhookEventId` — read-only, and it short-circuits a redelivery to `duplicate`;
2. `buildSettlementPatch()` — pure;
3. `saveTransaction()` — **exactly one `saveObject()`**. No loop; `limit: 2` bounds the read and one row is used;
4. `emitSettlementEvents()` — **at most one** CloudEvent (`settled` XOR `refunded`), and only on an actual status transition (`$paymentStatus === 'settled' && $previousStatus !== 'settled'`), so a redelivery emits nothing.

`grep` for `sms|whatsapp|IMailer|INotification` across `PosPaymentService` and `PosTenderService`: **no hits — no customer contact on either path.** `pipelinq.PosPayment.settled` has **no in-app listener**; it leaves only via OR's `WebhookService` to external subscribers, inside a `try/catch`. Nothing moves to a terminal state.

⚠️ **And the backlog does not stampede.** Providers do not resend a delivery they already got a 200 for, so switching this on does *not* replay two months of webhooks — only new deliveries arrive. That is the same fact that makes the manual reconciliation below unavoidable.

**`getTendersForTransaction()` — bounded per transaction.** Callers: `validateTenderSum()` and `assertBalancedForSettle()` (pure arithmetic, zero writes), `addTender()` (a `count()` for the default `sortOrder`), and `emitTendersPosted()`, which **is** a fan-out: one CloudEvent + one `saveObject()` per tender. It is bounded by the tenders on **one** transaction (a split tender is realistically 1–5), it is already capped by `MAX_GL_POST_ATTEMPTS`, and it is the designed behaviour of settling. Today it is unreachable — `assertBalancedForSettle()` 409s before `settleTransaction()` ever calls it.

Contrast with the sites left alone: `PosTenderService:828` is **whole-table, no limit, no filter, every five minutes, unattended**, and `SlaEngineService:565` is ≤15 000 `saveObject` per sweep plus real SMS/WhatsApp to customers. Those are the ones that need a backfill mode first, and they are untouched. Repairing `:358` does not make `:828` any more reachable — it is still mis-keyed, so the GL retry job still reads nothing.

### ⚠️ The 503 and the keying fix MUST ship together, and they do

Answering a retryable status switches on a provider-side retry loop that has never run. Two things bound it:

- **There is no retry loop inside pipelinq** — no job, no queue, no local re-delivery. The retry is entirely the provider's, so this cannot serialise writes on the instance the way a self-driving retry against a dead endpoint can.
- **Order matters, and it is why these are one commit.** With the 503 shipped *without* the keying fix, **every** settlement would answer `unmatched` and every provider would retry indefinitely against an endpoint that can never succeed. With both, `unmatched` is what it says: a genuinely unknown session. Do not cherry-pick the controller change.

## What is deliberately NOT in this change

- **The nine other #793 sites.** #793 sequences them behind guards this PR does not build: `SlaEngineService:565` needs a backfill mode before it fires real SMS/WhatsApp at customers, `AppointmentDepositTimeoutJob:157` needs an age ceiling in the query, `PosTenderService:828` needs a limit and a batch cap, and `:155`/`:921` flip endpoints from permissive to rejecting (a product decision).
- Three `PosTenderService` sites are still mis-keyed, so five existing tests now opt into a documented `acceptTopLevelContext` flag on the fake. Each carries a docblock naming its site and #793. **The flag defaults to `false`, so it is a greppable inventory of what is left** — when those three are repaired the flag comes off and the tests must still pass. No new usage may be added.
- **#784** (a *crash* inside `handleWebhook` is answered 200 `deferred`) is a separate open issue with its own committed skipped test asserting `>= 500`. Same family, different branch, left to its own change.
- `PosTenderService:764`/`:773` dispatch-before-persist: real, but it changes GL event-emission ordering and deserves its own change.

## Operations

⚠️ **A code fix does not recover the backlog.** Every webhook already answered 200 will not be resent by any provider. Settlements from **2026-06-08 to this merge** must be reconciled manually against Mollie / CCV / Adyen / Stripe. There is no queue to replay from.

## Checks

`2139 tests / 7268 assertions / 0 failures` (was 2130 / 7225). `phpcs` **0 errors** / 597 warnings (was 1 error — pre-existing, fixed). `phpmd`, `psalm`, `phpstan`: clean. Three "Undefined array key" warnings removed as well: `testUpdateProviderKeepsStoredSecretWhenMaskOrEmpty` read a config key the service stopped writing when the api key moved to the credential broker, so all three of its assertions compared `null` to `null` — green while measuring nothing.

Changed-file sets diffed against the other open PRs (#797, #779): **no overlap and no symbol coupling**, checked for the constructor-signature-vs-call-site shape that broke `development` once already.
