### PR TITLE
docs(orphan-auth): point the three gate-6 deferrals at the issue that tracks them (gate-6 stays red — by design)

### DIFF
--- a/lib/Service/External/Berichtenbox/LogBerichtenboxAdapter.php
+++ b/lib/Service/External/Berichtenbox/LogBerichtenboxAdapter.php
@@ -18,6 +18,19 @@
  * Mirrors the wave-3 `LogIb47Adapter` / `LogCbsBestandenAdapter`
  * dormant-default pattern from the fleet's external surface.
  *
+ * ⚠️ THE SEAM IS UNCONSUMED, AND THE CAPABILITY IT MODELS IS ALREADY
+ * LIVE ELSEWHERE. `BerichtenboxAdapterInterface` is DI-bound in
+ * `Application::register()` but injected into no service or controller,
+ * so `checkMailbox()` has zero callers and hydra gate-6 (orphan-auth)
+ * reports it. Do NOT close that finding by wiring
+ * `MailboxResolver::resolve()` to this adapter: that path already calls
+ * `LogiusConnector::checkMailboxExists()`, which performs a REAL
+ * mailbox check, so routing it here would replace a live check with a
+ * `MAILBOX_DEFERRED` stub — a regression wearing the costume of a fix.
+ * Consume-or-remove is a product decision, tracked in pipelinq#764
+ * ("Decision needed: consume-or-remove the 7 dormant capabilities behind
+ * gate-6 and gate-57").
+ *
  * Per AVG / WBP article 9, BSN values are NEVER passed to the
  * structured logger. Outbound `recipientBsn` + `dispatchMessage`'s
  * BSN payload field + `checkMailbox`'s `bsn` argument are all

--- a/lib/Service/Portal/PortalTenantService.php
+++ b/lib/Service/Portal/PortalTenantService.php
@@ -280,8 +280,10 @@ class PortalTenantService {
 	 * feature on a live schema field — but it must not be mistaken for
 	 * enforcement, and the fix for the gate-6 finding it raises is to BUILD
 	 * the flow and call this from it, never to invent an account-creation
-	 * endpoint just to give the predicate a caller. See pipelinq#401 and the
-	 * archived `2026-07-16-orphan-auth-remediation` change.
+	 * endpoint just to give the predicate a caller. Tracked in pipelinq#764
+	 * ("Decision needed: consume-or-remove the 7 dormant capabilities behind
+	 * gate-6 and gate-57"), which carries the full per-finding evidence; see
+	 * also the archived `2026-07-16-orphan-auth-remediation` change.
 	 *
 	 * @param string $tenantId The tenant id.
 	 *

--- a/lib/Service/Zgw/ZgwCoexistenceValidator.php
+++ b/lib/Service/Zgw/ZgwCoexistenceValidator.php
@@ -31,7 +31,9 @@
  * the natural hook at that point is OpenRegister's pre-persist, stoppable
  * `ObjectCreatingEvent`/`ObjectUpdatingEvent` on the endpoint schemas, since
  * ZGW endpoints are OpenRegister-object-managed (ADR-022) rather than
- * written through a pipelinq route. Tracked in pipelinq#401.
+ * written through a pipelinq route. Tracked in pipelinq#764 ("Decision
+ * needed: consume-or-remove the 7 dormant capabilities behind gate-6 and
+ * gate-57"), which carries the full per-finding evidence.
  *
  * The check is otherwise intentionally tolerant: a missing StUF schema
  * reduces to "ZGW only", and a ZgwEndpoint with `actief=false` or
@@ -51,7 +53,7 @@
  *
  * @link https://pipelinq.nl
  *
- * @spec openspec/changes/zgw-api-bridge/specs/zgw-api-bridge/spec.md#req-zgw-008
+ * @spec openspec/changes/archive/2026-06-14-zgw-api-bridge/specs/zgw-api-bridge/spec.md#req-zgw-008
  */
 
 declare(strict_types=1);


### PR DESCRIPTION
## ⚠️ This PR does NOT turn gate-6 green, and it deliberately does not try

**gate-6 (orphan-auth) stays RED at 3 findings.** Every remedy available to a code change here is either impossible or a regression, so rather than manufacture a green I am recording the reasoning in the code and leaving the gate red. A red gate is worth more than a green one that tests nothing.

What this PR *does* fix is that the deferral was **untracked while reading as tracked**.

## Before / after — the gate's own script

Run from the repo root with the gate's own helper, on the same file set `run-hydra-gates.sh` builds (`_enum_tracked '\.php$' lib/Service lib/Controller`, full-repo mode):

```
python3 <hydra-gates>/scripts/lib/check_orphan_auth.py "${FILES[@]}"
```

| | findings | **files measured** |
|---|---|---|
| base (`1df56acd3` = `origin/development`) | **3** | **326** |
| this branch | **3** | **326** |

The count is unchanged **on purpose** — this is comments only, 21 insertions across 3 files, no behaviour change. ⚠️ The helper always exits 0 by design; the count comes from its stdout, never its exit byte, so "exit 0" here is not a pass signal.

## The per-finding judgement

| # | finding | verdict | why |
|---|---|---|---|
| 1 | `LogBerichtenboxAdapter::checkMailbox` | **neither wire nor delete — product decision** | The `BerichtenboxAdapterInterface` seam is DI-bound in `Application::register()` and injected **nowhere** (grep widened to `*.md`/`*.json`/`*.xml`: only the DI binding and archived triage docs). But **wiring it is a regression**: `MailboxResolver::resolve()` already calls `LogiusConnector::checkMailboxExists()`, a real HTTP mailbox check, so routing the resolver here would swap a live check for a `MAILBOX_DEFERRED` stub. |
| 2 | `PortalTenantService::isSelfSignupAllowed` | **leave — the flow does not exist** | Re-verified independently: `PortalAccountService` exposes only `requestClosure()` and `close()`, and `appinfo/routes.php` has no signup route. Nothing creates a `portalAccount`. Wiring would mean **inventing an account-creation endpoint to give a predicate a caller** — widening the auth surface to satisfy a gate. |
| 3 | `ZgwCoexistenceValidator::validateWritePath` | **leave — wiring it would be an invisible pass** | Its own docblock already says so: the `stufEndpoint` schema moved to procest, so `activeStufWriters()` can only return `[]` and the conflict branch is **unreachable**. Wiring it installs "a check that is structurally incapable of rejecting anything". |

Deleting was considered as the safer default for #1 and rejected on evidence. This exact family in this repo has **already produced two wrong delete verdicts**: pipelinq#764 records the author's own retractions on `CalendarSyncService` (kept alive by a live capability spec that a too-narrow grep had missed) and on `WalkInQueueService::createTicket` (which turned out to be the only thing that can create a ticket). A Logius/BBK 1.7 surface is also a **national-standard** surface, which ADR-085 routes to openconnector — so the seam's destination is a migration, not a delete-in-place.

## What actually changes

1. **Two docblocks cited `pipelinq#401` as the tracker. #401 is "Implement: Proposal: crm-workflow-automation"** — an unrelated issue. A deferral pointing at the wrong tracker is untracked debt wearing the costume of tracked debt, and it nearly sent this review down the wrong path. Repointed to **pipelinq#764**, which carries the per-finding evidence.
2. `LogBerichtenboxAdapter` carried **no** tracker reference at all, and no warning against the obvious-but-wrong fix. Both added.
3. `ZgwCoexistenceValidator`'s `@spec` pointed at `openspec/changes/zgw-api-bridge/...`, which **does not exist** — that change was archived to `openspec/changes/archive/2026-06-14-zgw-api-bridge/`. Repointed to the path that does exist; the `#req-zgw-008` anchor resolves there (`spec.md:147`).

## Verification

- `php -l` clean on all three files.
- `phpcs --standard=phpcs.xml` on the three changed files: **0 errors** (only pre-existing missing-`@spec` warnings).
  ⚠️ This required copying `conduction/hydra-gates` into the local `vendor/` first — pipelinq's installed vendor **lacks** it, and without it phpcs prints `Referenced sniff … does not exist / No sniffs were registered`, which is an **error, not a clean run**. Anyone verifying locally will hit the same trap.
- Comments only, so no test behaviour can change and no test was touched.

## Base parity

Branched from and re-checked against `origin/development` @ `1df56acd3` — **0 commits behind** at both branch time and push. The fleet baseline run for pipelinq is **31928955543** (sha `f44765e6`), whose non-success jobs are `Hydra Gates` and `Quality Report`. This PR adds no failure the base does not already have, and removes none.

⚠️ **Heads-up**: workstream R1 is active in this repo on the `refactor/adr-084-type-hint-the-contract` fallout (missing `tests/Stubs/Contract/*`). This PR touches only three docblocks under `lib/Service/**` and should not collide.
