### PR TITLE
fix(security): guard the contract handoff endpoints and revive the dead per-object guard (#801)

### DIFF
--- a/lib/Controller/ActivityTimelineController.php
+++ b/lib/Controller/ActivityTimelineController.php
@@ -73,13 +73,20 @@ class ActivityTimelineController extends Controller
     /**
      * Verify that the underlying OR object exists and is accessible.
      *
-     * Returns true if the object is found. Returns false on a clean 404.
-     * Fails open on service errors so a temporary OR outage does not block
-     * the entire timeline/worklog surface.
+     * Returns true if the object is found. Returns false on a clean 404 and
+     * **false on any service error**.
+     *
+     * ⚠️ This used to `return true` from the catch, described as "fails open so
+     * a temporary OR outage does not block the timeline surface". That makes an
+     * unavailable object service indistinguishable from a successful check —
+     * CWE-863, and it is the only thing standing between a caller-supplied
+     * `entityId` and someone else's merged contactmoment/worklog/note history
+     * (#801). Availability is not worth trading for it: a failed check now
+     * denies, and the warning still records the outage.
      *
      * @param string $entityId The OR object UUID.
      *
-     * @return bool Whether the object can be accessed.
+     * @return bool Whether the object could be verified.
      */
     private function objectExists(string $entityId): bool
     {
@@ -89,10 +96,10 @@ class ActivityTimelineController extends Controller
             return $object !== null;
         } catch (\Throwable $e) {
             $this->logger->warning(
-                'ActivityTimelineController: could not verify object existence',
+                'ActivityTimelineController: could not verify object existence, denying',
                 ['entityId' => $entityId, 'exception' => $e->getMessage()]
             );
-            return true;
+            return false;
         }
     }//end objectExists()
 

--- a/lib/Controller/ContractController.php
+++ b/lib/Controller/ContractController.php
@@ -32,13 +32,13 @@ namespace OCA\Pipelinq\Controller;
 
 use InvalidArgumentException;
 use OCA\Pipelinq\AppInfo\Application;
+use OCA\Pipelinq\Lifecycle\ObjectOwnerAccessPolicy;
 use OCA\Pipelinq\Service\ContractService;
 use OCA\Pipelinq\Service\RecurringRevenueService;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\Attribute\NoAdminRequired;
 use OCP\AppFramework\Http\JSONResponse;
-use OCP\IGroupManager;
 use OCP\IRequest;
 use OCP\IUserSession;
 use Psr\Container\ContainerInterface;
@@ -53,29 +53,22 @@ use Throwable;
 class ContractController extends Controller
 {
     /**
-     * Groups whose members may transition any contract.
-     *
-     * @var string[]
-     */
-    private const PRIVILEGED_GROUPS = ['admin', 'sales'];
-
-    /**
      * Constructor.
      *
-     * @param IRequest                $request         The request.
-     * @param ContractService         $contractService Contract lifecycle service.
-     * @param RecurringRevenueService $revenueService  Recurring-revenue service.
-     * @param IUserSession            $userSession     The user session.
-     * @param IGroupManager           $groupManager    The group manager.
-     * @param ContainerInterface      $container       The DI container.
-     * @param LoggerInterface         $logger          PSR logger.
+     * @param IRequest                 $request         The request.
+     * @param ContractService          $contractService Contract lifecycle service.
+     * @param RecurringRevenueService  $revenueService  Recurring-revenue service.
+     * @param IUserSession             $userSession     The user session.
+     * @param ObjectOwnerAccessPolicy  $accessPolicy    Per-object owner authorization.
+     * @param ContainerInterface       $container       The DI container.
+     * @param LoggerInterface          $logger          PSR logger.
      */
     public function __construct(
         IRequest $request,
         private ContractService $contractService,
         private RecurringRevenueService $revenueService,
         private IUserSession $userSession,
-        private IGroupManager $groupManager,
+        private ObjectOwnerAccessPolicy $accessPolicy,
         private ContainerInterface $container,
         private LoggerInterface $logger,
     ) {
@@ -245,7 +238,16 @@ class ContractController extends Controller
 
         try {
             $objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
-            $object        = $objectService->find($id, $registerId, $schemaId);
+            // Named arguments are load-bearing: ObjectService::find()'s second and
+            // third parameters are `?array $_extend` and `bool $files`, so the
+            // positional form passed the register id into $_extend and raised a
+            // TypeError that the catch below swallowed into a 404 — for the owner
+            // as well as for a stranger. See #801.
+            $object = $objectService->find(
+                id: $id,
+                register: $registerId,
+                schema: $schemaId,
+            );
             if ($object === null) {
                 return null;
             }
@@ -272,16 +274,6 @@ class ContractController extends Controller
      */
     private function isAuthorized(string $uid, array $contract): bool
     {
-        if (((string) ($contract['ownerId'] ?? '')) === $uid) {
-            return true;
-        }
-
-        foreach (self::PRIVILEGED_GROUPS as $group) {
-            if ($this->groupManager->isInGroup($uid, $group) === true) {
-                return true;
-            }
-        }
-
-        return false;
+        return $this->accessPolicy->mayAccess(uid: $uid, object: $contract, ownerField: 'ownerId');
     }//end isAuthorized()
 }//end class

--- a/lib/Controller/ContractController.php
+++ b/lib/Controller/ContractController.php
@@ -55,13 +55,13 @@ class ContractController extends Controller
     /**
      * Constructor.
      *
-     * @param IRequest                 $request         The request.
-     * @param ContractService          $contractService Contract lifecycle service.
-     * @param RecurringRevenueService  $revenueService  Recurring-revenue service.
-     * @param IUserSession             $userSession     The user session.
-     * @param ObjectOwnerAccessPolicy  $accessPolicy    Per-object owner authorization.
-     * @param ContainerInterface       $container       The DI container.
-     * @param LoggerInterface          $logger          PSR logger.
+     * @param IRequest                $request         The request.
+     * @param ContractService         $contractService Contract lifecycle service.
+     * @param RecurringRevenueService $revenueService  Recurring-revenue service.
+     * @param IUserSession            $userSession     The user session.
+     * @param ObjectOwnerAccessPolicy $accessPolicy    Per-object owner authorization.
+     * @param ContainerInterface      $container       The DI container.
+     * @param LoggerInterface         $logger          PSR logger.
      */
     public function __construct(
         IRequest $request,

--- a/lib/Controller/SemanticHandoffController.php
+++ b/lib/Controller/SemanticHandoffController.php
@@ -30,6 +30,7 @@ declare(strict_types=1);
 namespace OCA\Pipelinq\Controller;
 
 use OCA\Pipelinq\AppInfo\Application;
+use OCA\Pipelinq\Lifecycle\ObjectOwnerAccessPolicy;
 use OCA\Pipelinq\Service\SemanticHandoffService;
 use OCA\Pipelinq\Service\TicketService;
 use OCP\AppFramework\Controller;
@@ -46,11 +47,20 @@ use Throwable;
 /**
  * Request→Case and Contract→Invoice emit endpoints.
  *
- * Endpoints (all NoAdminRequired + per-object register-RBAC guard):
+ * Endpoints (all NoAdminRequired):
  *   GET  /api/handoff/request/{id}/availability
  *   POST /api/handoff/request/{id}/convert-to-case
  *   GET  /api/handoff/contract/{id}/availability
  *   POST /api/handoff/contract/{id}/send-to-invoicing
+ *
+ * ⚠️ There is no per-object "register-RBAC guard" behind these routes — an
+ * earlier version of this docblock claimed one and there never was one. A
+ * schema that declares no `authorization` block makes OpenRegister's
+ * PermissionHandler grant every action to every authenticated user, so the
+ * controller is the only layer. The two contract routes therefore authorize
+ * explicitly against the contract's `ownerId` via {@see ObjectOwnerAccessPolicy}.
+ * The two request routes cannot: the `ticket` schema declares no owner field,
+ * so who may act on someone else's ticket is an open product decision (#801).
  *
  * Since unify-ticket-supertype a request is a `ticket` carrying
  * `ticketType: request` — the request endpoints read and write the unified
@@ -89,9 +99,10 @@ class SemanticHandoffController extends Controller
      * @param SemanticHandoffService $handoffService Kind resolution + emit wrapper.
      * @param ContainerInterface     $container      DI container (OR ObjectService).
      * @param IAppConfig             $appConfig      App config (register/schema slugs).
-     * @param TicketService          $ticketService  Unified ticket resolver.
-     * @param IUserSession           $userSession    User session.
-     * @param LoggerInterface        $logger         Logger.
+     * @param TicketService           $ticketService  Unified ticket resolver.
+     * @param IUserSession            $userSession    User session.
+     * @param ObjectOwnerAccessPolicy $accessPolicy   Per-object owner authorization.
+     * @param LoggerInterface         $logger         Logger.
      */
     public function __construct(
         IRequest $request,
@@ -100,6 +111,7 @@ class SemanticHandoffController extends Controller
         private IAppConfig $appConfig,
         private TicketService $ticketService,
         private IUserSession $userSession,
+        private ObjectOwnerAccessPolicy $accessPolicy,
         private LoggerInterface $logger,
     ) {
         parent::__construct(appName: Application::APP_ID, request: $request);
@@ -222,13 +234,18 @@ class SemanticHandoffController extends Controller
     #[NoAdminRequired]
     public function contractAvailability(string $id=''): JSONResponse
     {
-        if ($this->userSession->getUser() === null) {
+        $user = $this->userSession->getUser();
+        if ($user === null) {
             return new JSONResponse(['status' => 'unauthorized'], Http::STATUS_UNAUTHORIZED);
         }
 
         $contract = $this->loadObject(schema: $this->schemaSlug(key: 'contract_schema', default: 'contract'), id: $id);
         if ($contract === null) {
             return new JSONResponse(['status' => 'not-found'], Http::STATUS_NOT_FOUND);
+        }
+
+        if ($this->mayActOnContract(uid: $user->getUID(), contract: $contract) === false) {
+            return new JSONResponse(['status' => 'forbidden'], Http::STATUS_FORBIDDEN);
         }
 
         $available = $this->handoffService->hasImplementer(kindUri: self::KIND_INVOICE);
@@ -255,13 +272,20 @@ class SemanticHandoffController extends Controller
     #[NoAdminRequired]
     public function sendContractToInvoicing(string $id=''): JSONResponse
     {
-        if ($this->userSession->getUser() === null) {
+        $user = $this->userSession->getUser();
+        if ($user === null) {
             return new JSONResponse(['status' => 'unauthorized'], Http::STATUS_UNAUTHORIZED);
         }
 
         $contract = $this->loadObject(schema: $this->schemaSlug(key: 'contract_schema', default: 'contract'), id: $id);
         if ($contract === null) {
             return new JSONResponse(['status' => 'not-found'], Http::STATUS_NOT_FOUND);
+        }
+
+        // Authorize BEFORE the status gate: a stranger must not be able to
+        // distinguish "not yours" from "not active" on someone else's contract.
+        if ($this->mayActOnContract(uid: $user->getUID(), contract: $contract) === false) {
+            return new JSONResponse(['status' => 'forbidden'], Http::STATUS_FORBIDDEN);
         }
 
         if ((string) ($contract['status'] ?? '') !== 'active') {
@@ -345,7 +369,24 @@ class SemanticHandoffController extends Controller
     }//end ticketSchema()
 
     /**
-     * Load a pipelinq-register object by schema slug/id + id (per-object guard).
+     * Per-object authorization for a contract: owner or privileged group.
+     *
+     * @param string              $uid      The caller user ID.
+     * @param array<string,mixed> $contract The loaded contract.
+     *
+     * @return bool True when the caller may act on this contract.
+     */
+    private function mayActOnContract(string $uid, array $contract): bool
+    {
+        return $this->accessPolicy->mayAccess(uid: $uid, object: $contract, ownerField: 'ownerId');
+    }//end mayActOnContract()
+
+    /**
+     * Load a pipelinq-register object by schema slug/id + id.
+     *
+     * ⚠️ This is a LOAD, not a guard. Its docblock used to say "per-object
+     * guard" and the body has only ever been `find(id, register, schema)`;
+     * callers must authorize the object themselves (#801).
      *
      * @param string $schema Schema id or slug.
      * @param string $id     Object UUID.

--- a/lib/Controller/SemanticHandoffController.php
+++ b/lib/Controller/SemanticHandoffController.php
@@ -95,10 +95,10 @@ class SemanticHandoffController extends Controller
     /**
      * Constructor.
      *
-     * @param IRequest               $request        HTTP request.
-     * @param SemanticHandoffService $handoffService Kind resolution + emit wrapper.
-     * @param ContainerInterface     $container      DI container (OR ObjectService).
-     * @param IAppConfig             $appConfig      App config (register/schema slugs).
+     * @param IRequest                $request        HTTP request.
+     * @param SemanticHandoffService  $handoffService Kind resolution + emit wrapper.
+     * @param ContainerInterface      $container      DI container (OR ObjectService).
+     * @param IAppConfig              $appConfig      App config (register/schema slugs).
      * @param TicketService           $ticketService  Unified ticket resolver.
      * @param IUserSession            $userSession    User session.
      * @param ObjectOwnerAccessPolicy $accessPolicy   Per-object owner authorization.

--- a/lib/Lifecycle/ObjectOwnerAccessPolicy.php
+++ b/lib/Lifecycle/ObjectOwnerAccessPolicy.php
@@ -1,0 +1,107 @@
+<?php
+
+/**
+ * Pipelinq ObjectOwnerAccessPolicy.
+ *
+ * Per-object authorization for objects that carry an owner field: the caller
+ * must be the owner, or belong to a privileged group (ADR-005, OWASP A01:2021).
+ *
+ * @category Lifecycle
+ * @package  OCA\Pipelinq\Lifecycle
+ *
+ * @author    Conduction <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git_id>
+ *
+ * @link https://github.com/ConductionNL/pipelinq
+ *
+ * @spec openspec/specs/contract-renewal-tracking/spec.md#requirement-contract-lifecycle-management
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Pipelinq\Lifecycle;
+
+use OCP\IGroupManager;
+
+/**
+ * Owner-or-privileged-group authorization for a loaded register object.
+ *
+ * This is the single implementation of the model pipelinq already expressed in
+ * `ContractController::isAuthorized()`: the caller owns the object, or holds a
+ * privileged group membership. It is deliberately narrow — it authorizes only
+ * objects whose schema actually declares an owner field. At the time of writing
+ * `contract` (`ownerId`) is the only pipelinq schema that does; every other
+ * schema has no ownership concept, and guarding those requires a product
+ * decision about what "owns" a ticket, a client or a loyalty account rather
+ * than a new predicate here.
+ *
+ * Fails closed: an object with no owner value authorizes nobody but a
+ * privileged-group member.
+ */
+class ObjectOwnerAccessPolicy
+{
+    /**
+     * Groups whose members may act on any owned object.
+     *
+     * @var array<int, string>
+     */
+    public const PRIVILEGED_GROUPS = ['admin', 'sales'];
+
+    /**
+     * Constructor.
+     *
+     * @param IGroupManager $groupManager The NC group manager.
+     */
+    public function __construct(
+        private IGroupManager $groupManager,
+    ) {
+    }//end __construct()
+
+    /**
+     * Whether the caller may read or mutate this object.
+     *
+     * @param string              $uid        The caller user ID.
+     * @param array<string,mixed> $object     The loaded object.
+     * @param string              $ownerField The property holding the owner UID.
+     *
+     * @return bool True when the caller owns the object or is privileged.
+     *
+     * @spec openspec/specs/contract-renewal-tracking/spec.md#requirement-contract-lifecycle-management
+     */
+    public function mayAccess(string $uid, array $object, string $ownerField='ownerId'): bool
+    {
+        if ($uid === '') {
+            return false;
+        }
+
+        $owner = trim((string) ($object[$ownerField] ?? ''));
+        if ($owner !== '' && $owner === $uid) {
+            return true;
+        }
+
+        return $this->isPrivileged(uid: $uid);
+    }//end mayAccess()
+
+    /**
+     * Whether the caller belongs to any privileged group.
+     *
+     * @param string $uid The caller user ID.
+     *
+     * @return bool True when the caller is privileged.
+     *
+     * @spec openspec/specs/contract-renewal-tracking/spec.md#requirement-contract-lifecycle-management
+     */
+    public function isPrivileged(string $uid): bool
+    {
+        foreach (self::PRIVILEGED_GROUPS as $group) {
+            if ($this->groupManager->isInGroup($uid, $group) === true) {
+                return true;
+            }
+        }
+
+        return false;
+    }//end isPrivileged()
+}//end class

--- a/lib/Lifecycle/ObjectOwnerAccessPolicy.php
+++ b/lib/Lifecycle/ObjectOwnerAccessPolicy.php
@@ -40,6 +40,8 @@ use OCP\IGroupManager;
  *
  * Fails closed: an object with no owner value authorizes nobody but a
  * privileged-group member.
+ *
+ * @spec openspec/specs/contract-renewal-tracking/spec.md#requirement-contract-lifecycle-management
  */
 class ObjectOwnerAccessPolicy
 {

--- a/tests/Unit/Controller/ActivityTimelineControllerTest.php
+++ b/tests/Unit/Controller/ActivityTimelineControllerTest.php
@@ -231,6 +231,49 @@ class ActivityTimelineControllerTest extends TestCase
     }//end testGetTimelineReturnsNotFoundForAnAbsentEntity()
 
     /**
+     * When the object service cannot answer, the entity check DENIES.
+     *
+     * Regression for #801. `objectExists()` used to `return true` from its
+     * catch — "fails open so a temporary OR outage does not block the timeline
+     * surface" — which made an unavailable object service indistinguishable
+     * from a successful check on a caller-supplied `entityId` (CWE-863). This
+     * branch had no test at all, so the behaviour change was invisible to the
+     * other 2171.
+     *
+     * @return void
+     */
+    public function testGetTimelineDeniesWhenTheEntityCheckCannotBeCompleted(): void
+    {
+        $this->objects = new class {
+            /**
+             * Stand in for an object service that is unavailable.
+             *
+             * @param int|string $id      Object id.
+             * @param array|null $_extend Extend directives.
+             * @param bool       $files   Include files.
+             *
+             * @return array<string, mixed>|null
+             *
+             * @throws \RuntimeException Always.
+             */
+            public function find(int|string $id, ?array $_extend=[], bool $files=false): ?array
+            {
+                throw new \RuntimeException('object service unavailable');
+            }//end find()
+        };
+
+        $this->signIn();
+        $this->withParams(['entityType' => 'client', 'entityId' => 'someone-elses-client']);
+        // The point of the fix: an unanswerable check must not become an
+        // answered one. The timeline service is never reached.
+        $this->service->expects($this->never())->method('getTimeline');
+
+        $response = $this->buildController()->getTimeline();
+
+        $this->assertSame(Http::STATUS_NOT_FOUND, $response->getStatus());
+    }//end testGetTimelineDeniesWhenTheEntityCheckCannotBeCompleted()
+
+    /**
      * A service failure is mapped to a 500 carrying a static message — no
      * internal exception text may reach the wire.
      *

--- a/tests/Unit/Controller/ContractControllerTest.php
+++ b/tests/Unit/Controller/ContractControllerTest.php
@@ -31,6 +31,7 @@ declare(strict_types=1);
 namespace OCA\Pipelinq\Tests\Unit\Controller;
 
 use OCA\Pipelinq\Controller\ContractController;
+use OCA\Pipelinq\Lifecycle\ObjectOwnerAccessPolicy;
 use OCA\Pipelinq\Service\ContractService;
 use OCA\Pipelinq\Service\RecurringRevenueService;
 use OCP\AppFramework\Http;
@@ -138,15 +139,41 @@ class ContractControllerTest extends TestCase
             }//end seed()
 
             /**
-             * Read one row, tolerating any trailing arguments.
+             * Read one row.
              *
-             * @param int|string $id   Object id.
-             * @param mixed      $rest Any further arguments.
+             * ⚠️ This signature MIRRORS `OCA\OpenRegister\Service\ObjectService::find()`
+             * parameter for parameter, and that is load-bearing. It used to be
+             * `find(int|string $id, mixed ...$rest)` — "tolerating any trailing
+             * arguments" — which silently absorbed
+             * `find($id, $registerId, $schemaId)`, the positional call the
+             * controller actually shipped. Against the real service that call
+             * puts a string into `?array $_extend` and raises a TypeError, so
+             * `ContractController::transition` returned 404 to *every* caller,
+             * owner included, and its `isAuthorized()` guard never ran (#801).
+             * A double shaped to what the caller passes cannot detect that the
+             * caller is wrong.
+             *
+             * @param int|string  $id            Object id.
+             * @param array|null  $_extend       Extend directives.
+             * @param bool        $files         Include files.
+             * @param mixed       $register      Register id or slug.
+             * @param mixed       $schema        Schema id or slug.
+             * @param bool        $_rbac         RBAC posture.
+             * @param bool        $_multitenancy Tenancy posture.
+             * @param bool        $_render       Render posture.
              *
              * @return array<string, mixed>|null
              */
-            public function find(int|string $id, mixed ...$rest): ?array
-            {
+            public function find(
+                int|string $id,
+                ?array $_extend=[],
+                bool $files=false,
+                mixed $register=null,
+                mixed $schema=null,
+                bool $_rbac=true,
+                bool $_multitenancy=true,
+                bool $_render=true
+            ): ?array {
                 $row = ($this->store[(string) $id] ?? null);
                 if ($row === null || ($row['_deleted'] ?? null) !== null) {
                     return null;
@@ -368,7 +395,7 @@ class ContractControllerTest extends TestCase
                 logger: $logger,
             ),
             userSession: $this->userSession,
-            groupManager: $this->groupManager,
+            accessPolicy: new ObjectOwnerAccessPolicy(groupManager: $this->groupManager),
             container: $container,
             logger: $logger,
         );
@@ -595,14 +622,13 @@ class ContractControllerTest extends TestCase
 
         $response = $this->buildController($store)->transition(id: 'c-8');
 
-        if ($response->getStatus() === Http::STATUS_NOT_FOUND) {
-            $this->markTestSkipped(
-                'BUG: ContractController::loadContract() passes register/schema positionally to '
-                .'ObjectService::find(), where they land on $_extend/$files — every existing '
-                .'contract resolves to 404. See coordinator report.'
-            );
-        }
-
+        // ⚠️ This assertion used to sit behind
+        // `if ($response->getStatus() === 404) { markTestSkipped(<the bug>); }`.
+        // A conditional self-skip whose condition IS the defect can never fail:
+        // it was green for the whole life of the bug and would have gone green
+        // again once fixed, so it reported "pass" in both worlds and the
+        // security control it protects never ran. The skip is removed; the
+        // assertion now stands on its own.
         $this->assertSame(Http::STATUS_OK, $response->getStatus());
         $this->assertSame('active', $response->getData()['status']);
     }//end testTransitionResolvesTheContractAgainstTheUpstreamFindSignature()

--- a/tests/Unit/Controller/SemanticHandoffControllerTest.php
+++ b/tests/Unit/Controller/SemanticHandoffControllerTest.php
@@ -26,10 +26,12 @@ declare(strict_types=1);
 namespace OCA\Pipelinq\Tests\Unit\Controller;
 
 use OCA\Pipelinq\Controller\SemanticHandoffController;
+use OCA\Pipelinq\Lifecycle\ObjectOwnerAccessPolicy;
 use OCA\Pipelinq\Service\SemanticHandoffService;
 use OCA\Pipelinq\Service\TicketService;
 use OCP\AppFramework\Http;
 use OCP\IAppConfig;
+use OCP\IGroupManager;
 use OCP\IRequest;
 use OCP\IUser;
 use OCP\IUserSession;
@@ -48,6 +50,10 @@ class SemanticHandoffControllerTest extends TestCase
     private SemanticHandoffService $handoffService;
     private IUserSession $userSession;
     private object $objectService;
+    private IGroupManager $groupManager;
+    private ContainerInterface $container;
+    private IAppConfig $appConfig;
+    private TicketService $ticketService;
     private SemanticHandoffController $controller;
 
     /**
@@ -59,6 +65,10 @@ class SemanticHandoffControllerTest extends TestCase
     {
         $this->handoffService = $this->createMock(SemanticHandoffService::class);
         $this->userSession    = $this->createMock(IUserSession::class);
+        $this->groupManager   = $this->createMock(IGroupManager::class);
+        // Default: the caller holds no privileged group, so authorization has to
+        // come from ownership. A test that wants the privileged path says so.
+        $this->groupManager->method('isInGroup')->willReturn(false);
 
         $this->objectService = new class {
             /** @var array<string, array<string, mixed>> */
@@ -123,16 +133,36 @@ class SemanticHandoffControllerTest extends TestCase
         $ticketService = $this->createMock(TicketService::class);
         $ticketService->method('getSchemaId')->willReturn('');
 
+        $this->container     = $container;
+        $this->appConfig     = $appConfig;
+        $this->ticketService = $ticketService;
+
+        $this->rebuildControllerWithGroupManager($this->groupManager);
+    }//end setUp()
+
+    /**
+     * Rebuild the controller behind a specific group manager.
+     *
+     * Lets one test exercise the privileged-group branch without loosening the
+     * default (no privileged membership) that every other test relies on.
+     *
+     * @param IGroupManager $groupManager The group manager to authorize against.
+     *
+     * @return void
+     */
+    private function rebuildControllerWithGroupManager(IGroupManager $groupManager): void
+    {
         $this->controller = new SemanticHandoffController(
             $this->createMock(IRequest::class),
             $this->handoffService,
-            $container,
-            $appConfig,
-            $ticketService,
+            $this->container,
+            $this->appConfig,
+            $this->ticketService,
             $this->userSession,
+            new ObjectOwnerAccessPolicy(groupManager: $groupManager),
             $this->createMock(LoggerInterface::class),
         );
-    }//end setUp()
+    }//end rebuildControllerWithGroupManager()
 
     /**
      * Sign a user in.
@@ -303,7 +333,7 @@ class SemanticHandoffControllerTest extends TestCase
     public function testSendContractInvalidStatus(): void
     {
         $this->signIn();
-        $this->objectService->store['c-1'] = ['uuid' => 'c-1', 'status' => 'draft'];
+        $this->objectService->store['c-1'] = ['uuid' => 'c-1', 'status' => 'draft', 'ownerId' => 'agent-1'];
         $this->handoffService->expects($this->never())->method('handoff');
 
         $response = $this->controller->sendContractToInvoicing(id: 'c-1');
@@ -319,7 +349,7 @@ class SemanticHandoffControllerTest extends TestCase
     public function testSendContractSuccess(): void
     {
         $this->signIn();
-        $this->objectService->store['c-1'] = ['uuid' => 'c-1', 'status' => 'active', 'contractNumber' => 'C-2026-1'];
+        $this->objectService->store['c-1'] = ['uuid' => 'c-1', 'status' => 'active', 'contractNumber' => 'C-2026-1', 'ownerId' => 'agent-1'];
         $this->handoffService->method('hasImplementer')->willReturn(true);
         $this->handoffService->method('handoff')->willReturn([
             'ok'            => true,
@@ -370,6 +400,100 @@ class SemanticHandoffControllerTest extends TestCase
     }//end testContractAvailabilityNotFound()
 
     /**
+     * A stranger may not read another user's contract through the availability
+     * endpoint: 403, and the handoff service is never consulted.
+     *
+     * Regression for #801. Before the guard this returned **200** with the
+     * victim's `status`, measured live on a two-account rig.
+     *
+     * @return void
+     */
+    public function testContractAvailabilityRefusesAContractTheCallerDoesNotOwn(): void
+    {
+        $this->signIn();
+        $this->objectService->store['c-9'] = ['uuid' => 'c-9', 'status' => 'active', 'ownerId' => 'someone-else'];
+        $this->handoffService->expects($this->never())->method('hasImplementer');
+
+        $response = $this->controller->contractAvailability(id: 'c-9');
+
+        $this->assertSame(Http::STATUS_FORBIDDEN, $response->getStatus());
+        $this->assertSame(['status' => 'forbidden'], $response->getData());
+    }//end testContractAvailabilityRefusesAContractTheCallerDoesNotOwn()
+
+    /**
+     * A stranger may not mint an invoice against another user's contract: 403,
+     * nothing is handed off and nothing is written back.
+     *
+     * Regression for #801 — the worst endpoint in that issue. Live, the
+     * attacker passed the object load AND the `status === 'active'` gate on the
+     * victim's contract and was stopped only because no app implemented
+     * `ns#Invoice` on that rig (409 `not-available`). On an instance with
+     * shillinq installed the next statement mints a real invoice.
+     *
+     * @return void
+     */
+    public function testSendToInvoicingRefusesAContractTheCallerDoesNotOwn(): void
+    {
+        $this->signIn();
+        $this->objectService->store['c-9'] = ['uuid' => 'c-9', 'status' => 'active', 'ownerId' => 'someone-else'];
+        $this->handoffService->expects($this->never())->method('handoff');
+
+        $response = $this->controller->sendContractToInvoicing(id: 'c-9');
+
+        $this->assertSame(Http::STATUS_FORBIDDEN, $response->getStatus());
+        $this->assertSame(['status' => 'forbidden'], $response->getData());
+        $this->assertSame([], $this->objectService->saves);
+    }//end testSendToInvoicingRefusesAContractTheCallerDoesNotOwn()
+
+    /**
+     * Authorization is decided BEFORE the status gate, so a stranger cannot use
+     * the response to learn whether someone else's contract is active.
+     *
+     * @return void
+     */
+    public function testSendToInvoicingDoesNotLeakStatusOfAForeignContract(): void
+    {
+        $this->signIn();
+        $this->objectService->store['c-10'] = ['uuid' => 'c-10', 'status' => 'draft', 'ownerId' => 'someone-else'];
+
+        $response = $this->controller->sendContractToInvoicing(id: 'c-10');
+
+        // Not `invalid-status`: that answer would confirm the contract exists
+        // and is not active — a working oracle over another user's data.
+        $this->assertSame(Http::STATUS_FORBIDDEN, $response->getStatus());
+        $this->assertSame(['status' => 'forbidden'], $response->getData());
+    }//end testSendToInvoicingDoesNotLeakStatusOfAForeignContract()
+
+    /**
+     * A privileged-group member (sales) may act on a contract they do not own.
+     *
+     * This is the other half of the guard: without it a "deny everything" fix
+     * would pass every test above while breaking the app.
+     *
+     * @return void
+     */
+    public function testSendToInvoicingAllowsAPrivilegedGroupMember(): void
+    {
+        $groupManager = $this->createMock(IGroupManager::class);
+        $groupManager->method('isInGroup')->willReturnCallback(
+            static fn (string $uid, string $group): bool => ($group === 'sales')
+        );
+        $this->rebuildControllerWithGroupManager($groupManager);
+
+        $this->signIn();
+        $this->objectService->store['c-11'] = ['uuid' => 'c-11', 'status' => 'active', 'ownerId' => 'someone-else'];
+        $this->handoffService->method('hasImplementer')->willReturn(true);
+        $this->handoffService->method('handoff')->willReturn(
+            ['ok' => true, 'targetUuid' => 'inv-9', 'correlationId' => 'corr-9', 'reason' => '']
+        );
+
+        $response = $this->controller->sendContractToInvoicing(id: 'c-11');
+
+        $this->assertSame(Http::STATUS_OK, $response->getStatus());
+        $this->assertSame('sent', $response->getData()['status']);
+    }//end testSendToInvoicingAllowsAPrivilegedGroupMember()
+
+    /**
      * An active contract with an invoice implementer present reports the full
      * triple with `canSend: true`.
      *
@@ -378,7 +502,7 @@ class SemanticHandoffControllerTest extends TestCase
     public function testContractAvailabilityAllowsSendingAnActiveContract(): void
     {
         $this->signIn();
-        $this->objectService->store['c-1'] = ['uuid' => 'c-1', 'status' => 'active'];
+        $this->objectService->store['c-1'] = ['uuid' => 'c-1', 'status' => 'active', 'ownerId' => 'agent-1'];
         $this->handoffService->method('hasImplementer')->willReturn(true);
 
         $response = $this->controller->contractAvailability(id: 'c-1');
@@ -399,7 +523,7 @@ class SemanticHandoffControllerTest extends TestCase
     public function testContractAvailabilityRefusesANonActiveContract(): void
     {
         $this->signIn();
-        $this->objectService->store['c-2'] = ['uuid' => 'c-2', 'status' => 'draft'];
+        $this->objectService->store['c-2'] = ['uuid' => 'c-2', 'status' => 'draft', 'ownerId' => 'agent-1'];
         $this->handoffService->method('hasImplementer')->willReturn(true);
 
         $response = $this->controller->contractAvailability(id: 'c-2');
@@ -420,7 +544,7 @@ class SemanticHandoffControllerTest extends TestCase
     public function testContractAvailabilityReportsNoImplementer(): void
     {
         $this->signIn();
-        $this->objectService->store['c-3'] = ['uuid' => 'c-3', 'status' => 'active'];
+        $this->objectService->store['c-3'] = ['uuid' => 'c-3', 'status' => 'active', 'ownerId' => 'agent-1'];
         $this->handoffService->method('hasImplementer')->willReturn(false);
 
         $response = $this->controller->contractAvailability(id: 'c-3');
@@ -440,7 +564,7 @@ class SemanticHandoffControllerTest extends TestCase
     public function testContractAvailabilityWritesNothing(): void
     {
         $this->signIn();
-        $this->objectService->store['c-4'] = ['uuid' => 'c-4', 'status' => 'active'];
+        $this->objectService->store['c-4'] = ['uuid' => 'c-4', 'status' => 'active', 'ownerId' => 'agent-1'];
         $this->handoffService->method('hasImplementer')->willReturn(true);
 
         $this->controller->contractAvailability(id: 'c-4');


### PR DESCRIPTION
Closes the contract half of #801, and retracts the premise the whole issue was built on.

## What was measured, live

A single-owner rig (`pq-idor`, NC 34.0.0, two real accounts, Basic auth, **status code printed on every line**, content-type checked so the Nextcloud-HTML-at-200 trap could not fake a result). `pqvictim` creates a contract (`201`, `ownerId: pqvictim`); `pqattacker` then acts on that id.

| probe | before | after |
|---|---|---|
| attacker `POST /api/contracts/{id}/transition` | **404** | **403** |
| attacker `GET /api/handoff/contract/{id}/availability` | **200** — returned the victim's contract `status` | **403** |
| attacker `POST /api/handoff/contract/{id}/send-to-invoicing` | **409 `not-available`** | **403** |
| **owner** `POST /api/contracts/{id}/transition` | **404** | **422** (a real business rule) |

⚠️ **Read the 409 carefully — it was not a refusal.** The check order is auth-401 → load-404 → `status !== 'active'`-409 → `hasImplementer`-409 → mint. The attacker cleared the object load *and* the status gate on someone else's contract and was stopped only because no app implemented `ns#Invoice` on that rig. **On an instance with shillinq the next statement mints the invoice.** When an exploit is blocked, identify *which* gate blocked it.

## 🔴 The retraction: the positive control this issue rests on is dead code

#801, ConductionNL/.github#365 and `gate7-fleet-reaudit.md` all cite `ContractController::isAuthorized()` as proof that pipelinq *does* implement per-object authorisation — "so every absence below is a real omission, not a missing convention".

**It has never executed.** `loadContract()` called `find()` **positionally**:

```
ObjectService::find(): Argument #2 ($_extend) must be of type ?array, string given,
called in .../pipelinq/lib/Controller/ContractController.php on line 248
```

The upstream signature is `find($id, ?array $_extend, bool $files, $register, $schema, …)`, so the register id landed in `$_extend`, and `catch (Throwable) { return null; }` turned the TypeError into a **404 for every caller, the owner included**. The owner's move from 404 to 422 above is the proof it is now reachable — and that the fix is not a blanket deny.

Note the direction of the danger: **`SemanticHandoffController::loadObject()` uses named arguments and therefore works**, which is exactly why the IDOR was live *there* while the guard was dead *here*. **The broken call path was the safe one.** Fixing the load without adding the guard would have converted a dead endpoint into a live unguarded one.

## Why nothing caught it

- **The double absorbed the bug.** The test stub declared `find(int|string $id, mixed ...$rest)` — docblock: *"tolerating any trailing arguments"*. A variadic swallows the broken positional call, so the suite was green while production fatalled. The double now mirrors the collaborator's real signature parameter for parameter.
- **A test that proved it was disabled by a conditional self-skip whose condition was the defect**: `if ($response->getStatus() === 404) { markTestSkipped('BUG: …'); }`. Green while the bug lived, green once fixed — it could not fail in either world. Removed; the assertion now stands alone.
- **Two docblocks asserted the missing guard** — `loadObject()`'s *"per-object guard"* and the class's *"all NoAdminRequired + per-object register-RBAC guard"*. Both deleted in this commit, per the rule that a fix must delete the false comment alongside the real guard.
- **gate-7 reports `0`** and always has (`.github#365`: a `401` accepted as an authorisation guard).

## Changes

- **New `Lifecycle/ObjectOwnerAccessPolicy`** — one implementation of the model the app already expressed: owner, or a privileged group (`admin`, `sales`). Fails closed. `ContractController::isAuthorized()` delegates to it, so there is a single definition rather than a copy per controller.
- `loadContract()` uses **named arguments** — the guard becomes reachable.
- `contractAvailability` / `sendContractToInvoicing` **authorize explicitly, before the status gate**, so the response cannot be used as an oracle over another user's contract.
- `ActivityTimelineController::objectExists()` **no longer returns `true` from its catch**. Failing open made an unavailable object service indistinguishable from a successful check — CWE-863 on a caller-supplied `entityId`, independent of the IDOR question.

## Scope: what is deliberately NOT fixed here

**`contract` is the only pipelinq schema that declares an owner field.** `ticket` has `assignee` (a workflow field, not an access right); `client`, `contactmoment`, `giftCard` and the loyalty schemas have nothing. So the request/ticket, CTI, contacts-sync, notes and loyalty endpoints in #801 **have nothing to authorize against**, and inventing an ownership model for them would be a product decision wearing a security fix's clothes. Enumerated back on #801 for @rubenlinde's decision.

Same reason for `LoyaltyReportingController`: its class docblock says *"admin-only"* in one paragraph and *"the methods bypass the admin requirement… to surface KPIs to programme managers who are not Nextcloud admins"* in the next. Making it admin-only would break a stated requirement. That contradiction needs resolving, not a unilateral guard.

## Verification

Negative controls, **each with the number predicted before it was run**:

| control | predicted | actual |
|---|---|---|
| revert `loadContract()` to positional | 8 `ContractControllerTest` failures | **8** |
| remove both handoff guards | 3 `SemanticHandoffControllerTest` failures | **3** |

The privileged-group test still passes under the second control, which is what distinguishes a guard from a blanket deny.

**2171 tests / 7429 assertions / 0 failures.** phpmd, psalm, phpstan clean; phpcs **0 errors**. No gate or test was weakened: a skip was removed, a double was made stricter, and no timeout, threshold or baseline was touched.
