### PR TITLE
fix(install): import the register on a FRESH install, not only on upgrade

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -153,6 +153,27 @@ Vrij en open source onder de EUPL-1.2-licentie.
             <step>OCA\Pipelinq\Repair\MigrateAvgVerzoekenToOrDsar</step>
             <step>OCA\Pipelinq\Repair\RemoveLegacyPspKeys</step>
         </post-migration>
+        <!--
+            FRESH INSTALL. Nextcloud does NOT run post-migration on a first install:
+            `Installer::installAppLastSteps()` guards both the pre-migration and
+            post-migration blocks with `if ($previousVersion !== '')`, and only
+            `repair-steps/install` runs unconditionally afterwards. Until this block
+            existed a brand-new Pipelinq install ran NONE of the steps above, so
+            InitializeSettings never fired and the pipelinq register and schemas were
+            never imported. The step is annotated
+            `@spec openspec/specs/openregister-integration/spec.md#requirement-auto-configuration-on-install-repair-step`
+            — the spec said "on install"; the wiring never fired on install.
+
+            Only baseline-CREATING steps belong here. Everything else above operates
+            on data a fresh install does not have: the Normalise*/Unify*/Drain*/
+            InitSlaStatus steps rewrite existing rows, the Migrate*/Remove* steps are
+            one-way migrations, and IngestProductVendorMaster consumes a shillinq
+            export that a new instance has never received.
+        -->
+        <install>
+            <step>OCA\Pipelinq\Repair\InitializeSettings</step>
+            <step>OCA\Pipelinq\Repair\SeedTrustConfigurationRows</step>
+        </install>
     </repair-steps>
 
     <settings>


### PR DESCRIPTION
The pipelinq register has never been imported on a fresh instance.

`InitializeSettings` was declared only under `<post-migration>`. On a first install Nextcloud runs `migrateSchemaOnly()` — `$previousVersion` is `""`, so `Installer::installAppLastSteps()` skips **both** pre- and post-migration, and `<install>` is the only unconditional hook. The upgrade path runs pre/post-migration and *not* `install`.

The step carries `@spec openspec/specs/openregister-integration/spec.md#requirement-auto-configuration-on-install-repair-step`. The spec says "on install"; the wiring never fired on install.

## Scope

Added: `InitializeSettings`, `SeedTrustConfigurationRows` — both idempotent baseline creators.

Deliberately excluded, because each operates on data a fresh install does not have:

| step | why not |
|---|---|
| `NormaliseCtiPhoneNumbers`, `NormaliseTicketTitle`, `UnifyClientContactIdentity` | rewrite existing rows |
| `InitSlaStatus`, `DrainMdmSyncQueue` | operate over existing tickets/queue |
| `MigratePosBookkeepingToShillinq`, `MigrateAvgVerzoekenToOrDsar`, `RemoveRetiredAvgJobs`, `RemoveLegacyPspKeys` | one-way migrations |
| `IngestProductVendorMaster` | consumes a shillinq export a new instance has never received |

`<install>` sits after `</post-migration>` per the `info.xsd` sequence, verified against the schema.

Part of a sweep; openconnector and shillinq already carry this block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)