### PR TITLE
ci: enforce prettier via a `format` Frontend Check leg

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -367,7 +367,19 @@ jobs:
       # `check:vue-demi` in particular guards a dual-package hazard that fails
       # silently at runtime rather than at build time.
       # `test:unit` is NOT listed: "Frontend Tests (unit)" already runs it.
-      frontend-checks: '["check:manifest", "check:vue-demi", "test:l10n"]'
+      #
+      # `format` (prettier --check) is listed because the shared workflow has NO
+      # prettier job of its own — `quality.yml` runs eslint and stylelint and
+      # mentions prettier ZERO times. This repo already carries
+      # `@nextcloud/prettier-config` and a `format` script, so without this leg
+      # `npm run format` never runs outside a developer's editor and the tree
+      # drifts straight back out of format between merges — the same inert-
+      # formatter failure mode that made the old `.prettierrc` worth deleting.
+      # Centralising the config never stopped drift; the gate does.
+      # Measured on this tree before enabling: PASSES, 357 of 371 tracked
+      # frontend files in scope (docs/ and l10n/ excluded via .prettierignore /
+      # .gitignore, which prettier 3 also reads).
+      frontend-checks: '["check:manifest", "check:vue-demi", "test:l10n", "format"]'
 
       # ── Coverage ratchet ─────────────────────────────────────────────────
       # `enable-coverage-guard` defaults to FALSE, which is why both


### PR DESCRIPTION
## What

Appends `"format"` to this repo's existing `frontend-checks` array:

```yaml
frontend-checks: '["check:manifest", "check:vue-demi", "test:l10n", "format"]'
```

Every pre-existing entry and its order are unchanged; `format` is appended last and adds one `Frontend Check (format)` job.

## Why

This repo already carries `@nextcloud/prettier-config` and a `format` / `format:fix` script — but **nothing ran that script in CI**. The shared `quality.yml` has no prettier job of its own: it mentions prettier **zero** times (eslint 9, stylelint 10), and `frontend-checks` is the only opt-in that invokes a repo's own npm scripts.

So prettier was **active in editors and inert in CI** — precisely the state the fleet's old `.prettierrc` was deleted for. Formatting would drift straight back between merges. Centralising the config never stopped drift; the gate does.

Before this change, `format` was enforced in **1 of 19** fleet repos (`nextcloud-app-template`, which is the reference for this input and carries the same rationale).

## Result on this tree

✅ **Clean** — `prettier --check` already passes on this tree, so this PR is the workflow line only.

**Scope: 357/371 tracked frontend files are in `--check`.** The remainder is excluded deliberately (generated/vendored/build output) via `.prettierignore` — plus `.gitignore`, which prettier 3 reads as an ignore path by default. **No `.prettierignore` entry needed adding in this repo.**

## How this was measured

Not by eye: with prettier `3.9.6` and `@nextcloud/prettier-config` `1.2.0` — the same versions this repo's `package.json` pins — and the resolved config compared field-by-field against a real `npm ci` install (identical), on an identical file set. The rig was negative-controlled first: forcing a config change made it flag files, so a green here is a verdict rather than a check that never ran.

## Expected red that is not from this PR

`Hydra Gates` and `Quality Report` are red on most fleet apps for pre-existing findings. The job to read for this change is **`Frontend Check (format)`**.
