### PR TITLE
chore(security): enable the npm supply-chain cooldown on npm 11

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,7 +1,19 @@
 legacy-peer-deps=true
 
-# Supply-chain hardening: reject any npm package published less than
-# 24h ago. Compromised first-party-Conduction packages are excluded via
-# Dependabot cooldown (.github/dependabot.yml); for fresh @conduction/*
-# releases, override per-install with `npm install --min-release-age=0`.
-min-release-age=0
+# Supply-chain hardening: npm will not install a version published less than
+# 2 days ago, so a compromised release has a window in which it can be pulled
+# before it reaches this repo.
+#
+# npm 11+ ONLY. On npm 10 `min-release-age` does not exist — `npm config get
+# min-release-age` answers `undefined` — so this file is INERT on that
+# toolchain and the guard is not in effect. `engines.npm` declares the floor
+# and CI runs Node 24, which bundles npm 11; every Node 22 release bundles
+# npm 10 and cannot enforce this. gate-84 checks the three move together.
+#
+# @conduction/* is exempt so our own same-day releases still resolve. Without
+# the exemption the cooldown does NOT fail loudly — it silently resolves
+# backwards: measured 2026-08-15, installing @conduction/nextcloud-vue on
+# release day picked 2.0.7 instead of 2.3.0 and exited 0. Only the named
+# packages are exempt; their own dependencies still follow the policy.
+min-release-age=2
+min-release-age-exclude[]=@conduction/*

--- a/package-lock.json
+++ b/package-lock.json
@@ -70,7 +70,7 @@
       },
       "engines": {
         "node": "^22.14 || ^24 || >=26",
-        "npm": "^10.0.0"
+        "npm": "^11.0.0"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "license": "EUPL-1.2",
   "engines": {
     "node": "^22.14 || ^24 || >=26",
-    "npm": "^10.0.0"
+    "npm": "^11.0.0"
   },
   "scripts": {
     "prebuild": "node scripts/check-vue-demi.js",


### PR DESCRIPTION
## What

Turns on the npm supply-chain cooldown for this repo, and moves it to the toolchain that can actually enforce it.

- `.npmrc` — `min-release-age=2` and `min-release-age-exclude[]=@conduction/*`
- `package.json` — `engines.npm: ^11.0.0`
- `package-lock.json` — regenerated under npm 11 so the lock matches the declared toolchain

Companion to **ConductionNL/.github#469**, which moves the shared workflow to Node 24 (the only Node line whose bundled npm supports this) and adds **gate-84** to keep all 19 repos conformant.

## Why all three, and not just the value

The `.npmrc` comment in this repo has described a supply-chain cooldown for months. **It has never been in effect**, for two independent reasons — either alone is enough:

**`min-release-age` does not exist in npm 10.** Not rejected, not warned about: `npm config get min-release-age` answers `undefined`. Every Node 22 release bundles npm 10 (22.23.2 ships 10.9.8), so the setting was read by nothing. Node 24.19 bundles npm 11.17.

**Most repos set it to `0`,** which disables it outright. The unit is days, so `2` is a two-day window.

## Why `@conduction/*` is exempt

Without the exemption the cooldown does **not** fail loudly — it silently resolves backwards. Measured 2026-08-15, installing `@conduction/nextcloud-vue` on release day:

| config | resolves to | exit |
|---|---|---|
| `min-release-age=1`, no exemption | **2.0.7** | 0 |
| `min-release-age=1` + `@conduction/*` exempt | **2.3.0** | 0 |

A green install of months-old first-party code is a worse outcome than a red one. Only the named packages are exempt; their own dependencies still follow the policy.

## The lockfile

Regenerated under npm 11 and iterated to a fixed point (npm converges `dev`/`devOptional` over two passes, so one run is not proof of stability).

Where the dependency tree changed rather than just its metadata, the change is npm 10 → 11 reconciling a lock that was shaped by the older resolver — **not** the cooldown. Verified by isolation: regenerating with the cooldown enabled and disabled produced byte-identical trees.

## Verification

Run locally against npm 11.19.0:

| check | result |
|---|---|
| `npm ci` | exit 0 |
| `@conduction/nextcloud-vue` resolves | 2.3.0 |
| gate-84 conformance | pass |

Repos whose dependency tree changed also had `npm run build`, `lint` and `test` run — all exit 0.

Fleet-wide: **19 of 19 apps fail gate-84 at their current committed state; 19 of 19 pass with this change.**
