### PR TITLE
refactor(deps): inject OpenRegister instead of looking it up (ADR-083)

### DIFF
--- a/lib/BackgroundJob/BrpMonitorJob.php
+++ b/lib/BackgroundJob/BrpMonitorJob.php
@@ -34,9 +34,9 @@ use OCP\BackgroundJob\TimedJob;
 use OCP\IAppConfig;
 use OCP\IGroupManager;
 use OCP\Notification\IManager as INotificationManager;
-use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
 use Throwable;
+use OCA\OpenRegister\Service\ObjectService;
 
 /**
  * BRP availability + SLA monitor.
@@ -67,10 +67,10 @@ class BrpMonitorJob extends TimedJob {
 	public function __construct(
 		ITimeFactory $time,
 		private IAppConfig $appConfig,
-		private ContainerInterface $container,
 		private IGroupManager $groupManager,
 		private INotificationManager $notificationManager,
 		private LoggerInterface $logger,
+		private readonly ObjectService $objectService,
 	) {
 		parent::__construct(time: $time);
 		$this->setInterval(
@@ -105,7 +105,7 @@ class BrpMonitorJob extends TimedJob {
 			$now = new DateTimeImmutable('now', new DateTimeZone('UTC'));
 			$window = $now->modify('-24 hours');
 
-			$records = $this->container->get('OCA\OpenRegister\Service\ObjectService')->findAll(
+			$records = $this->objectService->findAll(
 				config: [
 					'filters' => [
 						'action' => 'brp-lookup-uitgevoerd',
@@ -252,7 +252,7 @@ class BrpMonitorJob extends TimedJob {
 		$totalRequest = 0;
 		$cacheHits = 0;
 		$durations = [];
-		$verzoeken = $this->container->get('OCA\OpenRegister\Service\ObjectService')->findAll(
+		$verzoeken = $this->objectService->findAll(
 			config: [
 				'filters' => [
 					'register' => $register,

--- a/lib/BackgroundJob/ReminderDispatchJob.php
+++ b/lib/BackgroundJob/ReminderDispatchJob.php
@@ -37,6 +37,7 @@ use OCP\BackgroundJob\TimedJob;
 use OCP\IAppConfig;
 use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
+use OCA\OpenRegister\Service\ObjectService;
 
 /**
  * ReminderDispatchJob — 5-minute reminder dispatcher.
@@ -78,6 +79,7 @@ class ReminderDispatchJob extends TimedJob {
 		private IAppConfig $appConfig,
 		private ContainerInterface $container,
 		private LoggerInterface $logger,
+		private readonly ObjectService $objectService,
 	) {
 		parent::__construct(time: $time);
 		$this->setInterval(seconds: self::INTERVAL_SECONDS);
@@ -236,7 +238,7 @@ class ReminderDispatchJob extends TimedJob {
 	 * @return object
 	 */
 	private function getObjectService(): object {
-		return $this->container->get('OCA\OpenRegister\Service\ObjectService');
+		return $this->objectService;
 	}//end getObjectService()
 
 	/**

--- a/lib/Controller/BerichtenboxAdminController.php
+++ b/lib/Controller/BerichtenboxAdminController.php
@@ -36,8 +36,8 @@ use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\IAppConfig;
 use OCP\IRequest;
-use Psr\Container\ContainerInterface;
 use Throwable;
+use OCA\OpenRegister\Service\ObjectService;
 
 /**
  * Admin endpoints for Berichtenbox ops.
@@ -52,8 +52,8 @@ class BerichtenboxAdminController extends Controller {
 	 */
 	public function __construct(
 		IRequest $request,
-		private readonly ContainerInterface $container,
 		private readonly IAppConfig $appConfig,
+		private readonly ObjectService $objectService,
 	) {
 		parent::__construct(appName: Application::APP_ID, request: $request);
 	}//end __construct()
@@ -193,7 +193,7 @@ class BerichtenboxAdminController extends Controller {
 	 * @return \OCA\OpenRegister\Service\ObjectService
 	 */
 	private function getObjectService(): \OCA\OpenRegister\Service\ObjectService {
-		return $this->container->get('OCA\OpenRegister\Service\ObjectService');
+		return $this->objectService;
 	}//end getObjectService()
 
 	/**

--- a/lib/Controller/BrpController.php
+++ b/lib/Controller/BrpController.php
@@ -47,10 +47,10 @@ use OCP\IGroupManager;
 use OCP\IL10N;
 use OCP\IRequest;
 use OCP\IUserSession;
-use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
 use RuntimeException;
 use Throwable;
+use OCA\OpenRegister\Service\ObjectService;
 
 /**
  * Controller for the BRP-lookup REST surface.
@@ -107,8 +107,8 @@ class BrpController extends Controller {
 		private BsnAuditService $audit,
 		private OptOutService $optOut,
 		private BrpMutationWebhookListener $webhookListener,
-		private ContainerInterface $container,
 		private LoggerInterface $logger,
+		private readonly ObjectService $objectService,
 	) {
 		parent::__construct(appName: Application::APP_ID, request: $request);
 	}//end __construct()
@@ -848,7 +848,7 @@ class BrpController extends Controller {
 	 */
 	private function getObjectService(): object {
 		try {
-			return $this->container->get('OCA\OpenRegister\Service\ObjectService');
+			return $this->objectService;
 		} catch (Throwable $e) {
 			throw new RuntimeException('OpenRegister service is not available.');
 		}

--- a/lib/Service/ActivityTimelineService.php
+++ b/lib/Service/ActivityTimelineService.php
@@ -42,10 +42,10 @@ use DateTimeInterface;
 use OCA\Pipelinq\AppInfo\Application;
 use OCP\IAppConfig;
 use OCP\IUserSession;
-use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
 use RuntimeException;
 use Throwable;
+use OCA\OpenRegister\Service\ObjectService;
 
 /**
  * Aggregates CRM activity data from multiple OpenRegister schemas.
@@ -85,11 +85,11 @@ class ActivityTimelineService {
 	 *                                     `ticketType=contactmoment`, not their own schema.
 	 */
 	public function __construct(
-		private ContainerInterface $container,
 		private IAppConfig $appConfig,
 		private IUserSession $userSession,
 		private LoggerInterface $logger,
 		private TicketService $ticketService,
+		private readonly ObjectService $objectService,
 	) {
 	}//end __construct()
 
@@ -102,7 +102,7 @@ class ActivityTimelineService {
 	 */
 	private function getObjectService(): object {
 		try {
-			return $this->container->get('OCA\OpenRegister\Service\ObjectService');
+			return $this->objectService;
 		} catch (Throwable $e) {
 			throw new RuntimeException('OpenRegister service is not available.');
 		}

--- a/lib/Service/AnalyticsService.php
+++ b/lib/Service/AnalyticsService.php
@@ -39,9 +39,9 @@ use DateTimeInterface;
 use InvalidArgumentException;
 use OCA\Pipelinq\AppInfo\Application;
 use OCP\IAppConfig;
-use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
 use RuntimeException;
+use OCA\OpenRegister\Service\ObjectService;
 
 /**
  * Cross-module analytics summary service.
@@ -137,10 +137,10 @@ class AnalyticsService {
 	 * @param TicketService $ticketService Resolver for the unified ticket schema.
 	 */
 	public function __construct(
-		private ContainerInterface $container,
 		private IAppConfig $appConfig,
 		private LoggerInterface $logger,
 		private readonly TicketService $ticketService,
+		private readonly ObjectService $objectService,
 	) {
 	}//end __construct()
 
@@ -251,7 +251,7 @@ class AnalyticsService {
 	 */
 	private function getObjectService(): object {
 		try {
-			return $this->container->get('OCA\OpenRegister\Service\ObjectService');
+			return $this->objectService;
 		} catch (\Throwable $e) {
 			throw new RuntimeException(message: 'OpenRegister ObjectService is unavailable.', code: 0, previous: $e);
 		}

--- a/lib/Service/AppointmentEmailService.php
+++ b/lib/Service/AppointmentEmailService.php
@@ -37,9 +37,9 @@ use OCP\IAppConfig;
 use OCP\IL10N;
 use OCP\IURLGenerator;
 use OCP\Mail\IMailer;
-use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
 use RuntimeException;
+use OCA\OpenRegister\Service\ObjectService;
 
 /**
  * AppointmentEmailService — composes confirmation + reminder emails.
@@ -115,12 +115,12 @@ class AppointmentEmailService {
 	 * @param LoggerInterface $logger The logger.
 	 */
 	public function __construct(
-		private ContainerInterface $container,
 		private IAppConfig $appConfig,
 		private IMailer $mailer,
 		private IURLGenerator $urlGenerator,
 		private IL10N $l10n,
 		private LoggerInterface $logger,
+		private readonly ObjectService $objectService,
 	) {
 	}//end __construct()
 
@@ -856,7 +856,7 @@ class AppointmentEmailService {
 	 */
 	private function getObjectService(): object {
 		try {
-			return $this->container->get('OCA\OpenRegister\Service\ObjectService');
+			return $this->objectService;
 		} catch (\Throwable $e) {
 			throw new RuntimeException('OpenRegister ObjectService is unavailable.', 0, $e);
 		}

--- a/lib/Service/AvailabilityService.php
+++ b/lib/Service/AvailabilityService.php
@@ -33,9 +33,9 @@ use OCA\Pipelinq\AppInfo\Application;
 use OCP\IAppConfig;
 use OCP\ICache;
 use OCP\ICacheFactory;
-use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
 use RuntimeException;
+use OCA\OpenRegister\Service\ObjectService;
 
 /**
  * Compute per-resource per-day availability as 15-minute-aligned free blocks.
@@ -132,10 +132,10 @@ class AvailabilityService {
 	 * @param LoggerInterface $logger The logger.
 	 */
 	public function __construct(
-		private ContainerInterface $container,
 		private IAppConfig $appConfig,
 		private ICacheFactory $cacheFactory,
 		private LoggerInterface $logger,
+		private readonly ObjectService $objectService,
 	) {
 	}//end __construct()
 
@@ -1097,7 +1097,7 @@ class AvailabilityService {
 	 */
 	private function getObjectService(): object {
 		try {
-			return $this->container->get('OCA\OpenRegister\Service\ObjectService');
+			return $this->objectService;
 		} catch (\Throwable $e) {
 			throw new RuntimeException('OpenRegister ObjectService is unavailable.', 0, $e);
 		}

--- a/lib/Service/BerichtenboxService.php
+++ b/lib/Service/BerichtenboxService.php
@@ -42,6 +42,7 @@ use OCP\IAppConfig;
 use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
 use RuntimeException;
+use OCA\OpenRegister\Service\ObjectService;
 
 /**
  * Berichtenbox message lifecycle service.
@@ -113,6 +114,7 @@ class BerichtenboxService {
 		private readonly DutchHolidayCalendar $holidayCalendar,
 		private readonly TicketService $ticketService,
 		private readonly LoggerInterface $logger,
+		private readonly ObjectService $objectService,
 	) {
 	}//end __construct()
 
@@ -1044,7 +1046,7 @@ class BerichtenboxService {
 	 */
 	private function getObjectService(): \OCA\OpenRegister\Service\ObjectService {
 		try {
-			return $this->container->get('OCA\OpenRegister\Service\ObjectService');
+			return $this->objectService;
 		} catch (\Throwable $e) {
 			throw new RuntimeException('OpenRegister service unavailable.', 0, $e);
 		}

--- a/lib/Service/BookingService.php
+++ b/lib/Service/BookingService.php
@@ -38,9 +38,9 @@ use OCA\Pipelinq\Service\Lifecycle\SchemaLifecycleGraph;
 use OCP\BackgroundJob\IJobList;
 use OCP\IAppConfig;
 use OCP\IUserSession;
-use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
 use RuntimeException;
+use OCA\OpenRegister\Service\ObjectService;
 
 /**
  * BookingService — booking lifecycle service.
@@ -172,13 +172,13 @@ class BookingService {
 	 * @param IJobList $jobList The background-job list (member 09 rebalance is deferred to it).
 	 */
 	public function __construct(
-		private ContainerInterface $container,
 		private IAppConfig $appConfig,
 		private IUserSession $userSession,
 		private AvailabilityService $availabilityService,
 		private EligibilityService $eligibilityService,
 		private LoggerInterface $logger,
 		private IJobList $jobList,
+		private readonly ObjectService $objectService,
 	) {
 	}//end __construct()
 
@@ -1576,7 +1576,7 @@ class BookingService {
 	 */
 	private function getObjectService(): object {
 		try {
-			return $this->container->get('OCA\OpenRegister\Service\ObjectService');
+			return $this->objectService;
 		} catch (\Throwable $e) {
 			throw new RuntimeException('OpenRegister ObjectService is unavailable.', 0, $e);
 		}

--- a/lib/Service/BrpCacheService.php
+++ b/lib/Service/BrpCacheService.php
@@ -29,10 +29,10 @@ use DateTimeImmutable;
 use DateTimeZone;
 use OCA\Pipelinq\AppInfo\Application;
 use OCP\IAppConfig;
-use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
 use RuntimeException;
 use Throwable;
+use OCA\OpenRegister\Service\ObjectService;
 
 /**
  * Cache wrapper around the brpPersoon schema.
@@ -53,9 +53,9 @@ class BrpCacheService {
 	 * @param LoggerInterface $logger Logger.
 	 */
 	public function __construct(
-		private ContainerInterface $container,
 		private IAppConfig $appConfig,
 		private LoggerInterface $logger,
+		private readonly ObjectService $objectService,
 	) {
 	}//end __construct()
 
@@ -281,7 +281,7 @@ class BrpCacheService {
 	 */
 	private function getObjectService(): object {
 		try {
-			return $this->container->get('OCA\OpenRegister\Service\ObjectService');
+			return $this->objectService;
 		} catch (Throwable $e) {
 			throw new RuntimeException('OpenRegister service is not available.');
 		}

--- a/lib/Service/BsnAuditService.php
+++ b/lib/Service/BsnAuditService.php
@@ -29,10 +29,10 @@ use DateTimeZone;
 use OCA\Pipelinq\AppInfo\Application;
 use OCP\IAppConfig;
 use OCP\IRequest;
-use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
 use RuntimeException;
 use Throwable;
+use OCA\OpenRegister\Service\ObjectService;
 
 /**
  * Append-only audit-trail service for BSN bevragingen.
@@ -60,10 +60,10 @@ class BsnAuditService {
 	 * @param LoggerInterface $logger Logger (raw BSN MUST never appear here).
 	 */
 	public function __construct(
-		private ContainerInterface $container,
 		private IAppConfig $appConfig,
 		private IRequest $request,
 		private LoggerInterface $logger,
+		private readonly ObjectService $objectService,
 	) {
 	}//end __construct()
 
@@ -328,7 +328,7 @@ class BsnAuditService {
 	 */
 	private function getObjectService(): object {
 		try {
-			return $this->container->get('OCA\OpenRegister\Service\ObjectService');
+			return $this->objectService;
 		} catch (Throwable $e) {
 			throw new RuntimeException('OpenRegister service is not available.');
 		}

--- a/lib/Service/CashShiftService.php
+++ b/lib/Service/CashShiftService.php
@@ -45,9 +45,11 @@ use OCP\AppFramework\OCS\OCSForbiddenException;
 use OCP\AppFramework\OCS\OCSNotFoundException;
 use OCP\EventDispatcher\Event;
 use OCP\IAppConfig;
-use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
 use RuntimeException;
+use OCA\OpenRegister\Service\WebhookService;
+use OCA\OpenRegister\Service\ObjectService;
+use OCA\OpenRegister\Service\Aggregation\AggregationRunner;
 
 /**
  * Service for POS cash-drawer (shift / drop / count / diff) operations.
@@ -105,10 +107,12 @@ class CashShiftService {
 	 * @param LoggerInterface $logger The logger.
 	 */
 	public function __construct(
-		private ContainerInterface $container,
 		private IAppConfig $appConfig,
 		private PosAccessPolicy $policy,
 		private LoggerInterface $logger,
+		private readonly WebhookService $webhookService,
+		private readonly ObjectService $objectService,
+		private readonly AggregationRunner $aggregationRunner,
 	) {
 	}//end __construct()
 
@@ -600,9 +604,8 @@ class CashShiftService {
 		];
 
 		try {
-			$webhookService = $this->container->get('OCA\OpenRegister\Service\WebhookService');
 			$event = new Event();
-			$webhookService->dispatchEvent(_event: $event, eventName: self::EVENT_CASH_DIFF_CONFIRMED, payload: $payload);
+			$this->webhookService->dispatchEvent(_event: $event, eventName: self::EVENT_CASH_DIFF_CONFIRMED, payload: $payload);
 			return $eventId;
 		} catch (\Throwable $e) {
 			$this->logger->warning(
@@ -804,7 +807,7 @@ class CashShiftService {
 	 */
 	private function getObjectService(): object {
 		try {
-			return $this->container->get('OCA\OpenRegister\Service\ObjectService');
+			return $this->objectService;
 		} catch (\Throwable $e) {
 			throw new RuntimeException('OpenRegister service is not available.');
 		}
@@ -823,7 +826,7 @@ class CashShiftService {
 	 */
 	private function getAggregationRunner(): object {
 		try {
-			return $this->container->get('OCA\OpenRegister\Service\Aggregation\AggregationRunner');
+			return $this->aggregationRunner;
 		} catch (\Throwable $e) {
 			throw new RuntimeException('OpenRegister aggregation runner is not available.');
 		}

--- a/lib/Service/ContactImportService.php
+++ b/lib/Service/ContactImportService.php
@@ -25,8 +25,8 @@ namespace OCA\Pipelinq\Service;
 
 use OCA\Pipelinq\AppInfo\Application;
 use OCP\IAppConfig;
-use Psr\Container\ContainerInterface;
 use RuntimeException;
+use OCA\OpenRegister\Service\ObjectService;
 
 /**
  * Service for importing Nextcloud contacts into Pipelinq objects.
@@ -41,8 +41,8 @@ class ContactImportService {
 	 */
 	public function __construct(
 		private IAppConfig $appConfig,
-		private ContainerInterface $container,
 		private ContactDataBuilder $dataBuilder,
+		private readonly ObjectService $objectService,
 	) {
 	}//end __construct()
 
@@ -159,6 +159,6 @@ class ContactImportService {
 	 * @return object The object service.
 	 */
 	private function getObjectService(): object {
-		return $this->container->get('OCA\OpenRegister\Service\ObjectService');
+		return $this->objectService;
 	}//end getObjectService()
 }//end class

--- a/lib/Service/ContactLinkedUidsService.php
+++ b/lib/Service/ContactLinkedUidsService.php
@@ -23,8 +23,8 @@ namespace OCA\Pipelinq\Service;
 
 use OCA\Pipelinq\AppInfo\Application;
 use OCP\IAppConfig;
-use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
+use OCA\OpenRegister\Service\ObjectService;
 
 /**
  * Service for finding already-linked contact UIDs.
@@ -39,8 +39,8 @@ class ContactLinkedUidsService {
 	 */
 	public function __construct(
 		private IAppConfig $appConfig,
-		private ContainerInterface $container,
 		private LoggerInterface $logger,
+		private readonly ObjectService $objectService,
 	) {
 	}//end __construct()
 
@@ -141,6 +141,6 @@ class ContactLinkedUidsService {
 	 * @return object The object service.
 	 */
 	private function getObjectService(): object {
-		return $this->container->get('OCA\OpenRegister\Service\ObjectService');
+		return $this->objectService;
 	}//end getObjectService()
 }//end class

--- a/lib/Service/ContactSyncService.php
+++ b/lib/Service/ContactSyncService.php
@@ -27,8 +27,8 @@ namespace OCA\Pipelinq\Service;
 use OCA\Pipelinq\AppInfo\Application;
 use OCP\Contacts\IManager as IContactsManager;
 use OCP\IAppConfig;
-use Psr\Container\ContainerInterface;
 use RuntimeException;
+use OCA\OpenRegister\Service\ObjectService;
 
 /**
  * Service for searching and importing Nextcloud contacts into Pipelinq.
@@ -50,7 +50,7 @@ class ContactSyncService {
 		private ContactVcardService $contactVcardService,
 		private ContactLinkedUidsService $linkedUidsService,
 		private IAppConfig $appConfig,
-		private ContainerInterface $container,
+		private readonly ObjectService $objectService,
 	) {
 	}//end __construct()
 
@@ -141,7 +141,7 @@ class ContactSyncService {
 	 * @return object The object service.
 	 */
 	private function getObjectService(): object {
-		return $this->container->get('OCA\OpenRegister\Service\ObjectService');
+		return $this->objectService;
 	}//end getObjectService()
 
 	/**

--- a/lib/Service/ContactVcardPropertyBuilder.php
+++ b/lib/Service/ContactVcardPropertyBuilder.php
@@ -25,7 +25,7 @@ namespace OCA\Pipelinq\Service;
 
 use OCA\Pipelinq\AppInfo\Application;
 use OCP\IAppConfig;
-use Psr\Container\ContainerInterface;
+use OCA\OpenRegister\Service\ObjectService;
 
 /**
  * Service for building vCard properties from Pipelinq object data.
@@ -39,7 +39,7 @@ class ContactVcardPropertyBuilder {
 	 */
 	public function __construct(
 		private IAppConfig $appConfig,
-		private ContainerInterface $container,
+		private readonly ObjectService $objectService,
 	) {
 	}//end __construct()
 
@@ -191,6 +191,6 @@ class ContactVcardPropertyBuilder {
 	 * @return object The object service.
 	 */
 	private function getObjectService(): object {
-		return $this->container->get('OCA\OpenRegister\Service\ObjectService');
+		return $this->objectService;
 	}//end getObjectService()
 }//end class

--- a/lib/Service/ContactVcardService.php
+++ b/lib/Service/ContactVcardService.php
@@ -26,8 +26,8 @@ namespace OCA\Pipelinq\Service;
 use OCA\Pipelinq\AppInfo\Application;
 use OCP\Contacts\IManager as IContactsManager;
 use OCP\IAppConfig;
-use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
+use OCA\OpenRegister\Service\ObjectService;
 
 /**
  * Service for syncing Pipelinq objects to Nextcloud Contacts as vCards.
@@ -59,11 +59,11 @@ class ContactVcardService {
 	public function __construct(
 		private IContactsManager $contactsManager,
 		private IAppConfig $appConfig,
-		private ContainerInterface $container,
 		private ContactVcardWriterService $writerService,
 		private ContactVcardPropertyBuilder $propBuilder,
 		private LoggerInterface $logger,
 		private RegisterResolverService $registerResolver,
+		private readonly ObjectService $objectService,
 	) {
 	}//end __construct()
 
@@ -279,6 +279,6 @@ class ContactVcardService {
 	 * @return object The object service.
 	 */
 	private function getObjectService(): object {
-		return $this->container->get('OCA\OpenRegister\Service\ObjectService');
+		return $this->objectService;
 	}//end getObjectService()
 }//end class

--- a/lib/Service/ContactVcardWriterService.php
+++ b/lib/Service/ContactVcardWriterService.php
@@ -26,8 +26,8 @@ namespace OCA\Pipelinq\Service;
 use OCA\Pipelinq\AppInfo\Application;
 use OCP\Contacts\IManager as IContactsManager;
 use OCP\IAppConfig;
-use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
+use OCA\OpenRegister\Service\ObjectService;
 
 /**
  * Service for writing vCard data to Nextcloud addressbooks.
@@ -47,9 +47,9 @@ class ContactVcardWriterService {
 	public function __construct(
 		private IContactsManager $contactsManager,
 		private IAppConfig $appConfig,
-		private ContainerInterface $container,
 		private LoggerInterface $logger,
 		private RegisterResolverService $registerResolver,
+		private readonly ObjectService $objectService,
 	) {
 	}//end __construct()
 
@@ -226,6 +226,6 @@ class ContactVcardWriterService {
 	 * @return object The object service.
 	 */
 	private function getObjectService(): object {
-		return $this->container->get('OCA\OpenRegister\Service\ObjectService');
+		return $this->objectService;
 	}//end getObjectService()
 }//end class

--- a/lib/Service/ContactmomentService.php
+++ b/lib/Service/ContactmomentService.php
@@ -27,9 +27,9 @@ namespace OCA\Pipelinq\Service;
 use OCP\AppFramework\Db\DoesNotExistException;
 use OCP\Files\NotPermittedException;
 use OCP\IGroupManager;
-use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
 use RuntimeException;
+use OCA\OpenRegister\Service\ObjectService;
 
 /**
  * Service for contactmoment business operations.
@@ -55,10 +55,10 @@ class ContactmomentService {
 	 * @param LoggerInterface $logger The logger.
 	 */
 	public function __construct(
-		private ContainerInterface $container,
 		private TicketService $ticketService,
 		private IGroupManager $groupManager,
 		private LoggerInterface $logger,
+		private readonly ObjectService $objectService,
 	) {
 	}//end __construct()
 
@@ -72,7 +72,7 @@ class ContactmomentService {
 	 */
 	public function getObjectService(): \OCA\OpenRegister\Service\ObjectService {
 		try {
-			return $this->container->get('OCA\OpenRegister\Service\ObjectService');
+			return $this->objectService;
 		} catch (\Exception $e) {
 			throw new RuntimeException('OpenRegister service is not available.');
 		}
@@ -217,7 +217,6 @@ class ContactmomentService {
 	 */
 	private function objectServiceLoose(): ?object {
 		try {
-			$service = $this->container->get('OCA\OpenRegister\Service\ObjectService');
 		} catch (\Throwable $e) {
 			return null;
 		}

--- a/lib/Service/Customer360SummaryService.php
+++ b/lib/Service/Customer360SummaryService.php
@@ -31,10 +31,10 @@ use DateTimeImmutable;
 use Exception;
 use OCA\Pipelinq\AppInfo\Application;
 use OCP\IAppConfig;
-use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
 use RuntimeException;
 use Throwable;
+use OCA\OpenRegister\Service\ObjectService;
 
 /**
  * Aggregates a client's open tickets (all `ticketType`s), SLA/queue status,
@@ -92,12 +92,12 @@ class Customer360SummaryService {
 	 * @param LoggerInterface $logger Logger.
 	 */
 	public function __construct(
-		private readonly ContainerInterface $container,
 		private readonly RegisterResolverService $registerResolver,
 		private readonly IAppConfig $appConfig,
 		private readonly TicketService $ticketService,
 		private readonly ActivityTimelineService $activityTimeline,
 		private readonly LoggerInterface $logger,
+		private readonly ObjectService $objectService,
 	) {
 	}//end __construct()
 
@@ -284,7 +284,7 @@ class Customer360SummaryService {
 	 */
 	private function getObjectService(): \OCA\OpenRegister\Service\ObjectService {
 		try {
-			return $this->container->get('OCA\OpenRegister\Service\ObjectService');
+			return $this->objectService;
 		} catch (Throwable $e) {
 			throw new RuntimeException('OpenRegister ObjectService is not available', 0, $e);
 		}

--- a/lib/Service/DefaultPipelineService.php
+++ b/lib/Service/DefaultPipelineService.php
@@ -25,8 +25,8 @@ namespace OCA\Pipelinq\Service;
 
 use OCA\Pipelinq\AppInfo\Application;
 use OCP\IAppConfig;
-use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
+use OCA\OpenRegister\Service\ObjectService;
 
 /**
  * Service for creating default pipelines.
@@ -42,9 +42,9 @@ class DefaultPipelineService {
 	 */
 	public function __construct(
 		private IAppConfig $appConfig,
-		private ContainerInterface $container,
 		private PipelineStageData $stageData,
 		private LoggerInterface $logger,
+		private readonly ObjectService $objectService,
 	) {
 	}//end __construct()
 
@@ -139,6 +139,6 @@ class DefaultPipelineService {
 	 * @return object The object service.
 	 */
 	private function getObjectService(): object {
-		return $this->container->get('OCA\OpenRegister\Service\ObjectService');
+		return $this->objectService;
 	}//end getObjectService()
 }//end class

--- a/lib/Service/DefaultQueueService.php
+++ b/lib/Service/DefaultQueueService.php
@@ -26,8 +26,8 @@ namespace OCA\Pipelinq\Service;
 
 use OCA\Pipelinq\AppInfo\Application;
 use OCP\IAppConfig;
-use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
+use OCA\OpenRegister\Service\ObjectService;
 
 /**
  * Service for creating default queues and skills.
@@ -112,9 +112,9 @@ class DefaultQueueService {
 	 */
 	public function __construct(
 		private IAppConfig $appConfig,
-		private ContainerInterface $container,
 		private LoggerInterface $logger,
 		private RegisterResolverService $registerResolver,
+		private readonly ObjectService $objectService,
 	) {
 	}//end __construct()
 
@@ -232,6 +232,6 @@ class DefaultQueueService {
 	 * @return object The object service.
 	 */
 	private function getObjectService(): object {
-		return $this->container->get('OCA\OpenRegister\Service\ObjectService');
+		return $this->objectService;
 	}//end getObjectService()
 }//end class

--- a/lib/Service/DeliveryAuditLogger.php
+++ b/lib/Service/DeliveryAuditLogger.php
@@ -35,9 +35,9 @@ use DateTimeInterface;
 use DateTimeZone;
 use OCA\Pipelinq\AppInfo\Application;
 use OCP\IAppConfig;
-use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
 use RuntimeException;
+use OCA\OpenRegister\Service\ObjectService;
 
 /**
  * Append-only audit logger.
@@ -60,9 +60,9 @@ class DeliveryAuditLogger {
 	 * @param LoggerInterface $logger Logger.
 	 */
 	public function __construct(
-		private readonly ContainerInterface $container,
 		private readonly IAppConfig $appConfig,
 		private readonly LoggerInterface $logger,
+		private readonly ObjectService $objectService,
 	) {
 	}//end __construct()
 
@@ -364,7 +364,7 @@ class DeliveryAuditLogger {
 	 */
 	private function getObjectService(): \OCA\OpenRegister\Service\ObjectService {
 		try {
-			return $this->container->get('OCA\OpenRegister\Service\ObjectService');
+			return $this->objectService;
 		} catch (\Throwable $e) {
 			throw new RuntimeException('OpenRegister service unavailable.', 0, $e);
 		}

--- a/lib/Service/EligibilityService.php
+++ b/lib/Service/EligibilityService.php
@@ -29,9 +29,9 @@ namespace OCA\Pipelinq\Service;
 
 use OCA\Pipelinq\AppInfo\Application;
 use OCP\IAppConfig;
-use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
 use RuntimeException;
+use OCA\OpenRegister\Service\ObjectService;
 
 /**
  * Resolve which Resources are eligible to perform a Service.
@@ -77,10 +77,10 @@ class EligibilityService {
 	 * @param LoggerInterface $logger The logger.
 	 */
 	public function __construct(
-		private ContainerInterface $container,
 		private IAppConfig $appConfig,
 		private AvailabilityService $availabilityService,
 		private LoggerInterface $logger,
+		private readonly ObjectService $objectService,
 	) {
 	}//end __construct()
 
@@ -526,7 +526,7 @@ class EligibilityService {
 	 */
 	private function getObjectService(): object {
 		try {
-			return $this->container->get('OCA\OpenRegister\Service\ObjectService');
+			return $this->objectService;
 		} catch (\Throwable $e) {
 			throw new RuntimeException('OpenRegister ObjectService is unavailable.', 0, $e);
 		}

--- a/lib/Service/EntityActivityService.php
+++ b/lib/Service/EntityActivityService.php
@@ -31,10 +31,10 @@ namespace OCA\Pipelinq\Service;
 use InvalidArgumentException;
 use OCA\Pipelinq\AppInfo\Application;
 use OCP\IAppConfig;
-use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
 use RuntimeException;
 use Throwable;
+use OCA\OpenRegister\Service\ObjectService;
 
 /**
  * Builds the merged, paginated activity feed for an entity.
@@ -107,10 +107,10 @@ class EntityActivityService {
 	 *                                     tickets after unify-ticket-supertype.
 	 */
 	public function __construct(
-		private readonly ContainerInterface $container,
 		private readonly IAppConfig $appConfig,
 		private readonly LoggerInterface $logger,
 		private readonly TicketService $ticketService,
+		private readonly ObjectService $objectService,
 	) {
 	}//end __construct()
 
@@ -600,7 +600,7 @@ class EntityActivityService {
 	 */
 	private function getObjectService(): object {
 		try {
-			return $this->container->get('OCA\OpenRegister\Service\ObjectService');
+			return $this->objectService;
 		} catch (Throwable $e) {
 			throw new RuntimeException('OpenRegister service is not available.');
 		}

--- a/lib/Service/Export/AbstractExportService.php
+++ b/lib/Service/Export/AbstractExportService.php
@@ -35,8 +35,8 @@ use DateTimeInterface;
 use OCA\Pipelinq\AppInfo\Application;
 use OCP\AppFramework\OCS\OCSNotFoundException;
 use OCP\IAppConfig;
-use Psr\Container\ContainerInterface;
 use RuntimeException;
+use OCA\OpenRegister\Service\ObjectService;
 
 /**
  * Base class for the BI export services.
@@ -59,6 +59,7 @@ abstract class AbstractExportService {
 	public function __construct(
 		protected ContainerInterface $container,
 		protected IAppConfig $appConfig,
+		private readonly ObjectService $objectService,
 	) {
 	}//end __construct()
 
@@ -184,7 +185,7 @@ abstract class AbstractExportService {
 	 */
 	protected function getObjectService(): object {
 		try {
-			return $this->container->get('OCA\OpenRegister\Service\ObjectService');
+			return $this->objectService;
 		} catch (\Throwable $e) {
 			throw new RuntimeException('OpenRegister service is not available.');
 		}

--- a/lib/Service/ForecastExportService.php
+++ b/lib/Service/ForecastExportService.php
@@ -26,9 +26,9 @@ namespace OCA\Pipelinq\Service;
 
 use OCA\Pipelinq\AppInfo\Application;
 use OCP\IAppConfig;
-use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
 use RuntimeException;
+use OCA\OpenRegister\Service\ObjectService;
 
 /**
  * Snapshot export builder.
@@ -56,11 +56,11 @@ class ForecastExportService {
 	 * @param LoggerInterface $logger The logger.
 	 */
 	public function __construct(
-		private ContainerInterface $container,
 		private IAppConfig $appConfig,
 		private ForecastService $forecastService,
 		private ReportingService $reportingService,
 		private LoggerInterface $logger,
+		private readonly ObjectService $objectService,
 	) {
 	}//end __construct()
 
@@ -374,7 +374,7 @@ class ForecastExportService {
 	 */
 	private function getObjectService(): object {
 		try {
-			return $this->container->get('OCA\OpenRegister\Service\ObjectService');
+			return $this->objectService;
 		} catch (\Throwable $e) {
 			throw new RuntimeException('OpenRegister ObjectService is unavailable.', 0, $e);
 		}

--- a/lib/Service/ForecastOverrideService.php
+++ b/lib/Service/ForecastOverrideService.php
@@ -27,9 +27,9 @@ namespace OCA\Pipelinq\Service;
 use DateTimeImmutable;
 use OCA\Pipelinq\AppInfo\Application;
 use OCP\IAppConfig;
-use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
 use RuntimeException;
+use OCA\OpenRegister\Service\ObjectService;
 
 /**
  * Manager-override lifecycle service.
@@ -61,10 +61,10 @@ class ForecastOverrideService {
 	 * @param LoggerInterface $logger The logger.
 	 */
 	public function __construct(
-		private ContainerInterface $container,
 		private IAppConfig $appConfig,
 		private ForecastService $forecastService,
 		private LoggerInterface $logger,
+		private readonly ObjectService $objectService,
 	) {
 	}//end __construct()
 
@@ -283,7 +283,7 @@ class ForecastOverrideService {
 	 */
 	private function getObjectService(): object {
 		try {
-			return $this->container->get('OCA\OpenRegister\Service\ObjectService');
+			return $this->objectService;
 		} catch (\Throwable $e) {
 			throw new RuntimeException('OpenRegister ObjectService is unavailable.', 0, $e);
 		}

--- a/lib/Service/ForecastService.php
+++ b/lib/Service/ForecastService.php
@@ -26,9 +26,9 @@ namespace OCA\Pipelinq\Service;
 
 use OCA\Pipelinq\AppInfo\Application;
 use OCP\IAppConfig;
-use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
 use RuntimeException;
+use OCA\OpenRegister\Service\ObjectService;
 
 /**
  * Forecast computation engine.
@@ -76,11 +76,11 @@ class ForecastService {
 	 * @param LoggerInterface $logger The logger.
 	 */
 	public function __construct(
-		private ContainerInterface $container,
 		private IAppConfig $appConfig,
 		private QuotaService $quotaService,
 		private ForecastRollupService $rollup,
 		private LoggerInterface $logger,
+		private readonly ObjectService $objectService,
 	) {
 	}//end __construct()
 
@@ -406,7 +406,7 @@ class ForecastService {
 	 */
 	private function getObjectService(): object {
 		try {
-			return $this->container->get('OCA\OpenRegister\Service\ObjectService');
+			return $this->objectService;
 		} catch (\Throwable $e) {
 			throw new RuntimeException('OpenRegister ObjectService is unavailable.', 0, $e);
 		}

--- a/lib/Service/GiftCardService.php
+++ b/lib/Service/GiftCardService.php
@@ -31,9 +31,9 @@ use DateTimeImmutable;
 use DateTimeZone;
 use OCA\Pipelinq\AppInfo\Application;
 use OCP\IAppConfig;
-use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
 use RuntimeException;
+use OCA\OpenRegister\Service\ObjectService;
 
 /**
  * Gift card lifecycle.
@@ -51,9 +51,9 @@ class GiftCardService {
 	 * @param LoggerInterface $logger The logger.
 	 */
 	public function __construct(
-		private ContainerInterface $container,
 		private IAppConfig $appConfig,
 		private LoggerInterface $logger,
+		private readonly ObjectService $objectService,
 	) {
 	}//end __construct()
 
@@ -707,7 +707,7 @@ class GiftCardService {
 	 */
 	private function getObjectService(): object {
 		try {
-			return $this->container->get('OCA\OpenRegister\Service\ObjectService');
+			return $this->objectService;
 		} catch (\Throwable $e) {
 			throw new RuntimeException('OpenRegister ObjectService is unavailable.', 0, $e);
 		}

--- a/lib/Service/KassakoppelingAuditService.php
+++ b/lib/Service/KassakoppelingAuditService.php
@@ -45,9 +45,9 @@ use OCA\Pipelinq\AppInfo\Application;
 use OCP\AppFramework\OCS\OCSBadRequestException;
 use OCP\AppFramework\OCS\OCSNotFoundException;
 use OCP\IAppConfig;
-use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
 use RuntimeException;
+use OCA\OpenRegister\Service\ObjectService;
 
 /**
  * Service for the POS Kassakoppeling audit log.
@@ -99,11 +99,11 @@ class KassakoppelingAuditService {
 	 * @param LoggerInterface $logger The logger.
 	 */
 	public function __construct(
-		private ContainerInterface $container,
 		private IAppConfig $appConfig,
 		private KassakoppelingSignatureService $signature,
 		private BelastingdienstExportService $exporter,
 		private LoggerInterface $logger,
+		private readonly ObjectService $objectService,
 	) {
 	}//end __construct()
 
@@ -627,7 +627,7 @@ class KassakoppelingAuditService {
 	 */
 	private function getObjectService(): object {
 		try {
-			return $this->container->get('OCA\OpenRegister\Service\ObjectService');
+			return $this->objectService;
 		} catch (\Throwable $e) {
 			throw new RuntimeException('OpenRegister service is not available.');
 		}

--- a/lib/Service/LoyaltyAccountService.php
+++ b/lib/Service/LoyaltyAccountService.php
@@ -31,9 +31,9 @@ use DateTimeImmutable;
 use DateTimeZone;
 use OCA\Pipelinq\AppInfo\Application;
 use OCP\IAppConfig;
-use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
 use RuntimeException;
+use OCA\OpenRegister\Service\ObjectService;
 
 /**
  * KlantLoyaltyAccount lifecycle service.
@@ -49,9 +49,9 @@ class LoyaltyAccountService {
 	 * @param LoggerInterface $logger The logger.
 	 */
 	public function __construct(
-		private ContainerInterface $container,
 		private IAppConfig $appConfig,
 		private LoggerInterface $logger,
+		private readonly ObjectService $objectService,
 	) {
 	}//end __construct()
 
@@ -450,7 +450,7 @@ class LoyaltyAccountService {
 	 */
 	private function getObjectService(): object {
 		try {
-			return $this->container->get('OCA\OpenRegister\Service\ObjectService');
+			return $this->objectService;
 		} catch (\Throwable $e) {
 			throw new RuntimeException('OpenRegister ObjectService is unavailable.', 0, $e);
 		}

--- a/lib/Service/LoyaltyEngineService.php
+++ b/lib/Service/LoyaltyEngineService.php
@@ -33,10 +33,10 @@ use OCA\Pipelinq\AppInfo\Application;
 use OCP\EventDispatcher\GenericEvent;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\IAppConfig;
-use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
 use RuntimeException;
 use Throwable;
+use OCA\OpenRegister\Service\ObjectService;
 
 /**
  * Orchestrates the end-to-end loyalty credit flow on a POS-trigger.
@@ -60,7 +60,6 @@ class LoyaltyEngineService {
 	 * @param LoggerInterface $logger The logger.
 	 */
 	public function __construct(
-		private ContainerInterface $container,
 		private IAppConfig $appConfig,
 		private LoyaltyAccountService $accountService,
 		private PointsLedgerService $ledgerService,
@@ -68,6 +67,7 @@ class LoyaltyEngineService {
 		private TierService $tierService,
 		private IEventDispatcher $eventDispatcher,
 		private LoggerInterface $logger,
+		private readonly ObjectService $objectService,
 	) {
 	}//end __construct()
 
@@ -558,7 +558,7 @@ class LoyaltyEngineService {
 	 */
 	private function getObjectService(): object {
 		try {
-			return $this->container->get('OCA\OpenRegister\Service\ObjectService');
+			return $this->objectService;
 		} catch (Throwable $e) {
 			throw new RuntimeException('OpenRegister ObjectService is unavailable.', 0, $e);
 		}

--- a/lib/Service/LoyaltyProgrammeService.php
+++ b/lib/Service/LoyaltyProgrammeService.php
@@ -27,9 +27,9 @@ namespace OCA\Pipelinq\Service;
 use OCA\Pipelinq\AppInfo\Application;
 use OCA\Pipelinq\Service\Lifecycle\SchemaLifecycleGraph;
 use OCP\IAppConfig;
-use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
 use RuntimeException;
+use OCA\OpenRegister\Service\ObjectService;
 
 /**
  * Programme activation + validation service.
@@ -53,9 +53,9 @@ class LoyaltyProgrammeService {
 	 * @param SchemaLifecycleGraph $lifecycleGraph Reads the programme status graph from its schema.
 	 */
 	public function __construct(
-		private ContainerInterface $container,
 		private IAppConfig $appConfig,
 		private LoggerInterface $logger,
+		private readonly ObjectService $objectService,
 		private SchemaLifecycleGraph $lifecycleGraph = new SchemaLifecycleGraph(),
 	) {
 	}//end __construct()
@@ -320,7 +320,7 @@ class LoyaltyProgrammeService {
 	 */
 	private function getObjectService(): object {
 		try {
-			return $this->container->get('OCA\OpenRegister\Service\ObjectService');
+			return $this->objectService;
 		} catch (\Throwable $e) {
 			throw new RuntimeException('OpenRegister ObjectService is unavailable.', 0, $e);
 		}

--- a/lib/Service/LoyaltyReportingService.php
+++ b/lib/Service/LoyaltyReportingService.php
@@ -32,9 +32,10 @@ use DateTimeZone;
 use OCA\OpenRegister\Service\Aggregation\AggregationQuery;
 use OCA\Pipelinq\AppInfo\Application;
 use OCP\IAppConfig;
-use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
 use RuntimeException;
+use OCA\OpenRegister\Service\ObjectService;
+use OCA\OpenRegister\Service\Aggregation\AggregationRunner;
 
 /**
  * Read-only reporting service.
@@ -62,12 +63,13 @@ class LoyaltyReportingService {
 	 * @param LoggerInterface $logger The logger.
 	 */
 	public function __construct(
-		private ContainerInterface $container,
 		private IAppConfig $appConfig,
 		private LoyaltyAccountService $accountService,
 		private PointsLedgerService $ledgerService,
 		private LoyaltyProgrammeService $programmeService,
 		private LoggerInterface $logger,
+		private readonly ObjectService $objectService,
+		private readonly AggregationRunner $aggregationRunner,
 	) {
 	}//end __construct()
 
@@ -436,7 +438,7 @@ class LoyaltyReportingService {
 	 */
 	private function getObjectService(): object {
 		try {
-			return $this->container->get('OCA\OpenRegister\Service\ObjectService');
+			return $this->objectService;
 		} catch (\Throwable $e) {
 			throw new RuntimeException('OpenRegister ObjectService is unavailable.', 0, $e);
 		}
@@ -455,7 +457,7 @@ class LoyaltyReportingService {
 	 */
 	private function getAggregationRunner(): object {
 		try {
-			return $this->container->get('OCA\OpenRegister\Service\Aggregation\AggregationRunner');
+			return $this->aggregationRunner;
 		} catch (\Throwable $e) {
 			throw new RuntimeException('OpenRegister aggregation runner is unavailable.', 0, $e);
 		}

--- a/lib/Service/MailboxResolver.php
+++ b/lib/Service/MailboxResolver.php
@@ -34,9 +34,9 @@ use DateTimeImmutable;
 use DateTimeZone;
 use OCA\Pipelinq\AppInfo\Application;
 use OCP\IAppConfig;
-use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
 use RuntimeException;
+use OCA\OpenRegister\Service\ObjectService;
 
 /**
  * Mailbox lookup with TTL cache.
@@ -61,11 +61,11 @@ class MailboxResolver {
 	 * @param LoggerInterface $logger Logger.
 	 */
 	public function __construct(
-		private readonly ContainerInterface $container,
 		private readonly IAppConfig $appConfig,
 		private readonly EncryptionService $encryption,
 		private readonly LogiusConnector $logiusConnector,
 		private readonly LoggerInterface $logger,
+		private readonly ObjectService $objectService,
 	) {
 	}//end __construct()
 
@@ -238,7 +238,7 @@ class MailboxResolver {
 	 */
 	private function getObjectService(): \OCA\OpenRegister\Service\ObjectService {
 		try {
-			return $this->container->get('OCA\OpenRegister\Service\ObjectService');
+			return $this->objectService;
 		} catch (\Throwable $e) {
 			throw new RuntimeException('OpenRegister service unavailable: ' . $e->getMessage(), 0, $e);
 		}

--- a/lib/Service/Mdm/MdmObjectRepository.php
+++ b/lib/Service/Mdm/MdmObjectRepository.php
@@ -31,9 +31,9 @@ use DateTimeImmutable;
 use DateTimeZone;
 use OCA\Pipelinq\AppInfo\Application;
 use OCP\IAppConfig;
-use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
 use RuntimeException;
+use OCA\OpenRegister\Service\ObjectService;
 
 /**
  * Repository helper for MDM OpenRegister objects.
@@ -80,9 +80,9 @@ class MdmObjectRepository {
 	 * @param LoggerInterface $logger The logger.
 	 */
 	public function __construct(
-		private ContainerInterface $container,
 		private IAppConfig $appConfig,
 		private LoggerInterface $logger,
+		private readonly ObjectService $objectService,
 	) {
 	}//end __construct()
 
@@ -333,7 +333,7 @@ class MdmObjectRepository {
 	 */
 	private function objectService(): object {
 		try {
-			return $this->container->get('OCA\OpenRegister\Service\ObjectService');
+			return $this->objectService;
 		} catch (\Throwable $e) {
 			throw new RuntimeException('OpenRegister service is not available.');
 		}

--- a/lib/Service/NaviService.php
+++ b/lib/Service/NaviService.php
@@ -55,9 +55,9 @@ namespace OCA\Pipelinq\Service;
 
 use OCA\Pipelinq\AppInfo\Application;
 use OCP\IAppConfig;
-use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
 use RuntimeException;
+use OCA\OpenRegister\Service\ObjectService;
 
 /**
  * Conversational analytics orchestrator (Navi AI).
@@ -97,11 +97,11 @@ class NaviService {
 	 * @param NaviConversationStore $conversationStore User-scoped store of conversation turns.
 	 */
 	public function __construct(
-		private ContainerInterface $container,
 		private IAppConfig $appConfig,
 		private LoggerInterface $logger,
 		private readonly TicketService $ticketService,
 		private readonly NaviConversationStore $conversationStore,
+		private readonly ObjectService $objectService,
 	) {
 	}//end __construct()
 
@@ -554,8 +554,7 @@ class NaviService {
 		}
 
 		try {
-			$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
-			$results = $objectService->findAll(
+			$results = $this->objectService->findAll(
 				config: ['filters' => ['register' => $register, 'schema' => $schema]]
 			);
 		} catch (\Throwable $e) {

--- a/lib/Service/OptOutService.php
+++ b/lib/Service/OptOutService.php
@@ -28,10 +28,10 @@ use DateTimeImmutable;
 use DateTimeZone;
 use OCA\Pipelinq\AppInfo\Application;
 use OCP\IAppConfig;
-use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
 use RuntimeException;
 use Throwable;
+use OCA\OpenRegister\Service\ObjectService;
 
 /**
  * Opt-out lookup + recording service.
@@ -51,9 +51,9 @@ class OptOutService {
 	 * @param LoggerInterface $logger Logger.
 	 */
 	public function __construct(
-		private ContainerInterface $container,
 		private IAppConfig $appConfig,
 		private LoggerInterface $logger,
+		private readonly ObjectService $objectService,
 	) {
 	}//end __construct()
 
@@ -288,7 +288,7 @@ class OptOutService {
 	 */
 	private function getObjectService(): object {
 		try {
-			return $this->container->get('OCA\OpenRegister\Service\ObjectService');
+			return $this->objectService;
 		} catch (Throwable $e) {
 			throw new RuntimeException('OpenRegister service is not available.');
 		}

--- a/lib/Service/PointsLedgerService.php
+++ b/lib/Service/PointsLedgerService.php
@@ -33,9 +33,10 @@ use DateTimeZone;
 use OCA\OpenRegister\Service\Aggregation\AggregationQuery;
 use OCA\Pipelinq\AppInfo\Application;
 use OCP\IAppConfig;
-use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
 use RuntimeException;
+use OCA\OpenRegister\Service\ObjectService;
+use OCA\OpenRegister\Service\Aggregation\AggregationRunner;
 
 /**
  * Append-only points ledger.
@@ -57,10 +58,11 @@ class PointsLedgerService {
 	 * @param LoggerInterface $logger The logger.
 	 */
 	public function __construct(
-		private ContainerInterface $container,
 		private IAppConfig $appConfig,
 		private LoyaltyAccountService $accountService,
 		private LoggerInterface $logger,
+		private readonly ObjectService $objectService,
+		private readonly AggregationRunner $aggregationRunner,
 	) {
 	}//end __construct()
 
@@ -539,7 +541,7 @@ class PointsLedgerService {
 	 */
 	private function getObjectService(): object {
 		try {
-			return $this->container->get('OCA\OpenRegister\Service\ObjectService');
+			return $this->objectService;
 		} catch (\Throwable $e) {
 			throw new RuntimeException('OpenRegister ObjectService is unavailable.', 0, $e);
 		}
@@ -558,7 +560,7 @@ class PointsLedgerService {
 	 */
 	private function getAggregationRunner(): object {
 		try {
-			return $this->container->get('OCA\OpenRegister\Service\Aggregation\AggregationRunner');
+			return $this->aggregationRunner;
 		} catch (\Throwable $e) {
 			throw new RuntimeException('OpenRegister aggregation runner is unavailable.', 0, $e);
 		}

--- a/lib/Service/PointsRuleEngine.php
+++ b/lib/Service/PointsRuleEngine.php
@@ -31,9 +31,9 @@ use DateTimeImmutable;
 use DateTimeZone;
 use OCA\Pipelinq\AppInfo\Application;
 use OCP\IAppConfig;
-use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
 use RuntimeException;
+use OCA\OpenRegister\Service\ObjectService;
 
 /**
  * Stateless points-rule evaluator.
@@ -49,9 +49,9 @@ class PointsRuleEngine {
 	 * @param LoggerInterface $logger The logger.
 	 */
 	public function __construct(
-		private ContainerInterface $container,
 		private IAppConfig $appConfig,
 		private LoggerInterface $logger,
+		private readonly ObjectService $objectService,
 	) {
 	}//end __construct()
 
@@ -503,7 +503,7 @@ class PointsRuleEngine {
 	 */
 	private function getObjectService(): object {
 		try {
-			return $this->container->get('OCA\OpenRegister\Service\ObjectService');
+			return $this->objectService;
 		} catch (\Throwable $e) {
 			throw new RuntimeException('OpenRegister ObjectService is unavailable.', 0, $e);
 		}

--- a/lib/Service/Portal/MainRegisterReader.php
+++ b/lib/Service/Portal/MainRegisterReader.php
@@ -30,9 +30,9 @@ namespace OCA\Pipelinq\Service\Portal;
 
 use OCA\Pipelinq\AppInfo\Application;
 use OCP\IAppConfig;
-use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
 use RuntimeException;
+use OCA\OpenRegister\Service\ObjectService;
 
 /**
  * Reads objects from the main pipelinq register.
@@ -49,9 +49,9 @@ class MainRegisterReader {
 	 * @param LoggerInterface $logger The logger.
 	 */
 	public function __construct(
-		private ContainerInterface $container,
 		private IAppConfig $appConfig,
 		private LoggerInterface $logger,
+		private readonly ObjectService $objectService,
 	) {
 	}//end __construct()
 
@@ -227,7 +227,7 @@ class MainRegisterReader {
 	 */
 	private function objectService(): object {
 		try {
-			return $this->container->get('OCA\OpenRegister\Service\ObjectService');
+			return $this->objectService;
 		} catch (\Throwable $e) {
 			throw new RuntimeException('OpenRegister service is not available.');
 		}

--- a/lib/Service/Portal/PortalObjectRepository.php
+++ b/lib/Service/Portal/PortalObjectRepository.php
@@ -31,9 +31,9 @@ namespace OCA\Pipelinq\Service\Portal;
 
 use OCA\Pipelinq\AppInfo\Application;
 use OCP\IAppConfig;
-use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
 use RuntimeException;
+use OCA\OpenRegister\Service\ObjectService;
 
 /**
  * Thin, register-scoped wrapper over the OpenRegister ObjectService for the
@@ -58,9 +58,9 @@ class PortalObjectRepository {
 	 * @param LoggerInterface $logger The logger.
 	 */
 	public function __construct(
-		private ContainerInterface $container,
 		private IAppConfig $appConfig,
 		private LoggerInterface $logger,
+		private readonly ObjectService $objectService,
 	) {
 	}//end __construct()
 
@@ -290,7 +290,7 @@ class PortalObjectRepository {
 	 */
 	private function objectService(): object {
 		try {
-			return $this->container->get('OCA\OpenRegister\Service\ObjectService');
+			return $this->objectService;
 		} catch (\Throwable $e) {
 			throw new RuntimeException('OpenRegister service is not available.');
 		}

--- a/lib/Service/PosBookkeepingService.php
+++ b/lib/Service/PosBookkeepingService.php
@@ -57,9 +57,10 @@ use OCP\AppFramework\OCS\OCSNotFoundException;
 use OCP\EventDispatcher\Event;
 use OCP\IAppConfig;
 use OCP\Mail\IMailer;
-use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
 use RuntimeException;
+use OCA\OpenRegister\Service\WebhookService;
+use OCA\OpenRegister\Service\ObjectService;
 
 /**
  * Service for the POS end-of-day pipeline + registry-mediated journal raise.
@@ -136,11 +137,12 @@ class PosBookkeepingService {
 	 * @param LoggerInterface $logger The logger.
 	 */
 	public function __construct(
-		private ContainerInterface $container,
 		private IAppConfig $appConfig,
 		private IMailer $mailer,
 		private PosAccessPolicy $policy,
 		private LoggerInterface $logger,
+		private readonly WebhookService $webhookService,
+		private readonly ObjectService $objectService,
 	) {
 	}//end __construct()
 
@@ -661,9 +663,8 @@ class PosBookkeepingService {
 	 */
 	private function dispatch(string $eventName, array $payload): bool {
 		try {
-			$webhookService = $this->container->get('OCA\OpenRegister\Service\WebhookService');
 			$event = new Event();
-			$webhookService->dispatchEvent(
+			$this->webhookService->dispatchEvent(
 				_event: $event,
 				eventName: $eventName,
 				payload: $payload
@@ -907,7 +908,7 @@ class PosBookkeepingService {
 	 */
 	private function getObjectService(): object {
 		try {
-			return $this->container->get('OCA\OpenRegister\Service\ObjectService');
+			return $this->objectService;
 		} catch (\Throwable $e) {
 			throw new RuntimeException('OpenRegister service is not available.');
 		}

--- a/lib/Service/PosCustomerLinkService.php
+++ b/lib/Service/PosCustomerLinkService.php
@@ -43,10 +43,10 @@ use OCA\Pipelinq\AppInfo\Application;
 use OCP\AppFramework\OCS\OCSBadRequestException;
 use OCP\AppFramework\OCS\OCSNotFoundException;
 use OCP\IAppConfig;
-use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
 use RuntimeException;
 use Throwable;
+use OCA\OpenRegister\Service\ObjectService;
 
 /**
  * Pipelinq contact lookup, attachment, history and consent sync for the POS.
@@ -108,9 +108,9 @@ class PosCustomerLinkService {
 	 * @param LoggerInterface $logger The logger.
 	 */
 	public function __construct(
-		private ContainerInterface $container,
 		private IAppConfig $appConfig,
 		private LoggerInterface $logger,
+		private readonly ObjectService $objectService,
 	) {
 	}//end __construct()
 
@@ -776,7 +776,7 @@ class PosCustomerLinkService {
 	 */
 	private function getObjectService(): object {
 		try {
-			return $this->container->get('OCA\OpenRegister\Service\ObjectService');
+			return $this->objectService;
 		} catch (Throwable $e) {
 			throw new RuntimeException('OpenRegister ObjectService is unavailable.', 0, $e);
 		}

--- a/lib/Service/PosRefundService.php
+++ b/lib/Service/PosRefundService.php
@@ -34,10 +34,12 @@ use OCP\AppFramework\OCS\OCSForbiddenException;
 use OCP\AppFramework\OCS\OCSNotFoundException;
 use OCP\EventDispatcher\Event;
 use OCP\IAppConfig;
-use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
 use ReflectionClass;
 use RuntimeException;
+use OCA\OpenRegister\Service\WebhookService;
+use OCA\OpenRegister\Service\ObjectService;
+use OCA\OpenRegister\Service\Lifecycle\TransitionEngine;
 
 /**
  * Service for POS refund business operations.
@@ -101,9 +103,11 @@ class PosRefundService {
 	 * @param LoggerInterface $logger The logger.
 	 */
 	public function __construct(
-		private ContainerInterface $container,
 		private IAppConfig $appConfig,
 		private LoggerInterface $logger,
+		private readonly WebhookService $webhookService,
+		private readonly ObjectService $objectService,
+		private readonly TransitionEngine $transitionEngine,
 	) {
 	}//end __construct()
 
@@ -400,9 +404,8 @@ class PosRefundService {
 		$payload = $this->buildRefundPayload(eventId: $eventId, refund: $refund);
 
 		try {
-			$webhookService = $this->container->get('OCA\OpenRegister\Service\WebhookService');
 			$event = new Event();
-			$webhookService->dispatchEvent(_event: $event, eventName: self::EVENT_REFUND_COMPLETED, payload: $payload);
+			$this->webhookService->dispatchEvent(_event: $event, eventName: self::EVENT_REFUND_COMPLETED, payload: $payload);
 			return $eventId;
 		} catch (\Throwable $e) {
 			$this->logger->warning(
@@ -450,9 +453,8 @@ class PosRefundService {
 			);
 
 			try {
-				$webhookService = $this->container->get('OCA\OpenRegister\Service\WebhookService');
 				$event = new Event();
-				$webhookService->dispatchEvent(
+				$this->webhookService->dispatchEvent(
 					_event: $event,
 					eventName: self::EVENT_STOCK_MOVEMENT,
 					payload: $payload
@@ -782,7 +784,7 @@ class PosRefundService {
 	 */
 	private function getObjectService(): object {
 		try {
-			return $this->container->get('OCA\OpenRegister\Service\ObjectService');
+			return $this->objectService;
 		} catch (\Throwable $e) {
 			throw new RuntimeException('OpenRegister service is not available.');
 		}
@@ -799,7 +801,7 @@ class PosRefundService {
 	 */
 	private function getTransitionEngine(): object {
 		try {
-			return $this->container->get('OCA\OpenRegister\Service\Lifecycle\TransitionEngine');
+			return $this->transitionEngine;
 		} catch (\Throwable $e) {
 			throw new RuntimeException('OpenRegister TransitionEngine is not available.');
 		}

--- a/lib/Service/PosRoleService.php
+++ b/lib/Service/PosRoleService.php
@@ -30,9 +30,9 @@ use OCP\AppFramework\OCS\OCSBadRequestException;
 use OCP\AppFramework\OCS\OCSForbiddenException;
 use OCP\AppFramework\OCS\OCSNotFoundException;
 use OCP\IAppConfig;
-use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
 use RuntimeException;
+use OCA\OpenRegister\Service\ObjectService;
 
 /**
  * Service for POS role business operations.
@@ -53,9 +53,9 @@ class PosRoleService {
 	 * @param LoggerInterface $logger The logger.
 	 */
 	public function __construct(
-		private ContainerInterface $container,
 		private IAppConfig $appConfig,
 		private LoggerInterface $logger,
+		private readonly ObjectService $objectService,
 	) {
 	}//end __construct()
 
@@ -288,7 +288,7 @@ class PosRoleService {
 	 */
 	private function getObjectService(): object {
 		try {
-			return $this->container->get('OCA\OpenRegister\Service\ObjectService');
+			return $this->objectService;
 		} catch (\Throwable $e) {
 			throw new RuntimeException('OpenRegister service is not available.');
 		}

--- a/lib/Service/PosStaffReportService.php
+++ b/lib/Service/PosStaffReportService.php
@@ -30,9 +30,10 @@ use OCA\OpenRegister\Service\Aggregation\AggregationQuery;
 use OCA\Pipelinq\AppInfo\Application;
 use OCP\AppFramework\OCS\OCSNotFoundException;
 use OCP\IAppConfig;
-use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
 use RuntimeException;
+use OCA\OpenRegister\Service\ObjectService;
+use OCA\OpenRegister\Service\Aggregation\AggregationRunner;
 
 /**
  * Service that aggregates posTransaction objects per staff member.
@@ -55,10 +56,11 @@ class PosStaffReportService {
 	 * @param LoggerInterface $logger The logger.
 	 */
 	public function __construct(
-		private ContainerInterface $container,
 		private IAppConfig $appConfig,
 		private PosStaffService $posStaffService,
 		private LoggerInterface $logger,
+		private readonly ObjectService $objectService,
+		private readonly AggregationRunner $aggregationRunner,
 	) {
 	}//end __construct()
 
@@ -353,7 +355,7 @@ class PosStaffReportService {
 	 */
 	private function getObjectService(): object {
 		try {
-			return $this->container->get('OCA\OpenRegister\Service\ObjectService');
+			return $this->objectService;
 		} catch (\Throwable $e) {
 			throw new RuntimeException('OpenRegister service is not available.');
 		}
@@ -372,7 +374,7 @@ class PosStaffReportService {
 	 */
 	private function getAggregationRunner(): object {
 		try {
-			return $this->container->get('OCA\OpenRegister\Service\Aggregation\AggregationRunner');
+			return $this->aggregationRunner;
 		} catch (\Throwable $e) {
 			throw new RuntimeException('OpenRegister aggregation runner is not available.');
 		}

--- a/lib/Service/PosStaffService.php
+++ b/lib/Service/PosStaffService.php
@@ -32,9 +32,9 @@ use OCP\AppFramework\OCS\OCSBadRequestException;
 use OCP\AppFramework\OCS\OCSForbiddenException;
 use OCP\AppFramework\OCS\OCSNotFoundException;
 use OCP\IAppConfig;
-use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
 use RuntimeException;
+use OCA\OpenRegister\Service\ObjectService;
 
 /**
  * Service for POS staff business operations.
@@ -86,10 +86,10 @@ class PosStaffService {
 	 * @param LoggerInterface $logger The logger.
 	 */
 	public function __construct(
-		private ContainerInterface $container,
 		private IAppConfig $appConfig,
 		private PosRoleService $posRoleService,
 		private LoggerInterface $logger,
+		private readonly ObjectService $objectService,
 	) {
 	}//end __construct()
 
@@ -648,7 +648,7 @@ class PosStaffService {
 	 */
 	private function getObjectService(): object {
 		try {
-			return $this->container->get('OCA\OpenRegister\Service\ObjectService');
+			return $this->objectService;
 		} catch (\Throwable $e) {
 			throw new RuntimeException('OpenRegister service is not available.');
 		}

--- a/lib/Service/ProductCatalogService.php
+++ b/lib/Service/ProductCatalogService.php
@@ -30,9 +30,9 @@ use OCA\Pipelinq\AppInfo\Application;
 use OCP\AppFramework\OCS\OCSBadRequestException;
 use OCP\AppFramework\OCS\OCSNotFoundException;
 use OCP\IAppConfig;
-use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
 use RuntimeException;
+use OCA\OpenRegister\Service\ObjectService;
 
 /**
  * Service for POS product catalogue resolution.
@@ -76,9 +76,9 @@ class ProductCatalogService {
 	 * @param LoggerInterface $logger The logger.
 	 */
 	public function __construct(
-		private ContainerInterface $container,
 		private IAppConfig $appConfig,
 		private LoggerInterface $logger,
+		private readonly ObjectService $objectService,
 	) {
 	}//end __construct()
 
@@ -541,7 +541,7 @@ class ProductCatalogService {
 	 */
 	private function getObjectService(): object {
 		try {
-			return $this->container->get('OCA\OpenRegister\Service\ObjectService');
+			return $this->objectService;
 		} catch (\Throwable $e) {
 			throw new RuntimeException('OpenRegister service is not available.');
 		}

--- a/lib/Service/ProductVendorProviderService.php
+++ b/lib/Service/ProductVendorProviderService.php
@@ -39,8 +39,8 @@ namespace OCA\Pipelinq\Service;
 
 use OCA\Pipelinq\AppInfo\Application;
 use OCP\IAppConfig;
-use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
+use OCA\OpenRegister\Service\ObjectService;
 
 /**
  * Integration-registry provider for the pipelinq Product and Supplier masters.
@@ -82,8 +82,8 @@ class ProductVendorProviderService {
 	 */
 	public function __construct(
 		private IAppConfig $appConfig,
-		private ContainerInterface $container,
 		private LoggerInterface $logger,
+		private readonly ObjectService $objectService,
 	) {
 	}//end __construct()
 
@@ -233,7 +233,6 @@ class ProductVendorProviderService {
 	 */
 	private function fetchObjectBySchemaAndId(string $schema, string $idField, string $idValue): ?array {
 		try {
-			$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
 			$registerId = $this->appConfig->getValueString(Application::APP_ID, 'register', '');
 			$schemaId = $this->appConfig->getValueString(Application::APP_ID, "{$schema}_schema", '');
 
@@ -245,7 +244,7 @@ class ProductVendorProviderService {
 				return null;
 			}
 
-			$results = $objectService->findAll(
+			$results = $this->objectService->findAll(
 				config: [
 					'filters' => [
 						$idField => $idValue,

--- a/lib/Service/QueueService.php
+++ b/lib/Service/QueueService.php
@@ -34,8 +34,8 @@ namespace OCA\Pipelinq\Service;
 
 use OCA\Pipelinq\AppInfo\Application;
 use OCP\IAppConfig;
-use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
+use OCA\OpenRegister\Service\ObjectService;
 
 /**
  * Service for queue operations such as capacity checks, overflow routing, and item assignment.
@@ -54,10 +54,10 @@ class QueueService {
 	 */
 	public function __construct(
 		private IAppConfig $appConfig,
-		private ContainerInterface $container,
 		private LoggerInterface $logger,
 		private RegisterResolverService $registerResolver,
 		private readonly TicketService $ticketService,
+		private readonly ObjectService $objectService,
 	) {
 	}//end __construct()
 
@@ -337,6 +337,6 @@ class QueueService {
 	 * @return object The object service.
 	 */
 	private function getObjectService(): object {
-		return $this->container->get('OCA\OpenRegister\Service\ObjectService');
+		return $this->objectService;
 	}//end getObjectService()
 }//end class

--- a/lib/Service/QuotaService.php
+++ b/lib/Service/QuotaService.php
@@ -26,9 +26,9 @@ namespace OCA\Pipelinq\Service;
 
 use OCA\Pipelinq\AppInfo\Application;
 use OCP\IAppConfig;
-use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
 use RuntimeException;
+use OCA\OpenRegister\Service\ObjectService;
 
 /**
  * Sales quota lookup and attainment math.
@@ -80,9 +80,9 @@ class QuotaService {
 	 * @param LoggerInterface $logger The logger.
 	 */
 	public function __construct(
-		private ContainerInterface $container,
 		private IAppConfig $appConfig,
 		private LoggerInterface $logger,
+		private readonly ObjectService $objectService,
 	) {
 	}//end __construct()
 
@@ -311,7 +311,7 @@ class QuotaService {
 	 */
 	private function getObjectService(): object {
 		try {
-			return $this->container->get('OCA\OpenRegister\Service\ObjectService');
+			return $this->objectService;
 		} catch (\Throwable $e) {
 			throw new RuntimeException('OpenRegister ObjectService is unavailable.', 0, $e);
 		}

--- a/lib/Service/RapportageService.php
+++ b/lib/Service/RapportageService.php
@@ -32,9 +32,9 @@ namespace OCA\Pipelinq\Service;
 
 use OCA\Pipelinq\AppInfo\Application;
 use OCP\IAppConfig;
-use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
 use RuntimeException;
+use OCA\OpenRegister\Service\ObjectService;
 
 /**
  * Pipeline analytics aggregation service.
@@ -61,9 +61,9 @@ class RapportageService {
 	 * @param LoggerInterface $logger Logger for fallback paths.
 	 */
 	public function __construct(
-		private ContainerInterface $container,
 		private IAppConfig $appConfig,
 		private LoggerInterface $logger,
+		private readonly ObjectService $objectService,
 	) {
 	}//end __construct()
 
@@ -470,7 +470,7 @@ class RapportageService {
 	 */
 	private function getObjectService(): object {
 		try {
-			return $this->container->get('OCA\OpenRegister\Service\ObjectService');
+			return $this->objectService;
 		} catch (\Throwable $e) {
 			throw new RuntimeException('OpenRegister ObjectService is unavailable.', 0, $e);
 		}

--- a/lib/Service/ReceiptDeliveryService.php
+++ b/lib/Service/ReceiptDeliveryService.php
@@ -39,9 +39,9 @@ use OCP\AppFramework\OCS\OCSNotFoundException;
 use OCP\IAppConfig;
 use OCP\IL10N;
 use OCP\Mail\IMailer;
-use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
 use RuntimeException;
+use OCA\OpenRegister\Service\ObjectService;
 
 /**
  * Service for receipt rendering, email delivery and thermal output.
@@ -84,7 +84,6 @@ class ReceiptDeliveryService {
 	 * @param LoggerInterface $logger The logger.
 	 */
 	public function __construct(
-		private ContainerInterface $container,
 		private ReceiptService $receiptService,
 		private InvoiceSequenceService $invoiceSequence,
 		private IMailer $mailer,
@@ -92,6 +91,7 @@ class ReceiptDeliveryService {
 		private PosAccessPolicy $policy,
 		private IL10N $l10n,
 		private LoggerInterface $logger,
+		private readonly ObjectService $objectService,
 	) {
 	}//end __construct()
 
@@ -662,7 +662,7 @@ class ReceiptDeliveryService {
 	 */
 	private function getObjectService(): object {
 		try {
-			return $this->container->get('OCA\OpenRegister\Service\ObjectService');
+			return $this->objectService;
 		} catch (\Throwable $e) {
 			throw new RuntimeException('OpenRegister service is not available.');
 		}

--- a/lib/Service/RedemptionService.php
+++ b/lib/Service/RedemptionService.php
@@ -29,9 +29,9 @@ use DateTimeImmutable;
 use DateTimeZone;
 use OCA\Pipelinq\AppInfo\Application;
 use OCP\IAppConfig;
-use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
 use RuntimeException;
+use OCA\OpenRegister\Service\ObjectService;
 
 /**
  * Redemption lifecycle service.
@@ -53,11 +53,11 @@ class RedemptionService {
 	 * @param LoggerInterface $logger The logger.
 	 */
 	public function __construct(
-		private ContainerInterface $container,
 		private IAppConfig $appConfig,
 		private LoyaltyAccountService $accountService,
 		private PointsLedgerService $ledgerService,
 		private LoggerInterface $logger,
+		private readonly ObjectService $objectService,
 	) {
 	}//end __construct()
 
@@ -645,7 +645,7 @@ class RedemptionService {
 	 */
 	private function getObjectService(): object {
 		try {
-			return $this->container->get('OCA\OpenRegister\Service\ObjectService');
+			return $this->objectService;
 		} catch (\Throwable $e) {
 			throw new RuntimeException('OpenRegister ObjectService is unavailable.', 0, $e);
 		}

--- a/lib/Service/RoutingService.php
+++ b/lib/Service/RoutingService.php
@@ -29,8 +29,8 @@ namespace OCA\Pipelinq\Service;
 
 use OCA\Pipelinq\AppInfo\Application;
 use OCP\IAppConfig;
-use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
+use OCA\OpenRegister\Service\ObjectService;
 
 /**
  * Read-aggregation service that produces a ranked shortlist of agents for an
@@ -71,9 +71,9 @@ class RoutingService {
 	 */
 	public function __construct(
 		private IAppConfig $appConfig,
-		private ContainerInterface $container,
 		private TicketService $ticketService,
 		private LoggerInterface $logger,
+		private readonly ObjectService $objectService,
 	) {
 	}//end __construct()
 
@@ -456,6 +456,6 @@ class RoutingService {
 	 * @return object The object service.
 	 */
 	private function getObjectService(): object {
-		return $this->container->get('OCA\OpenRegister\Service\ObjectService');
+		return $this->objectService;
 	}//end getObjectService()
 }//end class

--- a/lib/Service/ScheduledTaskService.php
+++ b/lib/Service/ScheduledTaskService.php
@@ -37,10 +37,11 @@ use OCP\AppFramework\OCS\OCSForbiddenException;
 use OCP\IAppConfig;
 use OCP\IGroupManager;
 use OCP\IUserSession;
-use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
 use RuntimeException;
 use Throwable;
+use OCA\OpenRegister\Service\LanguageService;
+use OCA\OpenRegister\Service\ObjectService;
 
 /**
  * Service for the Schedules API.
@@ -124,8 +125,9 @@ class ScheduledTaskService {
 		private readonly IUserSession $userSession,
 		private readonly IGroupManager $groupManager,
 		private readonly NotificationService $notificationService,
-		private readonly ContainerInterface $container,
 		private readonly LoggerInterface $logger,
+		private readonly LanguageService $languageService,
+		private readonly ObjectService $objectService,
 	) {
 	}//end __construct()
 
@@ -870,9 +872,8 @@ class ScheduledTaskService {
 		}
 
 		try {
-			$languageService = $this->container->get('OCA\OpenRegister\Service\LanguageService');
 			$lang = $this->parsePreferredLanguage(headerValue: $acceptLanguage);
-			$languageService->setPreferredLanguage(language: $lang);
+			$this->languageService->setPreferredLanguage(language: $lang);
 		} catch (\Throwable $e) {
 			$this->logger->debug(
 				message: 'applyAcceptLanguage: OR LanguageService unavailable.',
@@ -887,7 +888,7 @@ class ScheduledTaskService {
 	 * @return object The OpenRegister ObjectService instance.
 	 */
 	private function getObjectService(): object {
-		return $this->container->get('OCA\OpenRegister\Service\ObjectService');
+		return $this->objectService;
 	}//end getObjectService()
 
 	/**

--- a/lib/Service/SettingsLoadService.php
+++ b/lib/Service/SettingsLoadService.php
@@ -26,7 +26,7 @@ namespace OCA\Pipelinq\Service;
 use OCA\Pipelinq\AppInfo\Application;
 use OCP\App\IAppManager;
 use OCP\IAppConfig;
-use Psr\Container\ContainerInterface;
+use OCA\OpenRegister\Service\ConfigurationService;
 
 /**
  * Service for loading and importing Pipelinq configuration.
@@ -180,9 +180,9 @@ class SettingsLoadService {
 	public function __construct(
 		private IAppConfig $appConfig,
 		private IAppManager $appManager,
-		private ContainerInterface $container,
 		private SettingsMapBuilder $mapBuilder,
 		private ConfigFileLoaderService $fileLoader,
+		private readonly ConfigurationService $configurationService,
 	) {
 	}//end __construct()
 
@@ -345,6 +345,6 @@ class SettingsLoadService {
 	 * @return object The configuration service.
 	 */
 	private function getConfigurationService(): object {
-		return $this->container->get('OCA\OpenRegister\Service\ConfigurationService');
+		return $this->configurationService;
 	}//end getConfigurationService()
 }//end class

--- a/lib/Service/SnapshotGenerationService.php
+++ b/lib/Service/SnapshotGenerationService.php
@@ -29,9 +29,9 @@ use DateTimeImmutable;
 use OCA\Pipelinq\AppInfo\Application;
 use OCP\IAppConfig;
 use OCP\IGroupManager;
-use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
 use RuntimeException;
+use OCA\OpenRegister\Service\ObjectService;
 
 /**
  * Snapshot generation orchestration.
@@ -84,7 +84,6 @@ class SnapshotGenerationService {
 	 * @param LoggerInterface $logger The logger.
 	 */
 	public function __construct(
-		private ContainerInterface $container,
 		private IAppConfig $appConfig,
 		private IGroupManager $groupManager,
 		private ForecastRollupService $rollup,
@@ -93,6 +92,7 @@ class SnapshotGenerationService {
 		private QuotaService $quotaService,
 		private NotificationService $notifier,
 		private LoggerInterface $logger,
+		private readonly ObjectService $objectService,
 	) {
 	}//end __construct()
 
@@ -524,7 +524,7 @@ class SnapshotGenerationService {
 	 */
 	private function getObjectService(): object {
 		try {
-			return $this->container->get('OCA\OpenRegister\Service\ObjectService');
+			return $this->objectService;
 		} catch (\Throwable $e) {
 			throw new RuntimeException('OpenRegister ObjectService is unavailable.', 0, $e);
 		}

--- a/lib/Service/TicketService.php
+++ b/lib/Service/TicketService.php
@@ -48,9 +48,9 @@ use Exception;
 use OCA\OpenRegister\Mcp\Attribute\McpTool;
 use OCA\Pipelinq\AppInfo\Application;
 use OCP\IAppConfig;
-use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
 use RuntimeException;
+use OCA\OpenRegister\Service\ObjectService;
 
 /**
  * Resolver + read/write facade for the unified ticket schema.
@@ -124,9 +124,9 @@ class TicketService {
 	 * @param LoggerInterface $logger The logger.
 	 */
 	public function __construct(
-		private readonly ContainerInterface $container,
 		private readonly IAppConfig $appConfig,
 		private readonly LoggerInterface $logger,
+		private readonly ObjectService $objectService,
 	) {
 	}//end __construct()
 
@@ -141,7 +141,7 @@ class TicketService {
 	 */
 	public function getObjectService(): \OCA\OpenRegister\Service\ObjectService {
 		try {
-			return $this->container->get('OCA\OpenRegister\Service\ObjectService');
+			return $this->objectService;
 		} catch (\Exception $e) {
 			throw new RuntimeException('OpenRegister service is not available.');
 		}

--- a/lib/Service/TierService.php
+++ b/lib/Service/TierService.php
@@ -32,9 +32,9 @@ use OCA\Pipelinq\AppInfo\Application;
 use OCP\EventDispatcher\GenericEvent;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\IAppConfig;
-use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
 use RuntimeException;
+use OCA\OpenRegister\Service\ObjectService;
 
 /**
  * Tier classification and benefits service.
@@ -55,11 +55,11 @@ class TierService {
 	 * @param LoggerInterface $logger The logger.
 	 */
 	public function __construct(
-		private ContainerInterface $container,
 		private IAppConfig $appConfig,
 		private LoyaltyAccountService $accountService,
 		private IEventDispatcher $eventDispatcher,
 		private LoggerInterface $logger,
+		private readonly ObjectService $objectService,
 	) {
 	}//end __construct()
 
@@ -443,7 +443,7 @@ class TierService {
 	 */
 	private function getObjectService(): object {
 		try {
-			return $this->container->get('OCA\OpenRegister\Service\ObjectService');
+			return $this->objectService;
 		} catch (\Throwable $e) {
 			throw new RuntimeException('OpenRegister ObjectService is unavailable.', 0, $e);
 		}

--- a/lib/Service/WalkInQueueService.php
+++ b/lib/Service/WalkInQueueService.php
@@ -33,9 +33,9 @@ use InvalidArgumentException;
 use OCA\Pipelinq\AppInfo\Application;
 use OCA\Pipelinq\Service\Lifecycle\SchemaLifecycleGraph;
 use OCP\IAppConfig;
-use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
 use RuntimeException;
+use OCA\OpenRegister\Service\ObjectService;
 
 /**
  * WalkInQueueService — walk-in ticket lifecycle and queue rebalance.
@@ -122,10 +122,10 @@ class WalkInQueueService {
 	 * @param LoggerInterface $logger The logger.
 	 */
 	public function __construct(
-		private ContainerInterface $container,
 		private IAppConfig $appConfig,
 		private AvailabilityService $availabilityService,
 		private LoggerInterface $logger,
+		private readonly ObjectService $objectService,
 	) {
 	}//end __construct()
 
@@ -979,7 +979,7 @@ class WalkInQueueService {
 	 */
 	private function getObjectService(): object {
 		try {
-			return $this->container->get('OCA\OpenRegister\Service\ObjectService');
+			return $this->objectService;
 		} catch (\Throwable $e) {
 			throw new RuntimeException('OpenRegister ObjectService is unavailable.', 0, $e);
 		}

--- a/lib/Service/WorklistService.php
+++ b/lib/Service/WorklistService.php
@@ -49,9 +49,9 @@ use DateTimeImmutable;
 use OCA\Pipelinq\AppInfo\Application;
 use OCP\IAppConfig;
 use OCP\IL10N;
-use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
 use RuntimeException;
+use OCA\OpenRegister\Service\ObjectService;
 
 /**
  * "My work" worklist aggregation service.
@@ -153,11 +153,11 @@ class WorklistService {
 	 * @param TicketService $ticketService Resolver for the unified ticket schema.
 	 */
 	public function __construct(
-		private ContainerInterface $container,
 		private IAppConfig $appConfig,
 		private IL10N $l10n,
 		private LoggerInterface $logger,
 		private readonly TicketService $ticketService,
+		private readonly ObjectService $objectService,
 	) {
 	}//end __construct()
 
@@ -649,7 +649,7 @@ class WorklistService {
 	 */
 	private function getObjectService(): object {
 		try {
-			return $this->container->get('OCA\OpenRegister\Service\ObjectService');
+			return $this->objectService;
 		} catch (\Throwable $e) {
 			throw new RuntimeException(message: 'OpenRegister ObjectService is unavailable.', code: 0, previous: $e);
 		}


### PR DESCRIPTION
65 file(s) reached OpenRegister through `$this->container->get(...)` on an **unconditional** path — no availability check, no degrading catch. The dependency was announced nowhere: not in the constructor, not in the `use` block, not in any type. It appeared mid-method, as a **string**.

Now constructor-injected and typed. Behaviour is unchanged — same object, same container, resolved at construction instead of at first use. `ContainerInterface` is dropped only where nothing else used it.

**Deliberately not converted**, because they are correct as written (ADR-083 rule 1's exception): lookups behind `isInstalled()`/`getInstalledApps()`, and lookups whose `catch` degrades rather than rethrows. Converting those would make the service unconstructable without OpenRegister and turn a clean message into a 500.

Verified per file: `php -l` clean, and gate-66's lookup check reports **zero** remaining findings for each file changed.

gate-66 for this app: **78 → 8**.