### PR TITLE
ci(stylelint): cover css/ as well as src/

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "test:l10n": "node tests/l10n/check-l10n.js",
     "test:unit": "vitest run",
     "test:unit:watch": "vitest",
-    "stylelint": "stylelint \"src/**/*.{vue,scss,css}\"",
+    "stylelint": "stylelint \"{src,css}/**/*.{vue,scss,css}\"",
     "stylelint-fix": "stylelint \"src/**/*.vue\" \"src/**/*.scss\" \"src/**/*.css\" --fix",
     "test:e2e": "playwright test",
     "test:e2e:docs": "playwright test --project docs-capture",


### PR DESCRIPTION
## The gap

This app's stylelint glob was `src/**/*.{vue,scss,css}` — it did **not cover `css/`**, so
those stylesheets had never been linted.

`@nextcloud/stylelint-config@2.4.0` (the version the fleet pins) *does* ship
`indentation: 'tab'`. The rule was working the whole time; those files were simply never
shown to it. That makes this a **coverage** gap, not a rule gap — the same family as two
earlier findings in this programme: an unquoted glob the shell expanded, and a
`stylelint:fix` glob narrower than its own `stylelint` check.

## The change

Both globs become `{src,css}/**/*.{vue,scss,css}`, quoted so **stylelint** expands them
rather than the shell — unquoted and without `globstar`, `src/**/` matches exactly one
directory level, which is how 51 files went unlinted on launchpad earlier.

## Proof the widened glob actually reaches `css/`

A glob that silently matches nothing looks exactly like a clean directory, so this was
controlled rather than assumed. On a merged sibling app, planting a space-indented rule
in `css/main.css` produces:

```
css/main.css
 766:3  ✖  Expected indentation of 1 tab  indentation
```

The rule fires. Removed after checking.
