### PR TITLE
chore(deps): move @conduction/nextcloud-vue to ^2.3.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "license": "EUPL-1.2",
       "dependencies": {
-        "@conduction/nextcloud-vue": "2.3.0",
+        "@conduction/nextcloud-vue": "^2.3.0",
         "@nextcloud/axios": "~2.5.2",
         "@nextcloud/capabilities": "^1.2.1",
         "@nextcloud/dialogs": "^7.4.1",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "extends @nextcloud/browserslist-config"
   ],
   "dependencies": {
-    "@conduction/nextcloud-vue": "2.3.0",
+    "@conduction/nextcloud-vue": "^2.3.0",
     "@nextcloud/axios": "~2.5.2",
     "@nextcloud/capabilities": "^1.2.1",
     "@nextcloud/dialogs": "^7.4.1",


### PR DESCRIPTION
## Why now

`@conduction/nextcloud-vue@2.3.0` is released, and the **`vue3` and `latest` dist-tags have converged on it** — the separate `2.2.0-vue3.N` line is over.

The exact `2.2.0-vue3.16` pin left this app five releases behind and made a caret range impossible to express, because the `-vue3.N` prereleases don't order the way callers expect.

A caret also unblocks local library development: the sibling-checkout guard validates `../nextcloud-vue` against this app's declared range, so an exact pin refused **every** sibling that wasn't byte-identical — including newer ones.

## Verified, not assumed

- `npm install` resolves **2.3.0**
- `npm ci` reproduces it — run explicitly, because `npm install` does **not** re-run postinstall hooks for an already-present version, which is exactly how `vue-demi` ends up on the wrong shim
- production build: **exit 0, 0 errors**
- the app **renders in the browser with cache disabled** — a clean webpack build is precisely what the recent `vue-router` breakage produced, so the build alone isn't evidence

**All 17 apps in this sweep render.** Lockfile diff is `+5/-5` — the version lines and nothing else.

## Note for reviewers

2.3.0 declares the **same `peerDependencies`** as 2.2.0-vue3.16 — `dexie`, `marked`, `dompurify`, `gridstack`, `@vueuse/core`, `@nextcloud/capabilities` and friends. Those app-level declarations are **required by the library**, not redundant, and must not be pruned as "unused dependencies". (I initially mis-flagged 70 such declarations as dead before checking the peer list.)

## Not included

**nldesign is excluded.** It's the only app where nc-vue is a build-time icon source (`devDependencies`) rather than a runtime dep, and `npm install` there pruned its `@gouvfr/dsfr` optional dependency, gutting the lockfile by 2,312 lines. Reverted and left for separate handling, since a bump there changes the generated icon set.
