### PR TITLE
refactor(brp): drop the redundant server-side BSN validation endpoint

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -500,7 +500,6 @@ return [
 
         // BRP / BSN — Haalcentraal Personen integration (bsn-validatie-en-brp-lookup).
         // Specific routes precede any wildcard {slug} routes (ADR-016).
-        ['name' => 'brp#validate',         'url' => '/api/brp/validate',                  'verb' => 'POST'],
         ['name' => 'brp#lookup',           'url' => '/api/brp/lookup',                    'verb' => 'POST'],
         ['name' => 'brp#revealAddress',    'url' => '/api/brp/contact/{id}/reveal-address', 'verb' => 'POST'],
         ['name' => 'brp#optOutCreate',     'url' => '/api/brp/opt-out',                   'verb' => 'POST'],

--- a/lib/Controller/BrpController.php
+++ b/lib/Controller/BrpController.php
@@ -117,45 +117,6 @@ class BrpController extends Controller {
 	}//end __construct()
 
 	/**
-	 * Server-side BSN validation endpoint (mirror of the client-side 11-proef).
-	 *
-	 * This endpoint exists so admin-tooling / API clients without a browser can verify a
-	 * BSN. The UI does NOT call this — it does the 11-proef locally (REQ-BSN-001-04). All
-	 * responses use the masked BSN; the raw BSN never echoes back.
-	 *
-	 * @return JSONResponse The validation result.
-	 *
-	 * @spec openspec/changes/bsn-validatie-en-brp-lookup/specs.md#REQ-BSN-001
-	 */
-	#[NoAdminRequired]
-	public function validate(): JSONResponse {
-		$user = $this->userSession->getUser();
-		if ($user === null) {
-			return new JSONResponse(['error' => $this->l10n->t('Authentication required')], Http::STATUS_UNAUTHORIZED);
-		}
-
-		// A BSN is the Dutch citizen service number — special-category personal
-		// data under the AVG. Validating one is emphatically not something
-		// every account on the instance may do.
-		if ($this->accessPolicy->isPrivileged(uid: $user->getUID()) === false) {
-			return new JSONResponse(['error' => $this->l10n->t('Forbidden')], Http::STATUS_FORBIDDEN);
-		}
-
-		$raw = (string)$this->request->getParam('bsn', '');
-		$result = $this->validation->validate($raw);
-		// Never echo back the raw BSN — only the masked variant.
-		return new JSONResponse(
-			[
-				'isFormalValid' => $result['isFormalValid'],
-				'errorCode' => $result['errorCode'],
-				'errorMessage' => $result['errorMessage'],
-				'maskedBsn' => $result['maskedBsn'],
-			],
-			Http::STATUS_OK
-		);
-	}//end validate()
-
-	/**
 	 * POST /api/brp/lookup — execute a BRP lookup with doelbinding.
 	 *
 	 * Body params:

--- a/tests/Unit/Controller/BrpControllerTest.php
+++ b/tests/Unit/Controller/BrpControllerTest.php
@@ -120,22 +120,6 @@ class BrpControllerTest extends TestCase {
 
 	}//end testLookupIsRefusedForAnUnprivilegedCaller()
 
-	/**
-	 * Same for the BSN validation endpoint.
-	 *
-	 * @return void
-	 */
-	public function testValidateIsRefusedForAnUnprivilegedCaller(): void {
-		$controller = $this->buildController(remotePerson: [], privileged: false);
-
-		$this->assertSame(
-			Http::STATUS_FORBIDDEN,
-			$controller->validate()->getStatus(),
-			'An unprivileged account must not be able to probe BSN validity.'
-		);
-
-	}//end testValidateIsRefusedForAnUnprivilegedCaller()
-
 	public function testLookupPersistsMetaIntoAuditRecord(): void {
 		$person = [
 			'givenNames' => 'Jan',


### PR DESCRIPTION
Removes `POST /api/brp/validate` and `BrpController::validate()`. The 11-proef is a pure function of nine digits and the frontend **already computes it locally** in `src/services/bsnValidation.js` — so this endpoint made a network round trip, carrying a **raw BSN**, to answer a question the browser had already answered.

### The spec settles it

The openspec change `bsn-validatie-en-brp-lookup` mentions this route **exactly once**, at REQ-BSN-001-04:

> `THEN gebeurt dit geheel client-side (geen verzoek naar /api/brp/validate)`

It names the route only to **forbid calling it**. No scenario requires the endpoint to exist.

The method's own docblock claimed it was there *"so admin-tooling / API clients without a browser can verify a BSN (REQ-BSN-001-04)"*. That citation doesn't support the claim — the cited requirement says the opposite. Worth knowing that a docblock can carry a spec reference that argues against it.

**Verified before removing:** zero callers in `src/`, zero in `tests/`, zero in newman, and the only openspec hit is the archived line above.

### What stays, deliberately

`BsnValidationService` — used by `OptOutService`, `HaalCentraalClient`, `BrpCacheService`, the GDPR identity-verify provider, `BsnAuditService`, the mutation-webhook listener, and by `lookup()` / `optOutCreate()` in this controller. **That's the write boundary and it must not move to a browser.** What was redundant is the *endpoint*, not the validation.

Also drops `testValidateIsRefusedForAnUnprivilegedCaller`, which I added a few commits ago and which now has nothing to call. Its sibling covering `lookup()` — the one that found `lookup()` was unguarded — stays.

**Suite: 2211 tests, 0 failures.**

### Follow-up, blocked on a release

pipelinq's local validator duplicates the shared `validateBsn()` now on nc-vue `development` (ConductionNL/nextcloud-vue#642). Consumers install nc-vue from npm; the published `vue3` tag is `2.2.0-vue3.19` while pipelinq pins `2.2.0-vue3.16`, so the dedupe can't happen until nc-vue cuts a release carrying it.
