### PR TITLE
chore(deps): move to nc-vue 2.3.0, the line the vue3 prerelease folded into

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "license": "EUPL-1.2",
       "dependencies": {
-        "@conduction/nextcloud-vue": "2.2.0-vue3.21",
+        "@conduction/nextcloud-vue": "2.3.0",
         "@nextcloud/axios": "~2.5.2",
         "@nextcloud/capabilities": "^1.2.1",
         "@nextcloud/dialogs": "^7.4.1",
@@ -1786,9 +1786,9 @@
       }
     },
     "node_modules/@conduction/nextcloud-vue": {
-      "version": "2.2.0-vue3.21",
-      "resolved": "https://registry.npmjs.org/@conduction/nextcloud-vue/-/nextcloud-vue-2.2.0-vue3.21.tgz",
-      "integrity": "sha512-Qj6LLCOLYk3ESUCFxdIWSvLTbj1IvPpYTCboOGgZO0/tLQPCQu2gmqAkEWPTvH0V6x/s4icz4yNhzFDCfZtRFQ==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@conduction/nextcloud-vue/-/nextcloud-vue-2.3.0.tgz",
+      "integrity": "sha512-jwQJ5gqcUfWbKMCXUNO8BteRD4yakLVEAIx6Qd+2+BLZaiENLUFDYVnHxARef9AyZmvBAOxQCVHC3Fk8jgDBOA==",
       "license": "EUPL-1.2",
       "dependencies": {
         "@ckpack/vue-color": "^1.6.0",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "extends @nextcloud/browserslist-config"
   ],
   "dependencies": {
-    "@conduction/nextcloud-vue": "2.2.0-vue3.21",
+    "@conduction/nextcloud-vue": "2.3.0",
     "@nextcloud/axios": "~2.5.2",
     "@nextcloud/capabilities": "^1.2.1",
     "@nextcloud/dialogs": "^7.4.1",


### PR DESCRIPTION
## What

Moves pipelinq off the frozen prerelease line onto the mainline release: **`2.2.0-vue3.21` → `2.3.0`**.

## Why now

The `vue3` prerelease line has been **folded into 2.3 and continues there**. `feat/vue-3` is gone and `.releaserc` no longer maps the channel, so `2.2.0-vue3.21` — published yesterday — is the **last** release that line can ever have. `latest` is now `2.3.0`, a genuine Vue 3 build (`vue: ^3.5.0`, `@nextcloud/vue: ^9.0.0`).

pipelinq goes first because it is the only app already on `.21` and it carries the BSN contract spec, which is exactly the test that would catch a shape change.

## Checked before installing, not after

Everything this app imports from the library still exists in 2.3.0:

- `validateBsn` / `maskBsn` / `BSN_ERROR_*` — present, and the result still uses `isFormallyValid`
- `dist/esm/utils/validators/bsn.js` — the **standalone module path** `bsnValidation.spec.js` imports so the offline suite stays dependency-free
- `CnDetailCard` — still exported

## Verification

- **vitest: 6 files, 45 tests, all pass** — including the BSN contract spec that pins the exported symbols, the field names `BrpContactPanel` reads, and that the two error codes stay distinguishable.
- **eslint exit 0** on the BSN consumer and spec.
- **Production webpack build compiles**, with the same 6 pre-existing warnings as on `2.2.0-vue3.21` — no new ones.
- Pin held **exact** (`2.3.0`, not `^2.3.0`).

## The other 14 apps

`openregister`, `opencatalogi`, `openconnector`, `docudesk`, `softwarecatalog`, `larpingapp`, `procest`, `shillinq`, `scholiq`, `portaliq`, `decidesk`, `openbuild`, `doriath`, `hermiq` are all still on **`2.2.0-vue3.16`** — five releases behind the last prerelease and now on a dead line. This PR is the canary for that migration, not the whole of it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
