### PR TITLE
fix(security): give every public portal endpoint a volume ceiling (ADR-082)

### DIFF
--- a/lib/Controller/PortalAccountController.php
+++ b/lib/Controller/PortalAccountController.php
@@ -33,6 +33,7 @@ use OCA\Pipelinq\Service\Portal\PortalExportService;
 use OCA\Pipelinq\Service\Portal\PortalProfileService;
 use OCA\Pipelinq\Service\Portal\PortalRequestGuard;
 use OCP\AppFramework\Http;
+use OCP\AppFramework\Http\Attribute\AnonRateLimit;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\IRequest;
 use Psr\Log\LoggerInterface;
@@ -74,6 +75,7 @@ class PortalAccountController extends PortalApiController {
 	 * @NoCSRFRequired
 	 * @PublicPage
 	 */
+	#[AnonRateLimit(limit: 120, period: 60)]
 	public function profile(): JSONResponse {
 		return $this->guarded(
 			handler: function (): array {
@@ -92,6 +94,7 @@ class PortalAccountController extends PortalApiController {
 	 * @NoCSRFRequired
 	 * @PublicPage
 	 */
+	#[AnonRateLimit(limit: 30, period: 60)]
 	public function updateProfile(): JSONResponse {
 		return $this->guarded(
 			handler: function (): array {
@@ -122,6 +125,8 @@ class PortalAccountController extends PortalApiController {
 	 * @NoCSRFRequired
 	 * @PublicPage
 	 */
+	// Tight: a verification token is guessable in bulk without a ceiling.
+	#[AnonRateLimit(limit: 20, period: 60)]
 	public function verifyEmail(): JSONResponse {
 		return $this->guarded(
 			handler: function (): array {
@@ -145,6 +150,9 @@ class PortalAccountController extends PortalApiController {
 	 * @NoCSRFRequired
 	 * @PublicPage
 	 */
+	// Tight: an export is expensive to produce, so this is a cheap request that
+	// buys the caller a lot of server work.
+	#[AnonRateLimit(limit: 10, period: 60)]
 	public function requestExport(): JSONResponse {
 		return $this->guarded(
 			handler: function (): array {
@@ -164,6 +172,7 @@ class PortalAccountController extends PortalApiController {
 	 * @NoCSRFRequired
 	 * @PublicPage
 	 */
+	#[AnonRateLimit(limit: 10, period: 60)]
 	public function requestClose(): JSONResponse {
 		return $this->guarded(
 			handler: function (): array {
@@ -183,6 +192,7 @@ class PortalAccountController extends PortalApiController {
 	 * @NoCSRFRequired
 	 * @PublicPage
 	 */
+	#[AnonRateLimit(limit: 20, period: 60)]
 	public function confirmClose(): JSONResponse {
 		return $this->guarded(
 			handler: function (): array {

--- a/lib/Controller/PortalAuditController.php
+++ b/lib/Controller/PortalAuditController.php
@@ -30,6 +30,7 @@ namespace OCA\Pipelinq\Controller;
 use OCA\Pipelinq\Service\Portal\PortalAuditService;
 use OCA\Pipelinq\Service\Portal\PortalRequestGuard;
 use OCP\AppFramework\Http;
+use OCP\AppFramework\Http\Attribute\AnonRateLimit;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\IRequest;
 use Psr\Log\LoggerInterface;
@@ -64,6 +65,7 @@ class PortalAuditController extends PortalApiController {
 	 * @NoCSRFRequired
 	 * @PublicPage
 	 */
+	#[AnonRateLimit(limit: 120, period: 60)]
 	public function index(): JSONResponse {
 		return $this->guarded(
 			handler: function (): array {

--- a/lib/Controller/PortalAuthController.php
+++ b/lib/Controller/PortalAuthController.php
@@ -36,6 +36,7 @@ use OCA\Pipelinq\Service\Portal\PortalObjectRepository;
 use OCA\Pipelinq\Service\Portal\PortalRequestGuard;
 use OCA\Pipelinq\Service\Portal\PortalSessionManager;
 use OCP\AppFramework\Http;
+use OCP\AppFramework\Http\Attribute\AnonRateLimit;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\IRequest;
 use Psr\Log\LoggerInterface;
@@ -88,6 +89,12 @@ class PortalAuthController extends PortalApiController {
 	 * @NoCSRFRequired
 	 * @PublicPage
 	 */
+	// An IP-scoped ceiling ALONGSIDE the account-scoped lockout, not instead of
+	// it. PortalAuthService already arms a sliding-window lockout after repeated
+	// failures on ONE account — but an account lockout cannot see PASSWORD
+	// SPRAYING, where one IP tries one password against many accounts and never
+	// trips any single account's counter. That is the gap this closes.
+	#[AnonRateLimit(limit: 20, period: 60)]
 	public function login(): JSONResponse {
 		return $this->guarded(
 			handler: function (): array {
@@ -120,6 +127,7 @@ class PortalAuthController extends PortalApiController {
 	 * @NoCSRFRequired
 	 * @PublicPage
 	 */
+	#[AnonRateLimit(limit: 60, period: 60)]
 	public function logout(): JSONResponse {
 		return $this->guarded(
 			handler: function (): array {
@@ -140,6 +148,7 @@ class PortalAuthController extends PortalApiController {
 	 * @NoCSRFRequired
 	 * @PublicPage
 	 */
+	#[AnonRateLimit(limit: 60, period: 60)]
 	public function extendSession(): JSONResponse {
 		return $this->guarded(
 			handler: function (): array {
@@ -161,6 +170,9 @@ class PortalAuthController extends PortalApiController {
 	 * @NoCSRFRequired
 	 * @PublicPage
 	 */
+	// Tight: this one sends mail to an address the caller supplies, so an
+	// unbounded caller can use it to mail-bomb a third party.
+	#[AnonRateLimit(limit: 10, period: 60)]
 	public function passwordResetRequest(): JSONResponse {
 		return $this->guarded(
 			handler: function (): array {
@@ -180,6 +192,9 @@ class PortalAuthController extends PortalApiController {
 	 * @NoCSRFRequired
 	 * @PublicPage
 	 */
+	// Tight: the token is the only thing standing between a caller and an
+	// account takeover, so the ceiling bounds how fast one can be guessed.
+	#[AnonRateLimit(limit: 20, period: 60)]
 	public function passwordReset(): JSONResponse {
 		return $this->guarded(
 			handler: function (): array {
@@ -204,6 +219,7 @@ class PortalAuthController extends PortalApiController {
 	 * @NoCSRFRequired
 	 * @PublicPage
 	 */
+	#[AnonRateLimit(limit: 20, period: 60)]
 	public function mfaEnroll(): JSONResponse {
 		return $this->guarded(
 			handler: function (): array {
@@ -235,6 +251,9 @@ class PortalAuthController extends PortalApiController {
 	 * @NoCSRFRequired
 	 * @PublicPage
 	 */
+	// Tightest in this controller: a TOTP code is six digits, so the whole
+	// keyspace is a million guesses. Without a ceiling that is minutes of work.
+	#[AnonRateLimit(limit: 10, period: 60)]
 	public function mfaVerify(): JSONResponse {
 		return $this->guarded(
 			handler: function (): array {

--- a/lib/Controller/PortalController.php
+++ b/lib/Controller/PortalController.php
@@ -37,6 +37,7 @@ use OCA\Pipelinq\Service\BookingService;
 use OCP\App\IAppManager;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http;
+use OCP\AppFramework\Http\Attribute\AnonRateLimit;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\IAppConfig;
@@ -131,6 +132,7 @@ class PortalController extends Controller {
 	 *
 	 * @spec openspec/specs/appointment-booking/spec.md
 	 */
+	#[AnonRateLimit(limit: 120, period: 60)]
 	public function services(): JSONResponse {
 		try {
 			$services = $this->listBookableServices();
@@ -154,6 +156,7 @@ class PortalController extends Controller {
 	 *
 	 * @spec openspec/specs/appointment-booking/spec.md
 	 */
+	#[AnonRateLimit(limit: 120, period: 60)]
 	public function availability(): JSONResponse {
 		$serviceId = trim((string)$this->request->getParam('serviceId', ''));
 		$date = trim((string)$this->request->getParam('date', ''));
@@ -182,6 +185,9 @@ class PortalController extends Controller {
 	 *
 	 * @spec openspec/specs/appointment-booking/spec.md
 	 */
+	// Tight: a booking consumes a real slot, so an unbounded caller can exhaust
+	// availability for everyone else without ever authenticating.
+	#[AnonRateLimit(limit: 20, period: 60)]
 	public function book(): JSONResponse {
 		$params = $this->collectBookParams();
 		$error = $this->validateBookParams(params: $params);
@@ -287,6 +293,7 @@ class PortalController extends Controller {
 	 *
 	 * @spec openspec/specs/appointment-booking/spec.md
 	 */
+	#[AnonRateLimit(limit: 120, period: 60)]
 	public function getBooking(string $bookingId): JSONResponse {
 		$token = trim((string)$this->request->getParam('token', ''));
 		if ($token !== '') {
@@ -317,6 +324,7 @@ class PortalController extends Controller {
 	 *
 	 * @spec openspec/specs/appointment-booking/spec.md
 	 */
+	#[AnonRateLimit(limit: 30, period: 60)]
 	public function reschedule(): JSONResponse {
 		$token = trim((string)$this->request->getParam('token', ''));
 		$newStartAt = trim((string)$this->request->getParam('newStartAt', ''));
@@ -360,6 +368,7 @@ class PortalController extends Controller {
 	 *
 	 * @spec openspec/specs/appointment-booking/spec.md
 	 */
+	#[AnonRateLimit(limit: 30, period: 60)]
 	public function cancel(): JSONResponse {
 		$token = trim((string)$this->request->getParam('token', ''));
 		$reason = (string)$this->request->getParam('reason', '');

--- a/lib/Controller/PortalDataController.php
+++ b/lib/Controller/PortalDataController.php
@@ -35,6 +35,7 @@ use OCA\Pipelinq\Service\Portal\PortalOrderService;
 use OCA\Pipelinq\Service\Portal\PortalRequestGuard;
 use OCA\Pipelinq\Service\Portal\PortalTenantService;
 use OCP\AppFramework\Http;
+use OCP\AppFramework\Http\Attribute\AnonRateLimit;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\IRequest;
 use Psr\Log\LoggerInterface;
@@ -78,6 +79,7 @@ class PortalDataController extends PortalApiController {
 	 * @NoCSRFRequired
 	 * @PublicPage
 	 */
+	#[AnonRateLimit(limit: 120, period: 60)]
 	public function invoices(): JSONResponse {
 		return $this->requireListAccess(facade: $this->invoices, feature: 'invoices');
 	}//end invoices()
@@ -93,6 +95,7 @@ class PortalDataController extends PortalApiController {
 	 * @NoCSRFRequired
 	 * @PublicPage
 	 */
+	#[AnonRateLimit(limit: 120, period: 60)]
 	public function invoice(string $id): JSONResponse {
 		return $this->requireObjectAccess(facade: $this->invoices, feature: 'invoices', id: $id);
 	}//end invoice()
@@ -106,6 +109,7 @@ class PortalDataController extends PortalApiController {
 	 * @NoCSRFRequired
 	 * @PublicPage
 	 */
+	#[AnonRateLimit(limit: 120, period: 60)]
 	public function contracts(): JSONResponse {
 		return $this->requireListAccess(facade: $this->contracts, feature: 'contracts');
 	}//end contracts()
@@ -121,6 +125,7 @@ class PortalDataController extends PortalApiController {
 	 * @NoCSRFRequired
 	 * @PublicPage
 	 */
+	#[AnonRateLimit(limit: 120, period: 60)]
 	public function contract(string $id): JSONResponse {
 		return $this->requireObjectAccess(facade: $this->contracts, feature: 'contracts', id: $id);
 	}//end contract()
@@ -134,6 +139,7 @@ class PortalDataController extends PortalApiController {
 	 * @NoCSRFRequired
 	 * @PublicPage
 	 */
+	#[AnonRateLimit(limit: 120, period: 60)]
 	public function orders(): JSONResponse {
 		return $this->requireListAccess(facade: $this->orders, feature: 'orders');
 	}//end orders()
@@ -149,6 +155,7 @@ class PortalDataController extends PortalApiController {
 	 * @NoCSRFRequired
 	 * @PublicPage
 	 */
+	#[AnonRateLimit(limit: 120, period: 60)]
 	public function order(string $id): JSONResponse {
 		return $this->requireObjectAccess(facade: $this->orders, feature: 'orders', id: $id);
 	}//end order()

--- a/lib/Controller/PortalDelegationController.php
+++ b/lib/Controller/PortalDelegationController.php
@@ -31,6 +31,7 @@ use OCA\Pipelinq\Service\Portal\PortalDelegationService;
 use OCA\Pipelinq\Service\Portal\PortalException;
 use OCA\Pipelinq\Service\Portal\PortalRequestGuard;
 use OCP\AppFramework\Http;
+use OCP\AppFramework\Http\Attribute\AnonRateLimit;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\IRequest;
 use Psr\Log\LoggerInterface;
@@ -65,6 +66,7 @@ class PortalDelegationController extends PortalApiController {
 	 * @NoCSRFRequired
 	 * @PublicPage
 	 */
+	#[AnonRateLimit(limit: 120, period: 60)]
 	public function index(): JSONResponse {
 		return $this->guarded(
 			handler: function (): array {
@@ -84,6 +86,8 @@ class PortalDelegationController extends PortalApiController {
 	 * @NoCSRFRequired
 	 * @PublicPage
 	 */
+	// Tight: a delegation grants another party access to this account.
+	#[AnonRateLimit(limit: 20, period: 60)]
 	public function create(): JSONResponse {
 		return $this->guarded(
 			handler: function (): array {
@@ -123,6 +127,7 @@ class PortalDelegationController extends PortalApiController {
 	 * @NoCSRFRequired
 	 * @PublicPage
 	 */
+	#[AnonRateLimit(limit: 30, period: 60)]
 	public function destroy(string $id): JSONResponse {
 		return $this->guarded(
 			handler: function () use ($id): array {

--- a/lib/Controller/PortalDocumentController.php
+++ b/lib/Controller/PortalDocumentController.php
@@ -35,6 +35,7 @@ use OCA\Pipelinq\Service\Portal\PortalInvoiceService;
 use OCA\Pipelinq\Service\Portal\PortalObjectRepository;
 use OCA\Pipelinq\Service\Portal\PortalRequestGuard;
 use OCP\AppFramework\Http;
+use OCP\AppFramework\Http\Attribute\AnonRateLimit;
 use OCP\AppFramework\Http\DataDownloadResponse;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\IRequest;
@@ -87,6 +88,9 @@ class PortalDocumentController extends PortalApiController {
 	 * @NoCSRFRequired
 	 * @PublicPage
 	 */
+	// Tight: signing is a legally meaningful act, and the token that authorises
+	// it is the only barrier.
+	#[AnonRateLimit(limit: 20, period: 60)]
 	public function sign(): JSONResponse {
 		return $this->guarded(
 			handler: function (): array {
@@ -118,6 +122,7 @@ class PortalDocumentController extends PortalApiController {
 	 *
 	 * @spec openspec/changes/customer-portal/specs.md#REQ-005
 	 */
+	#[AnonRateLimit(limit: 60, period: 60)]
 	public function download(string $token) {
 		try {
 			$result = $this->signing->validateToken(token: $token);

--- a/lib/Controller/PortalPageController.php
+++ b/lib/Controller/PortalPageController.php
@@ -29,6 +29,7 @@ namespace OCA\Pipelinq\Controller;
 
 use OCA\Pipelinq\AppInfo\Application;
 use OCP\AppFramework\Controller;
+use OCP\AppFramework\Http\Attribute\AnonRateLimit;
 use OCP\AppFramework\Http\ContentSecurityPolicy;
 use OCP\AppFramework\Http\TemplateResponse;
 use OCP\IRequest;
@@ -55,6 +56,7 @@ class PortalPageController extends Controller {
 	 * @NoCSRFRequired
 	 * @PublicPage
 	 */
+	#[AnonRateLimit(limit: 240, period: 60)]
 	public function index(): TemplateResponse {
 		$response = new TemplateResponse(
 			Application::APP_ID,
@@ -89,6 +91,10 @@ class PortalPageController extends Controller {
 	 * @SuppressWarnings(PHPMD.UnusedFormalParameter) $path is a route-binding
 	 *  placeholder; the SPA shell is identical for every sub-path.
 	 */
+	// Generous, like index(): these two serve the portal's own HTML shell, and a
+	// tight ceiling here would break an ordinary browsing session rather than an
+	// attack.
+	#[AnonRateLimit(limit: 240, period: 60)]
 	public function subpath(string $path = ''): TemplateResponse {
 		return $this->index();
 	}//end subpath()

--- a/lib/Controller/PortalRequestController.php
+++ b/lib/Controller/PortalRequestController.php
@@ -32,6 +32,7 @@ use OCA\Pipelinq\Service\Portal\PortalRequestGuard;
 use OCA\Pipelinq\Service\Portal\PortalRequestService;
 use OCA\Pipelinq\Service\Portal\PortalTenantService;
 use OCP\AppFramework\Http;
+use OCP\AppFramework\Http\Attribute\AnonRateLimit;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\IRequest;
 use Psr\Log\LoggerInterface;
@@ -68,6 +69,7 @@ class PortalRequestController extends PortalApiController {
 	 * @NoCSRFRequired
 	 * @PublicPage
 	 */
+	#[AnonRateLimit(limit: 120, period: 60)]
 	public function index(): JSONResponse {
 		return $this->guarded(
 			handler: function (): array {
@@ -93,6 +95,7 @@ class PortalRequestController extends PortalApiController {
 	 * @NoCSRFRequired
 	 * @PublicPage
 	 */
+	#[AnonRateLimit(limit: 120, period: 60)]
 	public function show(string $id): JSONResponse {
 		return $this->guarded(
 			handler: function () use ($id): array {
@@ -117,6 +120,7 @@ class PortalRequestController extends PortalApiController {
 	 * @NoCSRFRequired
 	 * @PublicPage
 	 */
+	#[AnonRateLimit(limit: 30, period: 60)]
 	public function create(): JSONResponse {
 		return $this->guarded(
 			handler: function (): array {
@@ -150,6 +154,7 @@ class PortalRequestController extends PortalApiController {
 	 * @NoCSRFRequired
 	 * @PublicPage
 	 */
+	#[AnonRateLimit(limit: 30, period: 60)]
 	public function reply(string $id): JSONResponse {
 		return $this->guarded(
 			handler: function () use ($id): array {

--- a/lib/Controller/PortalTenantController.php
+++ b/lib/Controller/PortalTenantController.php
@@ -31,6 +31,7 @@ namespace OCA\Pipelinq\Controller;
 use OCA\Pipelinq\Service\Portal\PortalRequestGuard;
 use OCA\Pipelinq\Service\Portal\PortalTenantService;
 use OCP\AppFramework\Http;
+use OCP\AppFramework\Http\Attribute\AnonRateLimit;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\IRequest;
 use Psr\Log\LoggerInterface;
@@ -65,6 +66,7 @@ class PortalTenantController extends PortalApiController {
 	 * @NoCSRFRequired
 	 * @PublicPage
 	 */
+	#[AnonRateLimit(limit: 240, period: 60)]
 	public function config(): JSONResponse {
 		return $this->guarded(
 			handler: function (): array {


### PR DESCRIPTION
## What

Adds `#[AnonRateLimit]` to **38 publicly reachable methods** across the ten portal controllers (ADR-082). gate-82 goes 38 → 0.

## Why these were missed

They declare themselves public with the legacy **`@PublicPage` annotation**, not the `#[PublicPage]` attribute. The fleet sweep that reported this app fully throttled line-anchored the attribute form and excluded docblock matches — right about docblock *mentions*, wrong about the annotation, which is a live declaration (proven on two other apps: `openregister GraphQLController::execute` and `opencatalogi CatalogiController::index` both answer `200` unauthenticated with only the annotation).

## The portal auth endpoints were already protected — but not against this

`PortalAuthService` already arms a **sliding-window lockout after repeated failures on one account** (HTTP 429). This is not a claim that it was missing, and the distinction matters: I made the opposite error on openconnector#1251 and had to correct it.

What an account-scoped lockout **cannot see is password spraying** — one IP trying one password against many accounts, never tripping any single account's counter. That is the gap an IP-scoped ceiling closes, and it's written at the call site.

## Limits chosen per endpoint, not uniformly

| endpoint | limit | reason |
|---|---|---|
| `mfaVerify` | 10/60 | a TOTP code is six digits — the whole keyspace is a million guesses |
| `passwordResetRequest` | 10/60 | mails an address the caller supplies — mail-bomb vector |
| `requestExport` | 10/60 | cheap request, expensive server work |
| `login`, `passwordReset`, `book`, `sign`, delegation `create` | 20/60 | account takeover, slot exhaustion, or a legally meaningful act |
| writes (`create`, `reply`, `cancel`, …) | 30/60 | |
| reads (`invoices`, `contracts`, `orders`, …) | 120/60 | |
| portal HTML shell, tenant `config` | 240/60 | a tight ceiling here breaks ordinary browsing, not an attack |

## Why `AnonRateLimit` and not `BruteForceProtection`

`#[BruteForceProtection]` without a paired `registerAttempt()` is the **inert half** of a two-half mechanism — a mistake already made once in this programme. `AnonRateLimit` also leaves authenticated traffic untouched, so no integration can be throttled by this change.

## Verification

- `php -l` clean on all 10 files.
- Diff is **70 added lines, 0 removed** — purely additive.
- gate-82 (.github#460): **53 public methods, 53 throttled, 0 unthrottled**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
