### PR TITLE
fix(supply-chain): make the npm cooldown actually work (gate-84)

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,7 +1,17 @@
 legacy-peer-deps=true
 
-# Supply-chain hardening: reject any npm package published less than
-# 24h ago. Compromised first-party-Conduction packages are excluded via
-# Dependabot cooldown (.github/dependabot.yml); for fresh @conduction/*
-# releases, override per-install with `npm install --min-release-age=0`.
-min-release-age=0
+# Supply-chain hardening (gate-84). THREE settings that only work together;
+# any one alone is a configuration that looks like protection and is not:
+#
+#   1. min-release-age            — the cooldown window itself
+#   2. min-release-age-exclude[]  — first-party releases must NOT be delayed
+#   3. package.json engines.npm   — npm 10 does NOT implement min-release-age
+#
+# `min-release-age=0` (the previous value here) is a cooldown of ZERO: fully
+# inert while looking configured.
+#
+# Without the exclusion the cooldown does not fail loudly — it silently
+# resolves BACKWARDS. Installing @conduction/nextcloud-vue on release day
+# under a cooldown with no exclusion resolves an old version and exits 0.
+min-release-age=2
+min-release-age-exclude[]=@conduction/*

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "license": "EUPL-1.2",
   "engines": {
     "node": "^22.14 || ^24 || >=26",
-    "npm": "^10.0.0"
+    "npm": "^11.0.0"
   },
   "scripts": {
     "prebuild": "node scripts/check-vue-demi.js",


### PR DESCRIPTION
This repo carried a supply-chain "cooldown" that was **inert**.

## What was wrong

| setting | was | required |
|---|---|---|
| `.npmrc` `min-release-age` | see commit | `>= 2` (the unit is DAYS) |
| `.npmrc` `min-release-age-exclude[]` | **absent** | `@conduction/*` |
| `package.json` `engines.npm` | `^10.0.0` | npm **11+** |

Any one alone is a configuration that *looks like* protection and is not. **The option does not exist in npm 10** — `npm config get min-release-age` answers `undefined` — so the window was read by **nothing**.

Nine repos in the fleet had `min-release-age=0`: a cooldown of **zero**, fully inert while looking configured.

## The exclusion is the dangerous omission

Without it the cooldown does not fail loudly, it **silently resolves BACKWARDS**. Installing `@conduction/nextcloud-vue` on release day under a cooldown with no exclusion resolves an old version and **exits 0**.

That is a live risk to the fleet's `^2.3.0` migration: a green install of months-old first-party code is indistinguishable from a correct one.

## Verification

Run with the gate's **own** script against this tree:

| tree | result | exit |
|---|---|---|
| pristine `development` | `checked 3 setting(s): 3 failure(s)` | 1 |
| this branch | `checked 3 setting(s): 0 failure(s)` | 0 |

`checked 3` on **both** sides, so this is not a zero-file vacuous pass.

## Why this cannot break installs

- `npm ci` resolves from the **lockfile**, so the cooldown does not affect CI installs.
- No `.npmrc` in this fleet sets `engine-strict`, so the `engines.npm` bump produces at most an `EBADENGINE` warning.
- The pattern matches **opencatalogi, nldesign and softwarecatalog**, which already ship exactly this today.
- Piloted on [decidesk#502](https://github.com/ConductionNL/decidesk/pull/502): **Frontend Build, Frontend Tests and Security (npm) all pass, zero failures.**

## Fleet context

15 of 18 apps failed gate-84 with 3 failures each. This is one of 15 PRs closing it.
