### PR TITLE
perf(listeners): move post-event listener work off the write path (gate-61 / ADR-078)

### DIFF
--- a/lib/BackgroundJob/DeferredObjectListenerJob.php
+++ b/lib/BackgroundJob/DeferredObjectListenerJob.php
@@ -1,0 +1,193 @@
+<?php
+
+/**
+ * Pipelinq DeferredObjectListenerJob.
+ *
+ * @category BackgroundJob
+ * @package  OCA\Pipelinq\BackgroundJob
+ *
+ * @author    Conduction <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git_id>
+ *
+ * @link https://github.com/ConductionNL/pipelinq
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Pipelinq\BackgroundJob;
+
+use OCA\OpenRegister\BackgroundJob\ActorForwardedJob;
+use OCA\OpenRegister\Service\Deferral\DeferredListenerContext;
+use OCA\OpenRegister\Service\OrganisationService;
+use OCA\Pipelinq\Listener\DealCreatedListener;
+use OCA\Pipelinq\Listener\DealUpdatedListener;
+use OCA\Pipelinq\Listener\DeferredObjectWork;
+use OCA\Pipelinq\Listener\DeferredWorkGuard;
+use OCA\Pipelinq\Listener\ExpenseApprovalListener;
+use OCA\Pipelinq\Listener\ProjectCreationListener;
+use OCA\Pipelinq\Listener\ProjectPhaseStatusListener;
+use OCA\Pipelinq\Listener\SlaObjectCreatedListener;
+use OCA\Pipelinq\Listener\SlaObjectUpdatedListener;
+use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\IUserManager;
+use OCP\IUserSession;
+use Psr\Container\ContainerInterface;
+use Psr\Log\LoggerInterface;
+use Throwable;
+
+/**
+ * Runs the work pipelinq's post-event listeners used to do inside the write.
+ *
+ * ADR-078: `Object*edEvent` listeners cannot influence the write they observe,
+ * so their work is asynchronous by default. Each converted listener implements
+ * {@see DeferredObjectWork} and hands an entry to OpenRegister's
+ * `ListenerDeferralService`, which captures the acting user and enqueues this
+ * job. The job re-establishes that user (via {@see ActorForwardedJob}) and
+ * calls the listener back.
+ *
+ * ONE JOB FOR ALL SEVEN LISTENERS, NOT SEVEN JOBS. The deferral service buffers
+ * per job class, so a single class lets one request's worth of listener work
+ * coalesce into one job row instead of seven; and the re-entrancy guard below
+ * has to be applied identically to every one of them, which is easier to keep
+ * true in one place.
+ *
+ * THE HANDLER MAP IS AN ALLOW-LIST, NOT A LOOKUP. The handler key arrives from
+ * a persisted job row, so a class name taken from it and resolved through the
+ * container would be an instantiate-anything primitive. Only the keys below
+ * resolve; anything else is logged and dropped.
+ *
+ * It extends `ActorForwardedJob`, which is a `QueuedJob`: it runs once and is
+ * removed from the job list. It never re-queues itself, so it cannot starve the
+ * cron queue behind it.
+ *
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects) The class exists precisely to
+ *  fan one job out to the app's converted listeners; naming them is the point.
+ */
+class DeferredObjectListenerJob extends ActorForwardedJob {
+
+	/**
+	 * Handler key -> listener class. An allow-list; see the class docblock.
+	 *
+	 * @var array<string, class-string<DeferredObjectWork>>
+	 */
+	private const HANDLERS = [
+		DealCreatedListener::HANDLER_KEY => DealCreatedListener::class,
+		DealUpdatedListener::HANDLER_KEY => DealUpdatedListener::class,
+		ProjectCreationListener::HANDLER_KEY => ProjectCreationListener::class,
+		ProjectPhaseStatusListener::HANDLER_KEY => ProjectPhaseStatusListener::class,
+		ExpenseApprovalListener::HANDLER_KEY => ExpenseApprovalListener::class,
+		SlaObjectCreatedListener::HANDLER_KEY => SlaObjectCreatedListener::class,
+		SlaObjectUpdatedListener::HANDLER_KEY => SlaObjectUpdatedListener::class,
+	];
+
+	/**
+	 * Constructor.
+	 *
+	 * @param ITimeFactory $time Time factory for the parent job class.
+	 * @param IUserSession $userSession Session to impersonate on / restore.
+	 * @param IUserManager $userManager Resolver for the captured user id.
+	 * @param OrganisationService $organisation Active-organisation resolver.
+	 * @param LoggerInterface $logger PSR logger.
+	 * @param ContainerInterface $container DI container the listeners resolve from.
+	 *
+	 * @return void
+	 */
+	public function __construct(
+		ITimeFactory $time,
+		IUserSession $userSession,
+		IUserManager $userManager,
+		OrganisationService $organisation,
+		LoggerInterface $logger,
+		private readonly ContainerInterface $container,
+	) {
+		parent::__construct(
+			time: $time,
+			userSession: $userSession,
+			userManager: $userManager,
+			organisation: $organisation,
+			logger: $logger
+		);
+	}//end __construct()
+
+	/**
+	 * Run every entry's listener work under the re-established actor.
+	 *
+	 * @param DeferredListenerContext $context The captured dispatch-time context.
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/specs/event-listener-work-placement/spec.md#requirement-deferred-post-event-work-runs-in-one-actor-forwarded-job
+	 */
+	protected function runDeferred(DeferredListenerContext $context): void {
+		foreach ($context->getEntries() as $entry) {
+			if (is_array($entry) === false) {
+				continue;
+			}
+
+			$this->runEntry(entry: $entry);
+		}
+	}//end runDeferred()
+
+	/**
+	 * Resolve and run one entry's listener, guarded against re-entry.
+	 *
+	 * @param array<string, mixed> $entry The entry captured at dispatch time.
+	 *
+	 * @return void
+	 */
+	private function runEntry(array $entry): void {
+		$handler = ($entry['handler'] ?? '');
+		if (is_string($handler) === false || isset(self::HANDLERS[$handler]) === false) {
+			$this->logger->warning(
+				'Pipelinq: deferred listener entry names no known handler',
+				['handler' => $handler]
+			);
+			return;
+		}
+
+		try {
+			$listener = $this->container->get(self::HANDLERS[$handler]);
+		} catch (Throwable $e) {
+			$this->logger->warning(
+				'Pipelinq: deferred listener could not be resolved',
+				['handler' => $handler, 'exception' => $e->getMessage()]
+			);
+			return;
+		}
+
+		if (($listener instanceof DeferredObjectWork) === false) {
+			$this->logger->warning(
+				'Pipelinq: deferred listener does not implement DeferredObjectWork',
+				['handler' => $handler]
+			);
+			return;
+		}
+
+		$key = DeferredWorkGuard::key(handler: $handler, uuid: (string)($entry['uuid'] ?? ''));
+		if (DeferredWorkGuard::enter(key: $key) === false) {
+			// Already on this stack — the write we are about to make has
+			// already re-entered us once. Doing it again is the loop.
+			return;
+		}
+
+		try {
+			$listener->runDeferredWork($entry);
+		} catch (Throwable $e) {
+			// Same blast radius as the inline listeners had: a failure here is
+			// logged and dropped, never rethrown into cron.
+			$this->logger->warning(
+				'Pipelinq: deferred listener work failed',
+				[
+					'handler' => $handler,
+					'uuid' => ($entry['uuid'] ?? ''),
+					'exception' => $e->getMessage(),
+				]
+			);
+		} finally {
+			DeferredWorkGuard::leave(key: $key);
+		}
+	}//end runEntry()
+}//end class

--- a/lib/Listener/DealCreatedListener.php
+++ b/lib/Listener/DealCreatedListener.php
@@ -24,7 +24,9 @@ declare(strict_types=1);
 namespace OCA\Pipelinq\Listener;
 
 use OCA\OpenRegister\Event\ObjectCreatedEvent;
+use OCA\OpenRegister\Service\Deferral\ListenerDeferralService;
 use OCA\Pipelinq\AppInfo\Application;
+use OCA\Pipelinq\BackgroundJob\DeferredObjectListenerJob;
 use OCA\Pipelinq\Service\ForecastDealService;
 use OCA\Pipelinq\Service\SchemaMapService;
 use OCP\EventDispatcher\Event;
@@ -49,9 +51,24 @@ use Psr\Log\LoggerInterface;
  * the schema-default application. ForecastDealService reads the default value from
  * the schema annotation, so the source of truth is the schema, not this listener.
  *
+ * ADR-078: `ObjectCreatedEvent` is a POST event. The deal is already written and
+ * nothing this listener does can change that, so the backstop re-save no longer
+ * runs inside the create request — it is deferred to
+ * {@see DeferredObjectListenerJob} under the acting user. The deferred pass
+ * re-reads the deal, so a category applied by any other path in the meantime is
+ * simply left alone.
+ *
  * @implements IEventListener<Event>
  */
-class DealCreatedListener implements IEventListener {
+class DealCreatedListener implements IEventListener, DeferredObjectWork {
+
+	/**
+	 * Identifies this listener's entries in the deferral job.
+	 *
+	 * @var string
+	 */
+	public const HANDLER_KEY = 'deal-created';
+
 	/**
 	 * Constructor.
 	 *
@@ -59,6 +76,7 @@ class DealCreatedListener implements IEventListener {
 	 * @param ForecastDealService $dealService The forecast deal lifecycle service.
 	 * @param ContainerInterface $container The DI container (OpenRegister ObjectService lookup).
 	 * @param IAppConfig $appConfig The app configuration.
+	 * @param ListenerDeferralService $deferral The actor-forwarding deferral service.
 	 * @param LoggerInterface $logger The logger.
 	 */
 	public function __construct(
@@ -66,12 +84,15 @@ class DealCreatedListener implements IEventListener {
 		private ForecastDealService $dealService,
 		private ContainerInterface $container,
 		private IAppConfig $appConfig,
+		private ListenerDeferralService $deferral,
 		private LoggerInterface $logger,
 	) {
 	}//end __construct()
 
 	/**
 	 * Handle an object-created event.
+	 *
+	 * Does no work: filters to the lead schema and queues the backstop.
 	 *
 	 * @param Event $event The dispatched event.
 	 *
@@ -89,14 +110,54 @@ class DealCreatedListener implements IEventListener {
 			return;
 		}
 
-		$data = $entity->getObject();
+		$uuid = (string)$entity->getUuid();
+		if ($uuid === '') {
+			return;
+		}
+
+		// Our own deferred re-save re-enters this listener. Deferring again
+		// would enqueue another job whose write re-enters again — a cron loop.
+		if (DeferredWorkGuard::isRunning(key: DeferredWorkGuard::key(handler: self::HANDLER_KEY, uuid: $uuid)) === true) {
+			return;
+		}
+
+		$this->deferral->defer(
+			jobClass: DeferredObjectListenerJob::class,
+			entry: [
+				'handler' => self::HANDLER_KEY,
+				'uuid' => $uuid,
+			],
+			dedupeKey: self::HANDLER_KEY . '|' . $uuid
+		);
+	}//end handle()
+
+	/**
+	 * Apply the forecast-category backstop against the deal's CURRENT state.
+	 *
+	 * Re-reads the deal rather than trusting the dispatch-time payload:
+	 * delivery is at-least-once and the deal may have been edited or removed
+	 * since (ADR-078 Rule 7).
+	 *
+	 * @param array<string, mixed> $entry The entry captured at dispatch time.
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/changes/forecast-roll-up-and-categories/specs.md#REQ-FRC-001-01
+	 */
+	public function runDeferredWork(array $entry): void {
+		$uuid = (string)($entry['uuid'] ?? '');
+		$data = $this->fetch(uuid: $uuid);
+		if ($data === null) {
+			return;
+		}
+
 		$mutated = $this->dealService->applyDefaultCategory($data);
 		if ($mutated === null) {
 			return;
 		}
 
-		$this->persist(uuid: (string)$entity->getUuid(), data: $mutated);
-	}//end handle()
+		$this->persist(uuid: $uuid, data: $mutated);
+	}//end runDeferredWork()
 
 	/**
 	 * Whether the entity belongs to the lead (deal) schema.
@@ -109,6 +170,37 @@ class DealCreatedListener implements IEventListener {
 		$entityType = $this->schemaMapService->resolveEntityType(schemaId: $entity->getSchema());
 		return $entityType === 'lead';
 	}//end isLead()
+
+	/**
+	 * Read the deal's current data.
+	 *
+	 * @param string $uuid The deal UUID.
+	 *
+	 * @return array<string, mixed>|null The deal data, or null when it is gone.
+	 */
+	private function fetch(string $uuid): ?array {
+		$register = $this->appConfig->getValueString(Application::APP_ID, 'register', '');
+		$schema = $this->appConfig->getValueString(Application::APP_ID, 'lead_schema', '');
+		if ($register === '' || $schema === '' || $uuid === '') {
+			return null;
+		}
+
+		try {
+			$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
+			$object = $objectService->find(id: $uuid, register: $register, schema: $schema);
+			if ($object === null) {
+				return null;
+			}
+
+			return $object->getObject();
+		} catch (\Throwable $e) {
+			$this->logger->warning(
+				'Pipelinq: failed to re-read deal for deferred forecast_category default',
+				['exception' => $e->getMessage(), 'uuid' => $uuid]
+			);
+			return null;
+		}//end try
+	}//end fetch()
 
 	/**
 	 * Persist the mutated deal data back to OpenRegister.
@@ -139,6 +231,6 @@ class DealCreatedListener implements IEventListener {
 				'Pipelinq: failed to default forecast_category on new deal',
 				['exception' => $e->getMessage(), 'uuid' => $uuid]
 			);
-		}
+		}//end try
 	}//end persist()
 }//end class

--- a/lib/Listener/DealUpdatedListener.php
+++ b/lib/Listener/DealUpdatedListener.php
@@ -3,8 +3,7 @@
 /**
  * Pipelinq DealUpdatedListener.
  *
- * Enforces forecast-category transition rules on deal (lead) updates: closed
- * deals lock, large commits require justification, reopened deals reset.
+ * Enforces forecast-category transition rules on deal updates.
  *
  * @category Listener
  * @package  OCA\Pipelinq\Listener
@@ -25,7 +24,9 @@ declare(strict_types=1);
 namespace OCA\Pipelinq\Listener;
 
 use OCA\OpenRegister\Event\ObjectUpdatedEvent;
+use OCA\OpenRegister\Service\Deferral\ListenerDeferralService;
 use OCA\Pipelinq\AppInfo\Application;
+use OCA\Pipelinq\BackgroundJob\DeferredObjectListenerJob;
 use OCA\Pipelinq\Service\ForecastDealService;
 use OCA\Pipelinq\Service\SchemaMapService;
 use OCP\EventDispatcher\Event;
@@ -39,12 +40,35 @@ use Psr\Log\LoggerInterface;
  *
  * OpenRegister dispatches object events after the write, so a rejected
  * transition (changing a closed deal, or an unjustified large commit) is
- * reverted by re-saving the prior forecast_category. A reopen resets the
+ * corrected by re-saving the prior forecast_category. A reopen resets the
  * category to pipeline. Filtered to the lead schema.
+ *
+ * ADR-078: `ObjectUpdatedEvent` is a POST event — the offending value is
+ * already stored and the listener could never have vetoed it, so the correction
+ * is a compensating write, not a validation. It runs in
+ * {@see DeferredObjectListenerJob} under the acting user instead of inside the
+ * update request.
+ *
+ * BECAUSE THE CORRECTION IS NOW LATE, IT IS RE-DECIDED, NOT REPLAYED. The
+ * deferred pass re-reads the deal and re-runs `validateTransition()` against the
+ * CURRENT value: if someone has already put a valid category back, nothing
+ * happens. Blindly replaying the captured revert would overwrite that fix with
+ * a stale value — the failure mode ADR-078 Rule 7 exists to prevent.
+ *
+ * The old category is still carried in the entry, because it is the only thing
+ * a later read cannot recover.
  *
  * @implements IEventListener<Event>
  */
-class DealUpdatedListener implements IEventListener {
+class DealUpdatedListener implements IEventListener, DeferredObjectWork {
+
+	/**
+	 * Identifies this listener's entries in the deferral job.
+	 *
+	 * @var string
+	 */
+	public const HANDLER_KEY = 'deal-updated';
+
 	/**
 	 * Constructor.
 	 *
@@ -52,6 +76,7 @@ class DealUpdatedListener implements IEventListener {
 	 * @param ForecastDealService $dealService The forecast deal lifecycle service.
 	 * @param ContainerInterface $container The DI container (OpenRegister ObjectService lookup).
 	 * @param IAppConfig $appConfig The app configuration.
+	 * @param ListenerDeferralService $deferral The actor-forwarding deferral service.
 	 * @param LoggerInterface $logger The logger.
 	 */
 	public function __construct(
@@ -59,12 +84,16 @@ class DealUpdatedListener implements IEventListener {
 		private ForecastDealService $dealService,
 		private ContainerInterface $container,
 		private IAppConfig $appConfig,
+		private ListenerDeferralService $deferral,
 		private LoggerInterface $logger,
 	) {
 	}//end __construct()
 
 	/**
 	 * Handle an object-updated event.
+	 *
+	 * Does no work: filters to the lead schema, captures the previous state
+	 * the correction needs, and queues it.
 	 *
 	 * @param Event $event The dispatched event.
 	 *
@@ -83,29 +112,79 @@ class DealUpdatedListener implements IEventListener {
 			return;
 		}
 
-		$newData = $newEntity->getObject();
-		$oldData = $oldEntity->getObject();
 		$uuid = (string)$newEntity->getUuid();
+		if ($uuid === '') {
+			return;
+		}
 
-		// Reject invalid transitions by reverting to the prior category.
-		$error = $this->dealService->validateTransition(oldData: $oldData, newData: $newData);
+		// Our own deferred correction re-enters this listener. Deferring again
+		// would enqueue another job whose write re-enters again — a cron loop.
+		if (DeferredWorkGuard::isRunning(key: DeferredWorkGuard::key(handler: self::HANDLER_KEY, uuid: $uuid)) === true) {
+			return;
+		}
+
+		$oldData = $oldEntity->getObject();
+		$newData = $newEntity->getObject();
+
+		// Nothing to correct: skip the job row entirely rather than enqueue a
+		// no-op. Both decisions are re-taken against current state in the job.
+		if ($this->dealService->validateTransition(oldData: $oldData, newData: $newData) === null
+			&& $this->dealService->applyReopenReset(oldData: $oldData, newData: $newData) === null
+		) {
+			return;
+		}
+
+		$this->deferral->defer(
+			jobClass: DeferredObjectListenerJob::class,
+			entry: [
+				'handler' => self::HANDLER_KEY,
+				'uuid' => $uuid,
+				'oldData' => $oldData,
+			],
+			dedupeKey: self::HANDLER_KEY . '|' . $uuid
+		);
+	}//end handle()
+
+	/**
+	 * Re-decide and apply the forecast-category correction.
+	 *
+	 * @param array<string, mixed> $entry The entry captured at dispatch time.
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/changes/forecast-roll-up-and-categories/specs.md#REQ-FRC-002-01, REQ-FRC-003-01
+	 */
+	public function runDeferredWork(array $entry): void {
+		$uuid = (string)($entry['uuid'] ?? '');
+		$oldData = ($entry['oldData'] ?? []);
+		if (is_array($oldData) === false) {
+			return;
+		}
+
+		$current = $this->fetch(uuid: $uuid);
+		if ($current === null) {
+			// Deal gone since the update. Stale entry, no-op (ADR-078 Rule 7).
+			return;
+		}
+
+		// Re-decided against CURRENT data, not replayed from the captured payload.
+		$error = $this->dealService->validateTransition(oldData: $oldData, newData: $current);
 		if ($error !== null) {
 			$this->logger->warning(
 				'Pipelinq: rejected forecast_category transition; reverting',
 				['uuid' => $uuid, 'reason' => $error]
 			);
-			$reverted = $newData;
-			$reverted['forecast_category'] = $oldData['forecast_category'] ?? ForecastDealService::DEFAULT_CATEGORY;
+			$reverted = $current;
+			$reverted['forecast_category'] = ($oldData['forecast_category'] ?? ForecastDealService::DEFAULT_CATEGORY);
 			$this->persist(uuid: $uuid, data: $reverted);
 			return;
 		}
 
-		// Reopening a closed deal resets the forecast category to pipeline.
-		$reset = $this->dealService->applyReopenReset(oldData: $oldData, newData: $newData);
+		$reset = $this->dealService->applyReopenReset(oldData: $oldData, newData: $current);
 		if ($reset !== null) {
 			$this->persist(uuid: $uuid, data: $reset);
 		}
-	}//end handle()
+	}//end runDeferredWork()
 
 	/**
 	 * Whether the entity belongs to the lead (deal) schema.
@@ -118,6 +197,37 @@ class DealUpdatedListener implements IEventListener {
 		$entityType = $this->schemaMapService->resolveEntityType(schemaId: $entity->getSchema());
 		return $entityType === 'lead';
 	}//end isLead()
+
+	/**
+	 * Read the deal's current data.
+	 *
+	 * @param string $uuid The deal UUID.
+	 *
+	 * @return array<string, mixed>|null The deal data, or null when it is gone.
+	 */
+	private function fetch(string $uuid): ?array {
+		$register = $this->appConfig->getValueString(Application::APP_ID, 'register', '');
+		$schema = $this->appConfig->getValueString(Application::APP_ID, 'lead_schema', '');
+		if ($register === '' || $schema === '' || $uuid === '') {
+			return null;
+		}
+
+		try {
+			$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
+			$object = $objectService->find(id: $uuid, register: $register, schema: $schema);
+			if ($object === null) {
+				return null;
+			}
+
+			return $object->getObject();
+		} catch (\Throwable $e) {
+			$this->logger->warning(
+				'Pipelinq: failed to re-read deal for deferred forecast_category correction',
+				['exception' => $e->getMessage(), 'uuid' => $uuid]
+			);
+			return null;
+		}//end try
+	}//end fetch()
 
 	/**
 	 * Persist mutated deal data back to OpenRegister.
@@ -148,6 +258,6 @@ class DealUpdatedListener implements IEventListener {
 				'Pipelinq: failed to persist forecast_category correction on deal update',
 				['exception' => $e->getMessage(), 'uuid' => $uuid]
 			);
-		}
+		}//end try
 	}//end persist()
 }//end class

--- a/lib/Listener/DeferredObjectWork.php
+++ b/lib/Listener/DeferredObjectWork.php
@@ -1,0 +1,48 @@
+<?php
+
+/**
+ * Pipelinq DeferredObjectWork.
+ *
+ * @category Listener
+ * @package  OCA\Pipelinq\Listener
+ *
+ * @author    Conduction <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git_id>
+ *
+ * @link https://github.com/ConductionNL/pipelinq
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Pipelinq\Listener;
+
+/**
+ * Implemented by a post-event listener whose work runs in a background job.
+ *
+ * ADR-078: a listener on `ObjectCreatedEvent` / `ObjectUpdatedEvent` /
+ * `ObjectDeletedEvent` cannot influence the write it observes, so any real work
+ * it does is latency the user pays for a result they have already earned. Such
+ * a listener's `handle()` keeps only the cheap in-memory filtering and hands an
+ * entry to {@see \OCA\Pipelinq\BackgroundJob\DeferredObjectListenerJob} through
+ * OpenRegister's `ListenerDeferralService`; the job calls `runDeferredWork()`
+ * back on the listener under the captured actor.
+ *
+ * IMPLEMENTATIONS MUST BE IDEMPOTENT AND MUST RECONCILE AGAINST CURRENT STATE.
+ * Delivery is at-least-once and ordering against the write is not guaranteed
+ * (ADR-078 Rule 7), so an entry whose object is gone, or whose triggering
+ * condition no longer holds, is a no-op — not an error.
+ */
+interface DeferredObjectWork {
+
+	/**
+	 * Perform the work that used to run inside the object write.
+	 *
+	 * @param array<string, mixed> $entry The entry captured at dispatch time.
+	 *
+	 * @return void
+	 */
+	public function runDeferredWork(array $entry): void;
+}//end interface

--- a/lib/Listener/DeferredWorkGuard.php
+++ b/lib/Listener/DeferredWorkGuard.php
@@ -1,0 +1,118 @@
+<?php
+
+/**
+ * Pipelinq DeferredWorkGuard.
+ *
+ * @category Listener
+ * @package  OCA\Pipelinq\Listener
+ *
+ * @author    Conduction <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git_id>
+ *
+ * @link https://github.com/ConductionNL/pipelinq
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Pipelinq\Listener;
+
+/**
+ * Process-wide re-entrancy guard for deferred post-event listener work.
+ *
+ * THIS IS THE PART OF THE ADR-078 CONVERSION THAT IS EASY TO GET WRONG, so it
+ * is one class rather than seven copies.
+ *
+ * Every listener converted here writes an object back through
+ * `ObjectService::saveObject()`, and OpenRegister's `MagicMapper::update()`
+ * dispatches `ObjectUpdatedEvent` for that write — which re-enters the same
+ * listeners. Inline, that recursion terminated (or not) on each listener's own
+ * idempotency check. Deferred, it does not terminate at all: the re-entrant
+ * `handle()` would enqueue ANOTHER job, whose write re-enters again, and cron
+ * would grind on the same object forever. `cron.php` runs one job per web call,
+ * so a self-re-queuing job does not merely waste work — it starves every other
+ * job behind it.
+ *
+ * So the deferred work marks itself in-flight for its `(listener, uuid)` pair,
+ * and a listener that finds its own pair already running returns without
+ * deferring. The write raised by the deferred work is then observed exactly
+ * once and goes no further.
+ *
+ * Static state is correct here for the same reason it is correct in
+ * `ExpenseApprovalListener::$inFlight`, which this generalises: Nextcloud
+ * resolves a listener from the container per dispatch, so a re-entrant dispatch
+ * is not guaranteed to reach the same instance; and the process context is torn
+ * down per request / per cron job, so nothing leaks between them. `leave()` is
+ * always called from a `finally`.
+ */
+final class DeferredWorkGuard {
+
+	/**
+	 * Keys currently on the stack, as `<handler>|<uuid>`.
+	 *
+	 * @var array<string, true>
+	 */
+	private static array $inFlight = [];
+
+	/**
+	 * Build the guard key for a handler + object pair.
+	 *
+	 * @param string $handler The handler key of the listener doing the work.
+	 * @param string $uuid The uuid of the object being written.
+	 *
+	 * @return string The guard key.
+	 */
+	public static function key(string $handler, string $uuid): string {
+		return $handler . '|' . $uuid;
+	}//end key()
+
+	/**
+	 * Claim a key, or report that it is already claimed.
+	 *
+	 * @param string $key The guard key.
+	 *
+	 * @return bool True when the caller claimed it and MUST call leave();
+	 *              false when the work is already running on this stack.
+	 */
+	public static function enter(string $key): bool {
+		if (isset(self::$inFlight[$key]) === true) {
+			return false;
+		}
+
+		self::$inFlight[$key] = true;
+		return true;
+	}//end enter()
+
+	/**
+	 * Release a key claimed by enter().
+	 *
+	 * @param string $key The guard key.
+	 *
+	 * @return void
+	 */
+	public static function leave(string $key): void {
+		unset(self::$inFlight[$key]);
+	}//end leave()
+
+	/**
+	 * Whether a key is currently being processed on this stack.
+	 *
+	 * @param string $key The guard key.
+	 *
+	 * @return bool True when the deferred work for this pair is running.
+	 */
+	public static function isRunning(string $key): bool {
+		return isset(self::$inFlight[$key]);
+	}//end isRunning()
+
+	/**
+	 * Drop every claim. Tests only — a leaked key would make later tests lie.
+	 *
+	 * @return void
+	 */
+	public static function reset(): void {
+		self::$inFlight = [];
+	}//end reset()
+}//end class

--- a/lib/Listener/ExpenseApprovalListener.php
+++ b/lib/Listener/ExpenseApprovalListener.php
@@ -3,14 +3,7 @@
 /**
  * Pipelinq ExpenseApprovalListener.
  *
- * Listens to OpenRegister object create/update events, detects expense
- * schema objects that have transitioned to status=approved, dispatches the
- * approval to the Shillinq AP webhook and records the outcome on the
- * expense's apSyncStatus / apSyncedAt fields.
- *
- * Idempotent: an expense already marked apSyncStatus=synced is skipped so a
- * re-fired update event cannot create a duplicate AP voucher (REQ-AP-002
- * Scenario 5).
+ * Dispatches approved expenses to the Shillinq AP webhook.
  *
  * @category Listener
  * @package  OCA\Pipelinq\Listener
@@ -32,7 +25,9 @@ namespace OCA\Pipelinq\Listener;
 
 use OCA\OpenRegister\Event\ObjectCreatedEvent;
 use OCA\OpenRegister\Event\ObjectUpdatedEvent;
+use OCA\OpenRegister\Service\Deferral\ListenerDeferralService;
 use OCA\Pipelinq\AppInfo\Application;
+use OCA\Pipelinq\BackgroundJob\DeferredObjectListenerJob;
 use OCA\Pipelinq\Event\ExpenseApprovedEvent;
 use OCA\Pipelinq\Service\ApSyncNotifier;
 use OCA\Pipelinq\Service\SchemaMapService;
@@ -53,29 +48,53 @@ use Throwable;
  * expense's apSyncStatus / apSyncedAt fields with the dispatch outcome and
  * notifies admins through ApSyncNotifier on final failure.
  *
+ * ADR-078: the approval is already stored when this runs. The three
+ * `saveObject()` calls and the outbound AP webhook (with its own retry budget)
+ * therefore no longer run inside the approving user's request — they run in
+ * {@see DeferredObjectListenerJob} under that user.
+ *
+ * THE RE-ENTRANCY GUARD IS STILL THE LOAD-BEARING PART, and it moved to
+ * {@see DeferredWorkGuard} so every converted listener in this app shares one
+ * implementation. The mechanism is unchanged:
+ *
+ *   runDeferredWork() -> persist() -> ObjectService::saveObject(), and
+ *   MagicMapper::update() dispatches ObjectUpdatedEvent for that write. The
+ *   event carries the SAME expense, still status=approved, so every check in
+ *   handle() passes again. The idempotency guard cannot stop it: it
+ *   short-circuits only on apSyncStatus === 'synced', and the first re-entry
+ *   sees 'pending' — the value persist() has just written.
+ *
+ * `silent: true` on saveObject() does NOT fix this and was measured: $silent
+ * gates the audit trail and updateInverseRelations only (openregister
+ * lib/Service/Object/SaveObject.php:3468, :3489, :5445, :5515). The lifecycle
+ * dispatch at MagicMapper.php:8997 is gated solely by
+ * suppressLifecycleEvents(), i.e. by SystemOperationContext::isActive(), which
+ * a listener is not in.
+ *
+ * Deferral makes the guard MORE important, not less: without it the re-entrant
+ * handle() would enqueue another job, whose write would re-enter again, and the
+ * loop would move from one request's stack onto the cron queue — where
+ * `cron.php` runs one job per web call and a self-re-queuing job starves
+ * everything behind it.
+ *
  * @implements IEventListener<Event>
  *
  * @spec openspec/changes/pipelinq-expense-to-shillinq-ap/specs.md#REQ-AP-002
  *
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects) Bridges the schema map,
  *  Shillinq AP service, admin notifier, event dispatcher, OR ObjectService,
- *  app-config and logger — the minimal collaborator set for AP fan-out.
+ *  deferral service, app-config and logger — the minimal collaborator set for
+ *  AP fan-out.
  */
-class ExpenseApprovalListener implements IEventListener {
+class ExpenseApprovalListener implements IEventListener, DeferredObjectWork {
 	use EntityAccessorTrait;
 
 	/**
-	 * Expense UUIDs whose dispatch is currently on the stack.
+	 * Identifies this listener's entries in the deferral job.
 	 *
-	 * Static rather than per-instance on purpose: Nextcloud's event dispatcher
-	 * resolves the listener from the container per dispatch, so a re-entrant
-	 * dispatch is not guaranteed to reach the same object. Static state is safe
-	 * here because PHP-FPM tears the process context down per request, and the
-	 * `finally` in handle() releases the key even when dispatch throws.
-	 *
-	 * @var array<string, true>
+	 * @var string
 	 */
-	private static array $inFlight = [];
+	public const HANDLER_KEY = 'expense-approval';
 
 	/**
 	 * Constructor.
@@ -86,6 +105,7 @@ class ExpenseApprovalListener implements IEventListener {
 	 * @param IEventDispatcher $eventDispatcher The event dispatcher (for ExpenseApprovedEvent fan-out).
 	 * @param ContainerInterface $container The DI container (OpenRegister ObjectService lookup).
 	 * @param IAppConfig $appConfig The app configuration.
+	 * @param ListenerDeferralService $deferral The actor-forwarding deferral service.
 	 * @param LoggerInterface $logger The logger.
 	 */
 	public function __construct(
@@ -95,12 +115,15 @@ class ExpenseApprovalListener implements IEventListener {
 		private IEventDispatcher $eventDispatcher,
 		private ContainerInterface $container,
 		private IAppConfig $appConfig,
+		private ListenerDeferralService $deferral,
 		private LoggerInterface $logger,
 	) {
 	}//end __construct()
 
 	/**
 	 * Handle an object create/update event.
+	 *
+	 * Does no AP work: evaluates the preconditions and queues the dispatch.
 	 *
 	 * @param Event $event The dispatched event.
 	 *
@@ -121,42 +144,22 @@ class ExpenseApprovalListener implements IEventListener {
 				return;
 			}
 
-			[$uuid, $data] = $dispatchable;
+			[$uuid] = $dispatchable;
 
-			// Re-entrancy: our own persist() re-enters this listener.
-			//
-			// dispatchApproval() -> persist() -> ObjectService::saveObject(), and
-			// MagicMapper::update() dispatches ObjectUpdatedEvent for that write.
-			// The event carries the SAME expense, still status=approved, so every
-			// check above passes again. The idempotency guard cannot stop it: it
-			// short-circuits only on apSyncStatus === 'synced', and the first
-			// re-entry sees 'pending' — the value persist() has just written. The
-			// terminating write is therefore never reached and each level fires
-			// another outbound AP webhook with its own retries.
-			//
-			// `silent: true` on saveObject() does NOT fix this and was measured:
-			// $silent gates the audit trail and updateInverseRelations only
-			// (openregister lib/Service/Object/SaveObject.php:3468, :3489, :5445,
-			// :5515). The lifecycle dispatch at MagicMapper.php:8997 is gated
-			// solely by suppressLifecycleEvents(), i.e. by
-			// SystemOperationContext::isActive(), which a listener is not in.
-			//
-			// Until now the only thing preventing the loop was the method_exists()
-			// probe this branch repairs: isExpense() was permanently false, so
-			// handle() never reached dispatchApproval() at all. Reviving the
-			// listener without this guard arms the loop. Today it stays bounded
-			// only because shouldDispatch() is false without a configured webhook
-			// URL — i.e. it would arm the moment anyone configures AP sync.
-			if (isset(self::$inFlight[$uuid]) === true) {
+			// See the class docblock: our own persist() re-enters this listener
+			// with a payload that passes every check above.
+			if (DeferredWorkGuard::isRunning(key: DeferredWorkGuard::key(handler: self::HANDLER_KEY, uuid: $uuid)) === true) {
 				return;
 			}
 
-			self::$inFlight[$uuid] = true;
-			try {
-				$this->dispatchApproval(uuid: $uuid, data: $data);
-			} finally {
-				unset(self::$inFlight[$uuid]);
-			}
+			$this->deferral->defer(
+				jobClass: DeferredObjectListenerJob::class,
+				entry: [
+					'handler' => self::HANDLER_KEY,
+					'uuid' => $uuid,
+				],
+				dedupeKey: self::HANDLER_KEY . '|' . $uuid
+			);
 		} catch (Throwable $e) {
 			// CRITICAL: never throw — approval workflow must not be affected.
 			$this->logger->warning(
@@ -167,10 +170,38 @@ class ExpenseApprovalListener implements IEventListener {
 	}//end handle()
 
 	/**
+	 * Re-emit the approval event and dispatch the AP webhook, recording outcome.
+	 *
+	 * @param array<string, mixed> $entry The entry captured at dispatch time.
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/changes/pipelinq-expense-to-shillinq-ap/specs.md#REQ-AP-002
+	 */
+	public function runDeferredWork(array $entry): void {
+		$uuid = (string)($entry['uuid'] ?? '');
+		$data = $this->fetch(uuid: $uuid);
+		if ($data === null) {
+			// Expense gone since approval. Stale entry (ADR-078 Rule 7).
+			return;
+		}
+
+		// Re-checked against current state: the expense may have been
+		// un-approved, already synced, or the webhook unconfigured since.
+		if (($data['status'] ?? '') !== 'approved'
+			|| ($data['apSyncStatus'] ?? null) === 'synced'
+			|| $this->apService->shouldDispatch() === false
+		) {
+			return;
+		}
+
+		$this->dispatchApproval(uuid: $uuid, data: $data);
+	}//end runDeferredWork()
+
+	/**
 	 * Decide whether this event should produce an AP dispatch, and for what.
 	 *
-	 * Extracted from handle() so the preconditions live in one place and
-	 * handle() is left with the re-entrancy guard and the error boundary. Every
+	 * Extracted from handle() so the preconditions live in one place. Every
 	 * `null` here is a deliberate no-op named by REQ-AP-002.
 	 *
 	 * @param ObjectCreatedEvent|ObjectUpdatedEvent $event The dispatched event.
@@ -306,6 +337,37 @@ class ExpenseApprovalListener implements IEventListener {
 	}//end isExpense()
 
 	/**
+	 * Read the expense's current data.
+	 *
+	 * @param string $uuid The expense UUID.
+	 *
+	 * @return array<string, mixed>|null The expense data, or null when it is gone.
+	 */
+	private function fetch(string $uuid): ?array {
+		$register = $this->appConfig->getValueString(Application::APP_ID, 'register', '');
+		$schema = $this->appConfig->getValueString(Application::APP_ID, 'expense_schema', '');
+		if ($register === '' || $schema === '' || $uuid === '') {
+			return null;
+		}
+
+		try {
+			$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
+			$object = $objectService->find(id: $uuid, register: $register, schema: $schema);
+			if ($object === null) {
+				return null;
+			}
+
+			return $object->getObject();
+		} catch (Throwable $e) {
+			$this->logger->warning(
+				'Pipelinq: failed to re-read expense for deferred AP dispatch',
+				['exception' => $e->getMessage(), 'uuid' => $uuid]
+			);
+			return null;
+		}//end try
+	}//end fetch()
+
+	/**
 	 * Persist the mutated expense data back to OpenRegister.
 	 *
 	 * @param string $uuid The expense UUID.
@@ -329,7 +391,7 @@ class ExpenseApprovalListener implements IEventListener {
 				schema: $schema,
 				uuid: $uuid
 			);
-		} catch (\Throwable $e) {
+		} catch (Throwable $e) {
 			$this->logger->warning(
 				'Pipelinq: failed to persist expense AP sync status',
 				['exception' => $e->getMessage(), 'uuid' => $uuid]

--- a/lib/Listener/ProjectCreationListener.php
+++ b/lib/Listener/ProjectCreationListener.php
@@ -3,8 +3,7 @@
 /**
  * Pipelinq ProjectCreationListener.
  *
- * Dispatches a newly created project to the Shillinq project ledger and records
- * the outcome on the project's ledgerSyncStatus / ledgerSyncedAt fields.
+ * Dispatches a newly created project to the Shillinq ledger.
  *
  * @category Listener
  * @package  OCA\Pipelinq\Listener
@@ -25,7 +24,9 @@ declare(strict_types=1);
 namespace OCA\Pipelinq\Listener;
 
 use OCA\OpenRegister\Event\ObjectCreatedEvent;
+use OCA\OpenRegister\Service\Deferral\ListenerDeferralService;
 use OCA\Pipelinq\AppInfo\Application;
+use OCA\Pipelinq\BackgroundJob\DeferredObjectListenerJob;
 use OCA\Pipelinq\Service\LedgerSyncNotifier;
 use OCA\Pipelinq\Service\SchemaMapService;
 use OCA\Pipelinq\Service\ShillinqLedgerService;
@@ -42,11 +43,26 @@ use Psr\Log\LoggerInterface;
  * ledgerSyncStatus = synced is skipped so a re-fired creation event cannot
  * create a duplicate ledger entry.
  *
+ * ADR-078: this used to be the worst shape in the app — two `saveObject()`
+ * calls with an OUTBOUND HTTP DISPATCH (with its own retries) between them, all
+ * inside the user's create request. Shillinq's latency was the user's latency
+ * and Shillinq's outage was the user's slow project creation. The whole
+ * sequence now runs in {@see DeferredObjectListenerJob} under the acting user;
+ * `handle()` keeps only the schema filter and the two cheap short-circuits.
+ *
  * @implements IEventListener<Event>
  *
  * @spec openspec/changes/pipelinq-project-to-shillinq-ledger/specs.md#REQ-PLG-001
  */
-class ProjectCreationListener implements IEventListener {
+class ProjectCreationListener implements IEventListener, DeferredObjectWork {
+
+	/**
+	 * Identifies this listener's entries in the deferral job.
+	 *
+	 * @var string
+	 */
+	public const HANDLER_KEY = 'project-created';
+
 	/**
 	 * Constructor.
 	 *
@@ -55,6 +71,7 @@ class ProjectCreationListener implements IEventListener {
 	 * @param LedgerSyncNotifier $notifier The admin failure notifier.
 	 * @param ContainerInterface $container The DI container (OpenRegister ObjectService lookup).
 	 * @param IAppConfig $appConfig The app configuration.
+	 * @param ListenerDeferralService $deferral The actor-forwarding deferral service.
 	 * @param LoggerInterface $logger The logger.
 	 */
 	public function __construct(
@@ -63,12 +80,15 @@ class ProjectCreationListener implements IEventListener {
 		private LedgerSyncNotifier $notifier,
 		private ContainerInterface $container,
 		private IAppConfig $appConfig,
+		private ListenerDeferralService $deferral,
 		private LoggerInterface $logger,
 	) {
 	}//end __construct()
 
 	/**
 	 * Handle an object-created event.
+	 *
+	 * Does no ledger work: filters, then queues.
 	 *
 	 * @param Event $event The dispatched event.
 	 *
@@ -92,9 +112,53 @@ class ProjectCreationListener implements IEventListener {
 
 		$data = $entity->getObject();
 		$uuid = (string)$entity->getUuid();
+		if ($uuid === '') {
+			return;
+		}
 
 		// Idempotency: never re-dispatch an already-synced project (REQ-PLG-003-04).
 		if (($data['ledgerSyncStatus'] ?? null) === 'synced') {
+			return;
+		}
+
+		// Our own status writes re-enter the project listeners; deferring again
+		// from inside the deferred pass would be a cron loop.
+		if (DeferredWorkGuard::isRunning(key: DeferredWorkGuard::key(handler: self::HANDLER_KEY, uuid: $uuid)) === true) {
+			return;
+		}
+
+		$this->deferral->defer(
+			jobClass: DeferredObjectListenerJob::class,
+			entry: [
+				'handler' => self::HANDLER_KEY,
+				'uuid' => $uuid,
+			],
+			dedupeKey: self::HANDLER_KEY . '|' . $uuid
+		);
+	}//end handle()
+
+	/**
+	 * Dispatch the project to the Shillinq ledger and record the outcome.
+	 *
+	 * @param array<string, mixed> $entry The entry captured at dispatch time.
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/changes/pipelinq-project-to-shillinq-ledger/specs.md#REQ-PLG-001-01
+	 */
+	public function runDeferredWork(array $entry): void {
+		$uuid = (string)($entry['uuid'] ?? '');
+		$data = $this->fetch(uuid: $uuid);
+		if ($data === null) {
+			// Project gone since creation. Stale entry (ADR-078 Rule 7).
+			return;
+		}
+
+		// Re-checked here as well as at dispatch time: the webhook may have been
+		// unconfigured, or the project already synced, in the interval.
+		if ($this->ledgerService->shouldDispatch() === false
+			|| ($data['ledgerSyncStatus'] ?? null) === 'synced'
+		) {
 			return;
 		}
 
@@ -119,7 +183,7 @@ class ProjectCreationListener implements IEventListener {
 			eventType: 'created',
 			uuid: $uuid
 		);
-	}//end handle()
+	}//end runDeferredWork()
 
 	/**
 	 * Whether the entity belongs to the project schema.
@@ -132,6 +196,37 @@ class ProjectCreationListener implements IEventListener {
 		$entityType = $this->schemaMapService->resolveEntityType(schemaId: $entity->getSchema());
 		return $entityType === 'project';
 	}//end isProject()
+
+	/**
+	 * Read the project's current data.
+	 *
+	 * @param string $uuid The project UUID.
+	 *
+	 * @return array<string, mixed>|null The project data, or null when it is gone.
+	 */
+	private function fetch(string $uuid): ?array {
+		$register = $this->appConfig->getValueString(Application::APP_ID, 'register', '');
+		$schema = $this->appConfig->getValueString(Application::APP_ID, 'project_schema', '');
+		if ($register === '' || $schema === '' || $uuid === '') {
+			return null;
+		}
+
+		try {
+			$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
+			$object = $objectService->find(id: $uuid, register: $register, schema: $schema);
+			if ($object === null) {
+				return null;
+			}
+
+			return $object->getObject();
+		} catch (\Throwable $e) {
+			$this->logger->warning(
+				'Pipelinq: failed to re-read project for deferred ledger dispatch',
+				['exception' => $e->getMessage(), 'uuid' => $uuid]
+			);
+			return null;
+		}//end try
+	}//end fetch()
 
 	/**
 	 * Persist the mutated project data back to OpenRegister.

--- a/lib/Listener/ProjectPhaseStatusListener.php
+++ b/lib/Listener/ProjectPhaseStatusListener.php
@@ -3,9 +3,7 @@
 /**
  * Pipelinq ProjectPhaseStatusListener.
  *
- * Dispatches a Shillinq ledger status-change event when a project's status
- * changes, or when a project phase's status changes (resolved in the parent
- * project's context), and records the outcome on the project.
+ * Dispatches project / phase status changes to the Shillinq ledger.
  *
  * @category Listener
  * @package  OCA\Pipelinq\Listener
@@ -26,7 +24,9 @@ declare(strict_types=1);
 namespace OCA\Pipelinq\Listener;
 
 use OCA\OpenRegister\Event\ObjectUpdatedEvent;
+use OCA\OpenRegister\Service\Deferral\ListenerDeferralService;
 use OCA\Pipelinq\AppInfo\Application;
+use OCA\Pipelinq\BackgroundJob\DeferredObjectListenerJob;
 use OCA\Pipelinq\Service\LedgerSyncNotifier;
 use OCA\Pipelinq\Service\SchemaMapService;
 use OCA\Pipelinq\Service\ShillinqLedgerService;
@@ -44,11 +44,30 @@ use Psr\Log\LoggerInterface;
  * parent project, whose ledger sync status is then updated. Updates that do
  * not change status are ignored.
  *
+ * ADR-078: the status change is already stored when this runs, so the
+ * dispatch — two `saveObject()` calls around an outbound HTTP call with
+ * retries, plus a parent-project lookup for the phase case — no longer happens
+ * inside the update request. It runs in {@see DeferredObjectListenerJob} under
+ * the acting user.
+ *
+ * THE OLD AND NEW STATUS TRAVEL IN THE ENTRY. They are the ledger event's
+ * payload and the only part a later read cannot reconstruct; everything else
+ * (the project body, whether the webhook is still configured) is re-read in the
+ * job so the dispatch reflects current state.
+ *
  * @implements IEventListener<Event>
  *
  * @spec openspec/changes/pipelinq-project-to-shillinq-ledger/specs.md#REQ-PLG-002
  */
-class ProjectPhaseStatusListener implements IEventListener {
+class ProjectPhaseStatusListener implements IEventListener, DeferredObjectWork {
+
+	/**
+	 * Identifies this listener's entries in the deferral job.
+	 *
+	 * @var string
+	 */
+	public const HANDLER_KEY = 'project-phase-status';
+
 	/**
 	 * Constructor.
 	 *
@@ -57,6 +76,7 @@ class ProjectPhaseStatusListener implements IEventListener {
 	 * @param LedgerSyncNotifier $notifier The admin failure notifier.
 	 * @param ContainerInterface $container The DI container (OpenRegister ObjectService lookup).
 	 * @param IAppConfig $appConfig The app configuration.
+	 * @param ListenerDeferralService $deferral The actor-forwarding deferral service.
 	 * @param LoggerInterface $logger The logger.
 	 */
 	public function __construct(
@@ -65,12 +85,15 @@ class ProjectPhaseStatusListener implements IEventListener {
 		private LedgerSyncNotifier $notifier,
 		private ContainerInterface $container,
 		private IAppConfig $appConfig,
+		private ListenerDeferralService $deferral,
 		private LoggerInterface $logger,
 	) {
 	}//end __construct()
 
 	/**
 	 * Handle an object-updated event.
+	 *
+	 * Does no ledger work: detects the status change and queues the dispatch.
 	 *
 	 * @param Event $event The dispatched event.
 	 *
@@ -108,31 +131,69 @@ class ProjectPhaseStatusListener implements IEventListener {
 			return;
 		}
 
+		// A phase change is attributed to its parent project; the lookup itself
+		// is a read and belongs in the job, so only the reference travels.
+		$subjectUuid = (string)$newEntity->getUuid();
+		$projectRef = '';
 		if ($entityType === 'projectPhase') {
-			// Resolve the parent project and dispatch in its context (REQ-PLG-002-05).
-			$project = $this->fetchProject(uuid: (string)($newData['project'] ?? ''));
-			if ($project === null) {
+			$projectRef = (string)($newData['project'] ?? '');
+			if ($projectRef === '') {
 				return;
 			}
 
-			$projectUuid = (string)($project['id'] ?? $project['uuid'] ?? '');
-			$this->dispatchAndRecord(
-				project: $project,
-				projectUuid: $projectUuid,
-				oldStatus: $oldStatus,
-				newStatus: $newStatus
-			);
+			$subjectUuid = $projectRef;
+		}
+
+		if ($subjectUuid === '') {
 			return;
 		}
 
-		// Direct project status change.
-		$this->dispatchAndRecord(
-			project: $newData,
-			projectUuid: (string)$newEntity->getUuid(),
-			oldStatus: $oldStatus,
-			newStatus: $newStatus
+		// Our own status writes re-enter this listener; deferring again from
+		// inside the deferred pass would be a cron loop.
+		if (DeferredWorkGuard::isRunning(key: DeferredWorkGuard::key(handler: self::HANDLER_KEY, uuid: $subjectUuid)) === true) {
+			return;
+		}
+
+		$this->deferral->defer(
+			jobClass: DeferredObjectListenerJob::class,
+			entry: [
+				'handler' => self::HANDLER_KEY,
+				'uuid' => $subjectUuid,
+				'oldStatus' => $oldStatus,
+				'newStatus' => $newStatus,
+			],
+			dedupeKey: self::HANDLER_KEY . '|' . $subjectUuid . '|' . $oldStatus . '|' . $newStatus
 		);
 	}//end handle()
+
+	/**
+	 * Dispatch the status change to the ledger and record the outcome.
+	 *
+	 * @param array<string, mixed> $entry The entry captured at dispatch time.
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/changes/pipelinq-project-to-shillinq-ledger/specs.md#REQ-PLG-002-01
+	 */
+	public function runDeferredWork(array $entry): void {
+		$projectUuid = (string)($entry['uuid'] ?? '');
+		if ($projectUuid === '' || $this->ledgerService->shouldDispatch() === false) {
+			return;
+		}
+
+		$project = $this->fetchProject(uuid: $projectUuid);
+		if ($project === null) {
+			// Project gone since the status change. Stale entry (ADR-078 Rule 7).
+			return;
+		}
+
+		$this->dispatchAndRecord(
+			project: $project,
+			projectUuid: $projectUuid,
+			oldStatus: (string)($entry['oldStatus'] ?? ''),
+			newStatus: (string)($entry['newStatus'] ?? '')
+		);
+	}//end runDeferredWork()
 
 	/**
 	 * Dispatch a status-change ledger event and record the outcome on the project.
@@ -148,10 +209,6 @@ class ProjectPhaseStatusListener implements IEventListener {
 	 * @return void
 	 */
 	private function dispatchAndRecord(array $project, string $projectUuid, string $oldStatus, string $newStatus): void {
-		if ($projectUuid === '') {
-			return;
-		}
-
 		$project['ledgerSyncStatus'] = 'pending';
 		$this->persist(uuid: $projectUuid, data: $project);
 
@@ -201,7 +258,7 @@ class ProjectPhaseStatusListener implements IEventListener {
 			return $object->getObject();
 		} catch (\Throwable $e) {
 			$this->logger->warning(
-				'Pipelinq: failed to resolve parent project for phase ledger sync',
+				'Pipelinq: failed to resolve project for ledger status dispatch',
 				['exception' => $e->getMessage(), 'uuid' => $uuid]
 			);
 			return null;

--- a/lib/Listener/SlaObjectCreatedListener.php
+++ b/lib/Listener/SlaObjectCreatedListener.php
@@ -5,7 +5,7 @@
  *
  * Listens on OpenRegister `ObjectCreatedEvent` and initialises the SLA
  * tracking envelope (`slaStatus`) on tracked schemas (request, klacht
- * / complaint, callback) before the API response returns.
+ * / complaint, callback).
  *
  * @category Listener
  * @package  OCA\Pipelinq\Listener
@@ -19,7 +19,6 @@
  * @link https://github.com/ConductionNL/pipelinq
  *
  * @spec openspec/specs/sla-engine-and-escalation/spec.md
- * @spec openspec/specs/sla-engine-and-escalation/spec.md
  */
 
 declare(strict_types=1);
@@ -29,7 +28,9 @@ namespace OCA\Pipelinq\Listener;
 use DateTimeImmutable;
 use DateTimeZone;
 use OCA\OpenRegister\Event\ObjectCreatedEvent;
+use OCA\OpenRegister\Service\Deferral\ListenerDeferralService;
 use OCA\Pipelinq\AppInfo\Application;
+use OCA\Pipelinq\BackgroundJob\DeferredObjectListenerJob;
 use OCA\Pipelinq\Service\SchemaMapService;
 use OCA\Pipelinq\Service\SlaEngineService;
 use OCP\EventDispatcher\Event;
@@ -46,9 +47,25 @@ use Throwable;
  * exception is logged and swallowed — the underlying object save MUST
  * succeed (REQ-007 fail-safe).
  *
+ * ADR-078: the object is already written when this runs, so policy
+ * resolution and the `slaStatus` write no longer happen inside the create
+ * request. They run in {@see DeferredObjectListenerJob} under the acting
+ * user. `slaStatus` is therefore populated shortly AFTER the create response,
+ * bounded by the cron interval — the eventual consistency ADR-078 accepts for
+ * post-event effects. The envelope's timestamps come from the deferred pass's
+ * `now`, which is when the SLA clock is armed.
+ *
  * @implements IEventListener<Event>
  */
-class SlaObjectCreatedListener implements IEventListener {
+class SlaObjectCreatedListener implements IEventListener, DeferredObjectWork {
+
+	/**
+	 * Identifies this listener's entries in the deferral job.
+	 *
+	 * @var string
+	 */
+	public const HANDLER_KEY = 'sla-object-created';
+
 	private const TRACKED_TYPES = ['request', 'complaint', 'complaint', 'callback'];
 
 	/**
@@ -58,6 +75,7 @@ class SlaObjectCreatedListener implements IEventListener {
 	 * @param SchemaMapService $schemaMapService Schema → entity-type map.
 	 * @param ContainerInterface $container DI container (OR ObjectService).
 	 * @param IAppConfig $appConfig App config.
+	 * @param ListenerDeferralService $deferral The actor-forwarding deferral service.
 	 * @param LoggerInterface $logger PSR logger.
 	 */
 	public function __construct(
@@ -65,6 +83,7 @@ class SlaObjectCreatedListener implements IEventListener {
 		private SchemaMapService $schemaMapService,
 		private ContainerInterface $container,
 		private IAppConfig $appConfig,
+		private ListenerDeferralService $deferral,
 		private LoggerInterface $logger,
 	) {
 	}//end __construct()
@@ -72,11 +91,12 @@ class SlaObjectCreatedListener implements IEventListener {
 	/**
 	 * Handle a dispatched event.
 	 *
+	 * Does no SLA work: filters to tracked schemas and queues the init.
+	 *
 	 * @param Event $event The event.
 	 *
 	 * @return void
 	 *
-	 * @spec openspec/specs/sla-engine-and-escalation/spec.md
 	 * @spec openspec/specs/sla-engine-and-escalation/spec.md
 	 */
 	public function handle(Event $event): void {
@@ -86,15 +106,10 @@ class SlaObjectCreatedListener implements IEventListener {
 
 		try {
 			$entity = $event->getObject();
-			$type = $this->schemaMapService->resolveEntityType($entity->getSchema());
+			$schemaId = (string)$entity->getSchema();
+			$type = $this->schemaMapService->resolveEntityType($schemaId);
 			if (in_array($type, self::TRACKED_TYPES, true) === false) {
 				return;
-			}
-
-			// Normalise 'complaint' → 'complaint' for policy matching, per spec wording.
-			$matchType = $type;
-			if ($type === 'complaint') {
-				$matchType = 'complaint';
 			}
 
 			$data = $entity->getObject();
@@ -106,27 +121,80 @@ class SlaObjectCreatedListener implements IEventListener {
 				return;
 			}
 
-			$metadata = $this->extractMetadata(data: $data);
-			$policy = $this->engine->resolvePolicyForObject($matchType, (string)$entity->getUuid(), $metadata);
-			if ($policy === null) {
-				$this->logger->debug(
-					'SlaObjectCreatedListener: no matching policy',
-					['type' => $matchType, 'tier' => $metadata['tier'] ?? '']
-				);
+			$uuid = (string)$entity->getUuid();
+			if ($uuid === '' || $schemaId === '') {
 				return;
 			}
 
-			$now = new DateTimeImmutable('now', new DateTimeZone('UTC'));
-			$data['slaStatus'] = $this->engine->initialiseStatus($policy, $now);
+			// Our own slaStatus write re-enters the SLA listeners; deferring
+			// again from inside the deferred pass would be a cron loop.
+			if (DeferredWorkGuard::isRunning(key: DeferredWorkGuard::key(handler: self::HANDLER_KEY, uuid: $uuid)) === true) {
+				return;
+			}
 
-			$this->persist(entity: $entity, data: $data);
+			$this->deferral->defer(
+				jobClass: DeferredObjectListenerJob::class,
+				entry: [
+					'handler' => self::HANDLER_KEY,
+					'uuid' => $uuid,
+					'schema' => $schemaId,
+					'type' => (string)$type,
+				],
+				dedupeKey: self::HANDLER_KEY . '|' . $uuid
+			);
 		} catch (Throwable $e) {
 			$this->logger->warning(
-				'SlaObjectCreatedListener: SLA init failed (non-blocking)',
+				'SlaObjectCreatedListener: SLA init could not be queued (non-blocking)',
 				['error' => $e->getMessage()]
 			);
 		}//end try
 	}//end handle()
+
+	/**
+	 * Resolve the policy and write the initial slaStatus envelope.
+	 *
+	 * @param array<string, mixed> $entry The entry captured at dispatch time.
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/specs/sla-engine-and-escalation/spec.md
+	 */
+	public function runDeferredWork(array $entry): void {
+		$uuid = (string)($entry['uuid'] ?? '');
+		$schemaId = (string)($entry['schema'] ?? '');
+		$matchType = (string)($entry['type'] ?? '');
+		if ($uuid === '' || $schemaId === '' || $matchType === '') {
+			return;
+		}
+
+		$data = $this->fetch(uuid: $uuid, schemaId: $schemaId);
+		if ($data === null) {
+			// Object gone since creation. Stale entry (ADR-078 Rule 7).
+			return;
+		}
+
+		// Re-checked: another path may have armed the envelope in the interval.
+		if (isset($data['slaStatus']) === true && is_array($data['slaStatus']) === true
+			&& ($data['slaStatus']['policyId'] ?? '') !== ''
+		) {
+			return;
+		}
+
+		$metadata = $this->extractMetadata(data: $data);
+		$policy = $this->engine->resolvePolicyForObject($matchType, $uuid, $metadata);
+		if ($policy === null) {
+			$this->logger->debug(
+				'SlaObjectCreatedListener: no matching policy',
+				['type' => $matchType, 'tier' => ($metadata['tier'] ?? '')]
+			);
+			return;
+		}
+
+		$now = new DateTimeImmutable('now', new DateTimeZone('UTC'));
+		$data['slaStatus'] = $this->engine->initialiseStatus($policy, $now);
+
+		$this->persist(uuid: $uuid, schemaId: $schemaId, data: $data);
+	}//end runDeferredWork()
 
 	/**
 	 * Extract policy-resolution metadata from the object payload.
@@ -144,20 +212,50 @@ class SlaObjectCreatedListener implements IEventListener {
 	}//end extractMetadata()
 
 	/**
+	 * Read the tracked object's current data.
+	 *
+	 * @param string $uuid Object UUID.
+	 * @param string $schemaId Schema identity the object lives in.
+	 *
+	 * @return array<string, mixed>|null Object data, or null when it is gone.
+	 */
+	private function fetch(string $uuid, string $schemaId): ?array {
+		$register = $this->appConfig->getValueString(Application::APP_ID, 'register', '');
+		if ($register === '') {
+			return null;
+		}
+
+		try {
+			$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
+			$object = $objectService->find(id: $uuid, register: $register, schema: $schemaId);
+			if ($object === null) {
+				return null;
+			}
+
+			return $object->getObject();
+		} catch (Throwable $e) {
+			$this->logger->warning(
+				'SlaObjectCreatedListener: re-read failed (non-blocking)',
+				['error' => $e->getMessage(), 'uuid' => $uuid]
+			);
+			return null;
+		}//end try
+	}//end fetch()
+
+	/**
 	 * Persist the mutated object data back to OpenRegister.
 	 *
 	 * Uses OR's `saveObject()` to atomically write the slaStatus
 	 * envelope. Failure is logged but never thrown (REQ-007).
 	 *
-	 * @param object $entity Object entity from the event.
+	 * @param string $uuid Object UUID.
+	 * @param string $schemaId Schema identity the object lives in.
 	 * @param array<string, mixed> $data Mutated data including slaStatus.
 	 *
 	 * @return void
 	 */
-	private function persist(object $entity, array $data): void {
+	private function persist(string $uuid, string $schemaId, array $data): void {
 		$register = $this->appConfig->getValueString(Application::APP_ID, 'register', '');
-		$schemaId = (string)$entity->getSchema();
-		$uuid = (string)$entity->getUuid();
 		if ($register === '' || $schemaId === '' || $uuid === '') {
 			return;
 		}
@@ -176,6 +274,6 @@ class SlaObjectCreatedListener implements IEventListener {
 				'SlaObjectCreatedListener: persist failed (non-blocking)',
 				['error' => $e->getMessage(), 'uuid' => $uuid]
 			);
-		}
+		}//end try
 	}//end persist()
 }//end class

--- a/lib/Listener/SlaObjectUpdatedListener.php
+++ b/lib/Listener/SlaObjectUpdatedListener.php
@@ -18,8 +18,6 @@
  * @link https://github.com/ConductionNL/pipelinq
  *
  * @spec openspec/specs/sla-engine-and-escalation/spec.md
- * @spec openspec/specs/sla-engine-and-escalation/spec.md
- * @spec openspec/specs/sla-engine-and-escalation/spec.md
  */
 
 declare(strict_types=1);
@@ -30,7 +28,9 @@ use DateTimeImmutable;
 use DateTimeInterface;
 use DateTimeZone;
 use OCA\OpenRegister\Event\ObjectUpdatedEvent;
+use OCA\OpenRegister\Service\Deferral\ListenerDeferralService;
 use OCA\Pipelinq\AppInfo\Application;
+use OCA\Pipelinq\BackgroundJob\DeferredObjectListenerJob;
 use OCA\Pipelinq\Service\SchemaMapService;
 use OCA\Pipelinq\Service\SlaEngineService;
 use OCP\EventDispatcher\Event;
@@ -44,13 +44,40 @@ use Throwable;
  * React to tracked-object updates: handle pause/resume, status
  * re-evaluation and escalation firing.
  *
+ * ADR-078: the update is already stored when this runs. Policy loading,
+ * target re-evaluation, escalation firing and the `slaStatus` write now
+ * happen in {@see DeferredObjectListenerJob} under the acting user rather than
+ * inside the update request.
+ *
+ * ⚠️ THIS LISTENER RE-ENTERS ITSELF, AND ONLY THE GUARD STOPS IT.
+ * It reacts to `ObjectUpdatedEvent` and unconditionally writes
+ * `slaStatus.lastEvaluatedAt = now` — a value that differs on every pass. Its
+ * own `persist()` therefore raises another `ObjectUpdatedEvent` carrying an
+ * object that satisfies every one of its entry conditions, with no idempotency
+ * check anywhere that can stop it. Inline, that recursed on one request's
+ * stack. Deferred, each turn would enqueue a fresh job, and since `cron.php`
+ * runs one job per web call, that job would starve every other job on the
+ * instance indefinitely.
+ *
+ * {@see DeferredWorkGuard} closes it: the deferred pass marks
+ * `(sla-object-updated, uuid)` in flight, the write it makes re-enters
+ * `handle()`, `handle()` sees the mark and returns without deferring.
+ *
  * @implements IEventListener<Event>
  *
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects) Bridges the SLA engine,
- *  schema map, OR ObjectService, app-config and logger — an irreducible
- *  set of collaborators for the update-time SLA lifecycle.
+ *  schema map, OR ObjectService, deferral service, app-config and logger — an
+ *  irreducible set of collaborators for the update-time SLA lifecycle.
  */
-class SlaObjectUpdatedListener implements IEventListener {
+class SlaObjectUpdatedListener implements IEventListener, DeferredObjectWork {
+
+	/**
+	 * Identifies this listener's entries in the deferral job.
+	 *
+	 * @var string
+	 */
+	public const HANDLER_KEY = 'sla-object-updated';
+
 	private const TRACKED_TYPES = ['request', 'complaint', 'complaint', 'callback'];
 
 	/**
@@ -69,6 +96,7 @@ class SlaObjectUpdatedListener implements IEventListener {
 	 * @param SchemaMapService $schemaMapService Schema → entity-type map.
 	 * @param ContainerInterface $container DI container.
 	 * @param IAppConfig $appConfig App config.
+	 * @param ListenerDeferralService $deferral The actor-forwarding deferral service.
 	 * @param LoggerInterface $logger PSR logger.
 	 */
 	public function __construct(
@@ -76,6 +104,7 @@ class SlaObjectUpdatedListener implements IEventListener {
 		private SchemaMapService $schemaMapService,
 		private ContainerInterface $container,
 		private IAppConfig $appConfig,
+		private ListenerDeferralService $deferral,
 		private LoggerInterface $logger,
 	) {
 	}//end __construct()
@@ -83,11 +112,12 @@ class SlaObjectUpdatedListener implements IEventListener {
 	/**
 	 * Handle a dispatched event.
 	 *
+	 * Does no SLA work: filters and queues the re-evaluation.
+	 *
 	 * @param Event $event The event.
 	 *
 	 * @return void
 	 *
-	 * @spec openspec/specs/sla-engine-and-escalation/spec.md
 	 * @spec openspec/specs/sla-engine-and-escalation/spec.md
 	 */
 	public function handle(Event $event): void {
@@ -97,52 +127,104 @@ class SlaObjectUpdatedListener implements IEventListener {
 
 		try {
 			$entity = $event->getNewObject();
-			$type = $this->schemaMapService->resolveEntityType($entity->getSchema());
+			$schemaId = (string)$entity->getSchema();
+			$type = $this->schemaMapService->resolveEntityType($schemaId);
 			if (in_array($type, self::TRACKED_TYPES, true) === false) {
 				return;
 			}
 
 			$data = $entity->getObject();
-			$slaStatus = $data['slaStatus'] ?? null;
+			$slaStatus = ($data['slaStatus'] ?? null);
 			if (is_array($slaStatus) === false || ($slaStatus['policyId'] ?? '') === '') {
 				return;
 			}
 
-			$policy = $this->loadPolicy(policyId: (string)$slaStatus['policyId']);
-			if ($policy === null) {
-				$this->logger->debug(
-					'SlaObjectUpdatedListener: policy not found',
-					['policyId' => $slaStatus['policyId']]
-				);
+			$uuid = (string)$entity->getUuid();
+			if ($uuid === '' || $schemaId === '') {
 				return;
 			}
 
-			$now = new DateTimeImmutable('now', new DateTimeZone('UTC'));
-			$status = (string)($data['status'] ?? '');
+			// See the class docblock — without this the deferred write re-enters
+			// here and enqueues a job that re-enters again, for ever.
+			if (DeferredWorkGuard::isRunning(key: DeferredWorkGuard::key(handler: self::HANDLER_KEY, uuid: $uuid)) === true) {
+				return;
+			}
 
-			$slaStatus = $this->applyPauseResume(slaStatus: $slaStatus, policy: $policy, status: $status, now: $now);
-			$slaStatus = $this->applyResolution(slaStatus: $slaStatus, status: $status, now: $now);
-
-			// Re-evaluate target statuses and fire escalations.
-			$slaStatus['targets'] = $this->engine->evaluateTargets($slaStatus['targets'] ?? [], $policy, $now);
-
-			$slaStatus = $this->applyEscalations(
-				slaStatus: $slaStatus,
-				type: $type,
-				entity: $entity,
-				policy: $policy,
+			$this->deferral->defer(
+				jobClass: DeferredObjectListenerJob::class,
+				entry: [
+					'handler' => self::HANDLER_KEY,
+					'uuid' => $uuid,
+					'schema' => $schemaId,
+					'type' => (string)$type,
+				],
+				dedupeKey: self::HANDLER_KEY . '|' . $uuid
 			);
-
-			$slaStatus['lastEvaluatedAt'] = $now->format(DateTimeInterface::ATOM);
-			$data['slaStatus'] = $slaStatus;
-			$this->persist(entity: $entity, data: $data);
 		} catch (Throwable $e) {
 			$this->logger->warning(
-				'SlaObjectUpdatedListener: SLA update failed (non-blocking)',
+				'SlaObjectUpdatedListener: SLA update could not be queued (non-blocking)',
 				['error' => $e->getMessage()]
 			);
 		}//end try
 	}//end handle()
+
+	/**
+	 * Re-evaluate the SLA envelope against the object's current state.
+	 *
+	 * @param array<string, mixed> $entry The entry captured at dispatch time.
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/specs/sla-engine-and-escalation/spec.md
+	 */
+	public function runDeferredWork(array $entry): void {
+		$uuid = (string)($entry['uuid'] ?? '');
+		$schemaId = (string)($entry['schema'] ?? '');
+		$type = (string)($entry['type'] ?? '');
+		if ($uuid === '' || $schemaId === '' || $type === '') {
+			return;
+		}
+
+		$data = $this->fetch(uuid: $uuid, schemaId: $schemaId);
+		if ($data === null) {
+			// Object gone since the update. Stale entry (ADR-078 Rule 7).
+			return;
+		}
+
+		$slaStatus = ($data['slaStatus'] ?? null);
+		if (is_array($slaStatus) === false || ($slaStatus['policyId'] ?? '') === '') {
+			return;
+		}
+
+		$policy = $this->loadPolicy(policyId: (string)$slaStatus['policyId']);
+		if ($policy === null) {
+			$this->logger->debug(
+				'SlaObjectUpdatedListener: policy not found',
+				['policyId' => $slaStatus['policyId']]
+			);
+			return;
+		}
+
+		$now = new DateTimeImmutable('now', new DateTimeZone('UTC'));
+		$status = (string)($data['status'] ?? '');
+
+		$slaStatus = $this->applyPauseResume(slaStatus: $slaStatus, policy: $policy, status: $status, now: $now);
+		$slaStatus = $this->applyResolution(slaStatus: $slaStatus, status: $status, now: $now);
+
+		// Re-evaluate target statuses and fire escalations.
+		$slaStatus['targets'] = $this->engine->evaluateTargets(($slaStatus['targets'] ?? []), $policy, $now);
+
+		$slaStatus = $this->applyEscalations(
+			slaStatus: $slaStatus,
+			type: $type,
+			uuid: $uuid,
+			policy: $policy,
+		);
+
+		$slaStatus['lastEvaluatedAt'] = $now->format(DateTimeInterface::ATOM);
+		$data['slaStatus'] = $slaStatus;
+		$this->persist(uuid: $uuid, schemaId: $schemaId, data: $data);
+	}//end runDeferredWork()
 
 	/**
 	 * Fire due escalations for an unpaused timer and merge breach-event IDs.
@@ -151,7 +233,7 @@ class SlaObjectUpdatedListener implements IEventListener {
 	 *
 	 * @param array<string, mixed> $slaStatus Current slaStatus.
 	 * @param string $type Resolved entity type.
-	 * @param object $entity Object entity from the event.
+	 * @param string $uuid UUID of the tracked object.
 	 * @param array<string, mixed> $policy Policy.
 	 *
 	 * @return array<string, mixed> Updated slaStatus.
@@ -159,7 +241,7 @@ class SlaObjectUpdatedListener implements IEventListener {
 	private function applyEscalations(
 		array $slaStatus,
 		string $type,
-		object $entity,
+		string $uuid,
 		array $policy,
 	): array {
 		if (($slaStatus['pausedAt'] ?? null) !== null) {
@@ -174,8 +256,8 @@ class SlaObjectUpdatedListener implements IEventListener {
 
 		$result = $this->engine->executeEscalations(
 			$policy,
-			(string)$matchType,
-			(string)$entity->getUuid(),
+			$matchType,
+			$uuid,
 			$slaStatus['targets'],
 			$slaStatus['targets'],
 			$alreadyFired,
@@ -282,17 +364,47 @@ class SlaObjectUpdatedListener implements IEventListener {
 	}//end loadPolicy()
 
 	/**
+	 * Read the tracked object's current data.
+	 *
+	 * @param string $uuid Object UUID.
+	 * @param string $schemaId Schema identity the object lives in.
+	 *
+	 * @return array<string, mixed>|null Object data, or null when it is gone.
+	 */
+	private function fetch(string $uuid, string $schemaId): ?array {
+		$register = $this->appConfig->getValueString(Application::APP_ID, 'register', '');
+		if ($register === '') {
+			return null;
+		}
+
+		try {
+			$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
+			$object = $objectService->find(id: $uuid, register: $register, schema: $schemaId);
+			if ($object === null) {
+				return null;
+			}
+
+			return $object->getObject();
+		} catch (Throwable $e) {
+			$this->logger->warning(
+				'SlaObjectUpdatedListener: re-read failed (non-blocking)',
+				['error' => $e->getMessage(), 'uuid' => $uuid]
+			);
+			return null;
+		}//end try
+	}//end fetch()
+
+	/**
 	 * Persist the mutated object data back to OpenRegister.
 	 *
-	 * @param object $entity Object entity from the event.
+	 * @param string $uuid Object UUID.
+	 * @param string $schemaId Schema identity the object lives in.
 	 * @param array<string, mixed> $data Mutated data including slaStatus.
 	 *
 	 * @return void
 	 */
-	private function persist(object $entity, array $data): void {
+	private function persist(string $uuid, string $schemaId, array $data): void {
 		$register = $this->appConfig->getValueString(Application::APP_ID, 'register', '');
-		$schemaId = (string)$entity->getSchema();
-		$uuid = (string)$entity->getUuid();
 		if ($register === '' || $schemaId === '' || $uuid === '') {
 			return;
 		}
@@ -311,6 +423,6 @@ class SlaObjectUpdatedListener implements IEventListener {
 				'SlaObjectUpdatedListener: persist failed (non-blocking)',
 				['error' => $e->getMessage(), 'uuid' => $uuid]
 			);
-		}
+		}//end try
 	}//end persist()
 }//end class

--- a/openspec/specs/event-listener-work-placement/spec.md
+++ b/openspec/specs/event-listener-work-placement/spec.md
@@ -1,0 +1,127 @@
+---
+status: done
+---
+
+# event-listener-work-placement Specification
+
+## Purpose
+Places the work pipelinq's OpenRegister object-lifecycle listeners do according to what the event can still influence (ADR-078). Pre-`*ing` events may veto or mutate and stay synchronous; post-`*ed` events cannot change the write they observe, so their work is queued onto an actor-forwarded background job instead of being charged to the user's request. Covers the shared job, the handler allow-list, the acting-user contract, the reconcile-against-current-state rule, and the process-wide guard that stops a listener's own write from re-entering it and re-queuing itself for ever.
+
+@e2e exclude backend work placement — a listener queueing instead of writing has no browser surface; the observable behaviour (queued entry, job effect, no request-path write, no re-queue loop) is asserted by PHPUnit in tests/Unit/Listener and tests/Integration/ExpenseApSyncTest.php
+
+## Requirements
+
+### Requirement: Deferred post-event work runs in one actor-forwarded job
+
+Every pipelinq listener registered on `ObjectCreatedEvent` or `ObjectUpdatedEvent`
+that performs outbound I/O, a write, or an unbounded query MUST implement
+`OCA\Pipelinq\Listener\DeferredObjectWork` and MUST NOT do that work inside
+`handle()`.
+
+`handle()` MAY only: reject events of the wrong type, resolve the entity's
+schema through `SchemaMapService`, evaluate short-circuits that are answerable
+from the event payload alone, and call
+`ListenerDeferralService::defer()` with
+`DeferredObjectListenerJob::class` and an entry carrying at minimum
+`handler` (the listener's `HANDLER_KEY`) and `uuid`. An entry MAY carry
+additional scalars that a later read cannot reconstruct — the previous object
+state for a compensating correction, or the old/new status pair a ledger event
+must report. It MUST NOT carry the object body as the source of truth.
+
+`DeferredObjectListenerJob::runDeferred(DeferredListenerContext $context): void`
+MUST, for each entry:
+
+- resolve `handler` against a **hardcoded allow-list** of the app's own
+  listeners and log-and-skip an unknown key. A class name taken from a persisted
+  job row and passed to the container would be an instantiate-anything
+  primitive;
+- log-and-skip when the resolved service does not implement
+  `DeferredObjectWork`;
+- claim `DeferredWorkGuard::key(handler, uuid)` and skip the entry entirely when
+  the claim fails;
+- call `runDeferredWork($entry)` and release the claim in a `finally`;
+- catch `Throwable` per entry, log it, and continue — the same blast radius the
+  inline listeners had, and never a rethrow into cron.
+
+The job extends `OCA\OpenRegister\BackgroundJob\ActorForwardedJob`, so the user
+who performed the write is re-established for the duration of the work
+(ADR-078 Rule 6) and the job is a one-shot `QueuedJob` that is removed from the
+job list once it has run.
+
+#### Scenario: an approval queues instead of dispatching
+
+- **GIVEN** an expense whose `status` becomes `approved` and whose AP webhook is configured
+- **WHEN** `ExpenseApprovalListener::handle()` runs
+- **THEN** exactly one entry is deferred to `DeferredObjectListenerJob`
+- **AND** no domain event is emitted, no object is written and no outbound webhook is sent during the request
+
+#### Scenario: the queued entry does the work
+
+- **WHEN** the job runs that entry
+- **THEN** the domain event is emitted, `apSyncStatus` goes `pending` then `synced`, and exactly one CloudEvent envelope is dispatched
+
+#### Scenario: an unknown handler key is dropped, not resolved
+
+- **GIVEN** a job entry whose `handler` is not in the allow-list
+- **WHEN** the job runs
+- **THEN** a warning is logged and no service is resolved from the container
+
+### Requirement: Deferred work reconciles against current state
+
+`runDeferredWork()` MUST re-read the object it acts on rather than trusting the
+payload captured at dispatch time. Delivery is at-least-once and ordering
+against the write is not guaranteed (ADR-078 Rule 7).
+
+An object that no longer resolves MUST be treated as a stale no-op — logged at
+most, never an error. Every condition that decided to queue the work
+(status still approved, sync status not already `synced`, integration still
+configured, SLA envelope still unarmed) MUST be re-evaluated against the re-read
+state before acting.
+
+Where the deferred work is a **compensating correction** rather than a
+projection — `DealUpdatedListener` reverting a rejected `forecast_category`
+transition — the decision MUST be re-taken, not replayed. Replaying a captured
+revert would overwrite a value someone has since corrected.
+
+#### Scenario: a deleted object is a stale no-op
+
+- **GIVEN** a queued entry whose object has been deleted before the job runs
+- **WHEN** the job runs
+- **THEN** nothing is written, nothing is dispatched, and the job completes normally
+
+#### Scenario: a rejected transition already fixed is left alone
+
+- **GIVEN** a deal whose invalid `forecast_category` has been corrected by another path since the update
+- **WHEN** the deferred correction runs
+- **THEN** `validateTransition()` re-run against the CURRENT value returns no error and no write is made
+
+### Requirement: A listener's own write must not re-queue it
+
+`DeferredWorkGuard` holds a process-wide claim on `<handler>|<uuid>` for the
+duration of the deferred work. Every converted listener MUST test
+`DeferredWorkGuard::isRunning()` for its own `(HANDLER_KEY, uuid)` pair before
+calling `defer()`, and MUST return without deferring when the claim is held.
+
+This is load-bearing, not defensive. `ObjectService::saveObject()` causes
+`MagicMapper::update()` to dispatch `ObjectUpdatedEvent`, which re-enters the
+same listeners with an object that satisfies their entry conditions —
+`SlaObjectUpdatedListener` writes `slaStatus.lastEvaluatedAt = now` on every
+pass and has no idempotency check that could stop it, and
+`ExpenseApprovalListener`'s `apSyncStatus === 'synced'` check cannot stop it
+because the re-entry sees the `pending` value the deferred pass has just
+written. Inline, that recursed on one request's stack. Without the guard, the
+deferred form enqueues a fresh job on every turn, and since `cron.php` runs one
+job per web call, that job starves every other job on the instance.
+
+`leave()` MUST be called from a `finally`. The claim is deliberately static:
+Nextcloud resolves a listener from the container per dispatch, so a re-entrant
+dispatch is not guaranteed to reach the same instance, and the process context
+is torn down per request and per cron job.
+
+#### Scenario: the deferred write re-enters the listener exactly once and stops
+
+- **GIVEN** an approved expense and an object service that dispatches `ObjectUpdatedEvent` for every write, as the mapper does
+- **WHEN** the job runs the deferred AP dispatch
+- **THEN** the outbound AP webhook is sent exactly once
+- **AND** the terminating `synced` write is reached
+- **AND** no further entry is queued

--- a/psalm.xml
+++ b/psalm.xml
@@ -75,6 +75,15 @@
                 <referencedClass name="OCA\OpenRegister\Service\FileService"/>
                 <referencedClass name="OCA\OpenRegister\Service\CalendarEventService"/>
                 <referencedClass name="OCA\OpenRegister\Mcp\IMcpToolProvider"/>
+                <!-- ADR-078 actor-forwarded deferral contract (gate-61). The seven
+                     converted post-event listeners hand their work to
+                     DeferredObjectListenerJob through ListenerDeferralService instead
+                     of running it inside the user's write; all three types live in
+                     OpenRegister and resolve at runtime, exactly like ObjectService. -->
+                <referencedClass name="OCA\OpenRegister\Service\Deferral\ListenerDeferralService"/>
+                <referencedClass name="OCA\OpenRegister\Service\Deferral\DeferredListenerContext"/>
+                <referencedClass name="OCA\OpenRegister\Service\OrganisationService"/>
+                <referencedClass name="OCA\OpenRegister\BackgroundJob\ActorForwardedJob"/>
                 <!-- OpenRegister AVG/DSAR integration seams (ADR-047 Phase-3) -->
                 <referencedClass name="OCA\OpenRegister\Service\Gdpr\Identity\IdentityVerifyProvider"/>
                 <referencedClass name="OCA\OpenRegister\Service\Gdpr\Identity\IdentityVerifyResult"/>

--- a/tests/Integration/ExpenseApSyncTest.php
+++ b/tests/Integration/ExpenseApSyncTest.php
@@ -93,9 +93,42 @@ class IntegrationFakeObjectService {
 	public function saveObject($object, array $extend = [], string $register = '', string $schema = '', ?string $uuid = null): array {
 		$data = (array)$object;
 		$this->saved[(string)$uuid] = $data;
+		$this->stored[(string)$uuid] = $data;
 		$this->trail[] = ['uuid' => (string)$uuid, 'data' => $data];
 		return $data;
 	}//end saveObject()
+
+	/**
+	 * Objects readable by find(), keyed by uuid.
+	 *
+	 * ADR-078: the AP dispatch runs in a background job now, and the job
+	 * re-reads the expense rather than trusting the dispatch-time payload, so
+	 * the fake has to be able to serve that read.
+	 *
+	 * @var array<string, array<string, mixed>>
+	 */
+	public array $stored = [];
+
+	/**
+	 * Serve the deferred pass's re-read of current state.
+	 *
+	 * @param string $id The object uuid.
+	 * @param string $register The register id.
+	 * @param string $schema The schema id.
+	 *
+	 * @return ObjectEntity|null
+	 */
+	public function find(string $id, string $register = '', string $schema = ''): ?ObjectEntity {
+		if (isset($this->stored[$id]) === false) {
+			return null;
+		}
+
+		$entity = new ObjectEntity();
+		$entity->setUuid($id);
+		$entity->setSchema($schema);
+		$entity->setObject($this->stored[$id]);
+		return $entity;
+	}//end find()
 }//end class
 
 /**
@@ -220,6 +253,24 @@ class IntegrationFakeEventDispatcher implements IEventDispatcher {
  * Integration tests for the expense-approval -> Shillinq AP flow.
  */
 class ExpenseApSyncTest extends TestCase {
+
+	/**
+	 * The deferral recorder the last-built listener was wired with.
+	 *
+	 * @var \OCA\Pipelinq\Tests\Unit\Listener\RecordingDeferralService|null
+	 */
+	private ?\OCA\Pipelinq\Tests\Unit\Listener\RecordingDeferralService $deferral = null;
+
+	/**
+	 * Clear the shared re-entrancy guard between tests.
+	 *
+	 * @return void
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+		\OCA\Pipelinq\Listener\DeferredWorkGuard::reset();
+	}//end setUp()
+
 	/**
 	 * Build an ObjectEntity double for the expense schema with the given data.
 	 *
@@ -297,6 +348,8 @@ class ExpenseApSyncTest extends TestCase {
 		$schemaMap = $this->createMock(SchemaMapService::class);
 		$schemaMap->method('resolveEntityType')->willReturn('expense');
 
+		$this->deferral = new \OCA\Pipelinq\Tests\Unit\Listener\RecordingDeferralService();
+
 		return new ExpenseApprovalListener(
 			schemaMapService: $schemaMap,
 			apService: $apService,
@@ -304,9 +357,28 @@ class ExpenseApSyncTest extends TestCase {
 			eventDispatcher: $dispatcher,
 			container: $container,
 			appConfig: $appConfig,
+			deferral: $this->deferral,
 			logger: $logger,
 		);
 	}//end buildListener()
+
+	/**
+	 * Run whatever the listener queued, through the real background job.
+	 *
+	 * ADR-078 moved the AP dispatch off the approval request. The end-to-end
+	 * flow this file asserts is therefore approval -> queued entry -> job ->
+	 * domain event + pending + CloudEvent + synced; running the job is part of
+	 * the flow, not a test convenience.
+	 *
+	 * @param ExpenseApprovalListener $listener The listener under test.
+	 *
+	 * @return void
+	 */
+	private function runQueuedWork(ExpenseApprovalListener $listener): void {
+		if ($this->deferral !== null) {
+			\OCA\Pipelinq\Tests\Unit\Listener\DeferredJobDrain::run($this, $this->deferral, $listener);
+		}
+	}//end runQueuedWork()
 
 	/**
 	 * Successful flow: approval -> domain event -> pending -> CloudEvent dispatch -> synced.
@@ -320,7 +392,7 @@ class ExpenseApSyncTest extends TestCase {
 
 		$listener = $this->buildListener($objects, $webhooks, $dispatcher);
 
-		$listener->handle(new ObjectCreatedEvent($this->expenseEntity([
+		$expense = [
 			'uuid' => 'exp-int-1',
 			'title' => 'Hotel Den Haag',
 			'amount' => 185.50,
@@ -332,7 +404,19 @@ class ExpenseApSyncTest extends TestCase {
 			'status' => 'approved',
 			'approvedBy' => 'alice',
 			'approvedAt' => '2026-05-15T14:30:00Z',
-		])));
+		];
+		$objects->stored['exp-int-1'] = $expense;
+
+		$listener->handle(new ObjectCreatedEvent($this->expenseEntity($expense)));
+
+		// 0. ADR-078: the approval request itself does NOTHING but queue. No
+		//    domain event, no write, no outbound CloudEvent on the user's write.
+		$this->assertCount(1, $this->deferral->entries, 'The approval MUST queue exactly one entry.');
+		$this->assertCount(0, $dispatcher->dispatched, 'No domain event on the request path.');
+		$this->assertCount(0, $objects->saved, 'No write on the request path.');
+		$this->assertCount(0, $webhooks->dispatched, 'No outbound webhook on the request path.');
+
+		$this->runQueuedWork($listener);
 
 		// 1. Domain ExpenseApprovedEvent was fanned out (REQ-AP-002 consumer contract).
 		$this->assertCount(1, $dispatcher->dispatched, 'ExpenseApprovedEvent MUST fan out exactly once.');
@@ -402,7 +486,9 @@ class ExpenseApSyncTest extends TestCase {
 				'amount' => 100.0,
 			])
 		));
+		$this->runQueuedWork($listener);
 
+		$this->assertCount(0, $this->deferral->entries, 'Replay MUST NOT queue any work.');
 		$this->assertCount(0, $webhooks->dispatched, 'Replay MUST NOT dispatch a duplicate AP voucher.');
 		$this->assertCount(0, $objects->saved, 'Replay MUST NOT mutate the synced expense.');
 		$this->assertCount(0, $dispatcher->dispatched, 'Replay MUST NOT re-emit the domain event.');
@@ -426,14 +512,18 @@ class ExpenseApSyncTest extends TestCase {
 
 		$listener = $this->buildListener($objects, $webhooks, $dispatcher, $notifier);
 
-		$listener->handle(new ObjectCreatedEvent($this->expenseEntity([
+		$expense = [
 			'uuid' => 'exp-int-3',
 			'title' => 'Catering',
 			'amount' => 78.30,
 			'status' => 'approved',
 			'approvedBy' => 'bob',
 			'approvedAt' => '2026-05-10T11:20:00Z',
-		])));
+		];
+		$objects->stored['exp-int-3'] = $expense;
+
+		$listener->handle(new ObjectCreatedEvent($this->expenseEntity($expense)));
+		$this->runQueuedWork($listener);
 
 		$this->assertSame('failed', $objects->saved['exp-int-3']['apSyncStatus']);
 		$this->assertArrayNotHasKey(
@@ -463,7 +553,9 @@ class ExpenseApSyncTest extends TestCase {
 			'approvedBy' => 'carol',
 			'approvedAt' => '2026-05-11T09:00:00Z',
 		])));
+		$this->runQueuedWork($listener);
 
+		$this->assertCount(0, $this->deferral->entries);
 		$this->assertCount(0, $webhooks->dispatched);
 		$this->assertCount(0, $objects->saved);
 		$this->assertCount(0, $dispatcher->dispatched);

--- a/tests/Stubs/BackgroundJob/ActorForwardedJob.php
+++ b/tests/Stubs/BackgroundJob/ActorForwardedJob.php
@@ -1,0 +1,110 @@
+<?php
+
+/**
+ * Test stub for OCA\OpenRegister\BackgroundJob\ActorForwardedJob.
+ *
+ * Mirrors the real abstract base
+ * (openregister/lib/BackgroundJob/ActorForwardedJob.php): the same constructor
+ * parameter list, the same `protected abstract runDeferred()` contract, and the
+ * same `protected readonly LoggerInterface $logger` that subclasses use.
+ *
+ * `run()` is deliberately NOT re-implemented — the real base re-establishes the
+ * acting user and restores it in a `finally`. Tests here call `runDeferred()`
+ * directly, which is the method this app actually writes.
+ *
+ * @category Test
+ * @package  OCA\Pipelinq\Tests\Stubs\BackgroundJob
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\BackgroundJob;
+
+use OCA\OpenRegister\Service\Deferral\DeferredListenerContext;
+use OCA\OpenRegister\Service\OrganisationService;
+use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\BackgroundJob\QueuedJob;
+use OCP\IUserManager;
+use OCP\IUserSession;
+use Psr\Log\LoggerInterface;
+
+if (class_exists(ActorForwardedJob::class) === false) {
+	/**
+	 * Stub base for ActorForwardedJob — used only in standalone unit tests.
+	 */
+	abstract class ActorForwardedJob extends QueuedJob {
+
+		/**
+		 * Wire the identity plumbing shared by all actor-forwarded jobs.
+		 *
+		 * @param ITimeFactory $time Time factory for the parent job class.
+		 * @param IUserSession $userSession Session to impersonate on / restore.
+		 * @param IUserManager $userManager Resolver for the captured user id.
+		 * @param OrganisationService $organisation Active-organisation resolver.
+		 * @param LoggerInterface $logger PSR logger shared with subclasses.
+		 *
+		 * @return void
+		 */
+		public function __construct(
+			ITimeFactory $time,
+			private readonly IUserSession $userSession,
+			private readonly IUserManager $userManager,
+			private readonly OrganisationService $organisation,
+			protected readonly LoggerInterface $logger,
+		) {
+			parent::__construct(time: $time);
+		}//end __construct()
+
+		/**
+		 * Re-establish the captured actor, run the deferred work, restore.
+		 *
+		 * Mirrors the real base's identity rules: a captured user that no longer
+		 * resolves SKIPS the work rather than running it under whatever identity
+		 * the worker holds, and the previous user is restored in a `finally` so a
+		 * cron process never carries one job's identity into the next.
+		 *
+		 * @param array<string, mixed> $argument Serialized DeferredListenerContext.
+		 *
+		 * @return void
+		 */
+		protected function run($argument): void {
+			$context = DeferredListenerContext::fromJobArguments($argument);
+			if (count($context->getEntries()) === 0) {
+				return;
+			}
+
+			$userId = $context->getUserId();
+			$user = null;
+			if ($userId !== null) {
+				$user = $this->userManager->get($userId);
+				if ($user === null) {
+					return;
+				}
+			}
+
+			$previousUser = $this->userSession->getUser();
+			if ($user !== null) {
+				$this->userSession->setUser($user);
+			}
+
+			try {
+				$this->runDeferred(context: $context);
+			} finally {
+				$this->userSession->setUser($previousUser);
+			}
+		}//end run()
+
+		/**
+		 * The deferred listener work, executed under the re-established actor.
+		 *
+		 * @param DeferredListenerContext $context The captured dispatch-time context.
+		 *
+		 * @return void
+		 */
+		abstract protected function runDeferred(DeferredListenerContext $context): void;
+	}
+}

--- a/tests/Stubs/Service/Deferral/DeferredListenerContext.php
+++ b/tests/Stubs/Service/Deferral/DeferredListenerContext.php
@@ -1,0 +1,115 @@
+<?php
+
+/**
+ * Test stub for OCA\OpenRegister\Service\Deferral\DeferredListenerContext.
+ *
+ * Mirrors the real value object's public surface
+ * (openregister/lib/Service/Deferral/DeferredListenerContext.php) so tests can
+ * construct a real instance and hand it to a job's runDeferred().
+ *
+ * NOTE: the real class is `final`. The stub is not, because PHPUnit cannot mock
+ * a final class — but nothing in this app subclasses it, and the constructor
+ * plus the four accessors are byte-identical to the real ones, so a test that
+ * passes here passes against the real class.
+ *
+ * @category Test
+ * @package  OCA\Pipelinq\Tests\Stubs\Service\Deferral
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Service\Deferral;
+
+if (class_exists(DeferredListenerContext::class) === false) {
+	/**
+	 * Stub class for DeferredListenerContext — used only in standalone unit tests.
+	 */
+	class DeferredListenerContext {
+
+		/**
+		 * Wrap a captured acting context.
+		 *
+		 * @param string|null $userId Acting user id at dispatch time.
+		 * @param string|null $orgUuid Active organisation uuid at dispatch time.
+		 * @param array<int, array<string, mixed>> $entries Per-object entries.
+		 *
+		 * @return void
+		 */
+		public function __construct(
+			private readonly ?string $userId = null,
+			private readonly ?string $orgUuid = null,
+			private readonly array $entries = [],
+		) {
+		}//end __construct()
+
+		/**
+		 * The acting user id captured at dispatch time.
+		 *
+		 * @return string|null
+		 */
+		public function getUserId(): ?string {
+			return $this->userId;
+		}//end getUserId()
+
+		/**
+		 * The active organisation uuid captured at dispatch time.
+		 *
+		 * @return string|null
+		 */
+		public function getOrganisationUuid(): ?string {
+			return $this->orgUuid;
+		}//end getOrganisationUuid()
+
+		/**
+		 * The per-object entries the job must process.
+		 *
+		 * @return array<int, array<string, mixed>>
+		 */
+		public function getEntries(): array {
+			return $this->entries;
+		}//end getEntries()
+
+		/**
+		 * Serialize to the array shape stored in `oc_jobs.argument`.
+		 *
+		 * @return array<string, mixed>
+		 */
+		public function toJobArguments(): array {
+			return [
+				'userId' => $this->userId,
+				'organisationUuid' => $this->orgUuid,
+				'entries' => array_values($this->entries),
+			];
+		}//end toJobArguments()
+
+		/**
+		 * Rebuild a context from a job's argument payload.
+		 *
+		 * @param mixed $argument Raw job argument.
+		 *
+		 * @return self
+		 */
+		public static function fromJobArguments(mixed $argument): self {
+			if (is_array($argument) === false) {
+				return new self(userId: null, orgUuid: null, entries: []);
+			}
+
+			$entries = [];
+			foreach (($argument['entries'] ?? []) as $rawEntry) {
+				if (is_array($rawEntry) === true) {
+					$entries[] = $rawEntry;
+				}
+			}
+
+			return new self(
+				userId: ($argument['userId'] ?? null),
+				orgUuid: ($argument['organisationUuid'] ?? null),
+				entries: $entries
+			);
+		}//end fromJobArguments()
+	}
+}

--- a/tests/Stubs/Service/Deferral/ListenerDeferralService.php
+++ b/tests/Stubs/Service/Deferral/ListenerDeferralService.php
@@ -1,0 +1,90 @@
+<?php
+
+/**
+ * Test stub for OCA\OpenRegister\Service\Deferral\ListenerDeferralService.
+ *
+ * The method surface mirrors the real class
+ * (openregister/lib/Service/Deferral/ListenerDeferralService.php) exactly —
+ * parameter names, order, types and defaults. A stub whose signature drifts
+ * from the class it stands in for produces tests that pass against a shape
+ * nobody ships.
+ *
+ * Loaded via Composer's autoload-dev PSR-4 mapping
+ * ("OCA\\OpenRegister\\" => "tests/Stubs/"); a no-op when the real openregister
+ * app is present (class_exists guard).
+ *
+ * @category Test
+ * @package  OCA\Pipelinq\Tests\Stubs\Service\Deferral
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Service\Deferral;
+
+if (class_exists(ListenerDeferralService::class) === false) {
+	/**
+	 * Stub class for ListenerDeferralService — used only in standalone unit tests.
+	 */
+	class ListenerDeferralService {
+
+		/**
+		 * Kill-switch value that restores synchronous listener execution.
+		 *
+		 * @var string
+		 */
+		public const MODE_INLINE = 'inline';
+
+		/**
+		 * Default deferral mode.
+		 *
+		 * @var string
+		 */
+		public const MODE_BACKGROUND = 'background';
+
+		/**
+		 * Default number of entries per enqueued job.
+		 *
+		 * @var integer
+		 */
+		public const DEFAULT_CHUNK_SIZE = 100;
+
+		/**
+		 * Whether deferral is enabled on this instance.
+		 *
+		 * @return bool
+		 */
+		public function isDeferralEnabled(): bool {
+			return true;
+		}//end isDeferralEnabled()
+
+		/**
+		 * Buffer one entry for a job class.
+		 *
+		 * @param string $jobClass FQCN of the ActorForwardedJob subclass.
+		 * @param array<string, mixed> $entry Entry payload.
+		 * @param int $chunkSize Maximum entries per enqueued job.
+		 * @param string|null $dedupeKey Optional coalescing key.
+		 *
+		 * @return void
+		 */
+		public function defer(
+			string $jobClass,
+			array $entry,
+			int $chunkSize = self::DEFAULT_CHUNK_SIZE,
+			?string $dedupeKey = null,
+		): void {
+		}//end defer()
+
+		/**
+		 * Flush every remaining buffer to the job list.
+		 *
+		 * @return void
+		 */
+		public function flushAll(): void {
+		}//end flushAll()
+	}
+}

--- a/tests/Unit/Listener/DeferredJobDrain.php
+++ b/tests/Unit/Listener/DeferredJobDrain.php
@@ -1,0 +1,98 @@
+<?php
+
+/**
+ * Test helper: run recorded deferrals through the REAL background job.
+ *
+ * @category Test
+ * @package  OCA\Pipelinq\Tests\Unit\Listener
+ *
+ * @author    Conduction <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://github.com/ConductionNL/pipelinq
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Pipelinq\Tests\Unit\Listener;
+
+use OCA\OpenRegister\Service\Deferral\DeferredListenerContext;
+use OCA\OpenRegister\Service\OrganisationService;
+use OCA\Pipelinq\BackgroundJob\DeferredObjectListenerJob;
+use OCA\Pipelinq\Listener\DeferredObjectWork;
+use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\IUserManager;
+use OCP\IUserSession;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Drains a {@see RecordingDeferralService} through {@see DeferredObjectListenerJob}.
+ *
+ * WHY THE REAL JOB AND NOT A DIRECT CALL TO runDeferredWork(): the job carries
+ * the handler allow-list AND the {@see \OCA\Pipelinq\Listener\DeferredWorkGuard}
+ * claim that stops a listener's own write from re-entering it and enqueueing
+ * another job. A test that called `runDeferredWork()` directly would run the
+ * work with the guard NOT held — the one condition production never has — and
+ * would report success for a listener whose deferral loops forever in cron.
+ */
+final class DeferredJobDrain {
+
+	/**
+	 * Run every recorded entry through the real job.
+	 *
+	 * @param TestCase $test The calling test (for building mocks).
+	 * @param RecordingDeferralService $deferral The recorder holding the entries.
+	 * @param DeferredObjectWork $listener The listener the entries belong to.
+	 *
+	 * @return void
+	 */
+	public static function run(
+		TestCase $test,
+		RecordingDeferralService $deferral,
+		DeferredObjectWork $listener,
+	): void {
+		$entries = $deferral->entries;
+		if ($entries === []) {
+			return;
+		}
+
+		$container = $test->getMockBuilder(ContainerInterface::class)->getMock();
+		$container->method('get')->willReturnCallback(
+			static function (string $id) use ($listener): object {
+				if ($id === $listener::class) {
+					return $listener;
+				}
+
+				throw new \RuntimeException('unexpected service ' . $id);
+			}
+		);
+
+		$job = new DeferredObjectListenerJob(
+			$test->getMockBuilder(ITimeFactory::class)->getMock(),
+			$test->getMockBuilder(IUserSession::class)->getMock(),
+			$test->getMockBuilder(IUserManager::class)->getMock(),
+			$test->getMockBuilder(OrganisationService::class)->disableOriginalConstructor()->getMock(),
+			$test->getMockBuilder(LoggerInterface::class)->getMock(),
+			$container,
+		);
+
+		// The entries are consumed, so a listener that queues MORE work from
+		// inside the deferred pass (the loop this design forbids) shows up as a
+		// growing list rather than silently recursing here.
+		$deferral->entries = [];
+
+		$context = new DeferredListenerContext(userId: 'tester', orgUuid: null, entries: $entries);
+
+		$run = new \ReflectionMethod(DeferredObjectListenerJob::class, 'runDeferred');
+		$run->setAccessible(true);
+		$run->invoke($job, $context);
+	}//end run()
+}//end class

--- a/tests/Unit/Listener/ExpenseApprovalListenerTest.php
+++ b/tests/Unit/Listener/ExpenseApprovalListenerTest.php
@@ -66,8 +66,37 @@ class ApFakeObjectService {
 	 */
 	public function saveObject($object, array $extend = [], string $register = '', string $schema = '', ?string $uuid = null): array {
 		$this->saved[(string)$uuid] = (array)$object;
+		$this->stored[(string)$uuid] = (array)$object;
 		return (array)$object;
 	}//end saveObject()
+
+	/**
+	 * Objects readable by find(), keyed by uuid.
+	 *
+	 * @var array<string, array<string, mixed>>
+	 */
+	public array $stored = [];
+
+	/**
+	 * Serve the deferred pass's re-read of current state.
+	 *
+	 * @param string $id The object uuid.
+	 * @param string $register The register id.
+	 * @param string $schema The schema id.
+	 *
+	 * @return ObjectEntity|null
+	 */
+	public function find(string $id, string $register = '', string $schema = ''): ?ObjectEntity {
+		if (isset($this->stored[$id]) === false) {
+			return null;
+		}
+
+		$entity = new ObjectEntity();
+		$entity->setUuid($id);
+		$entity->setSchema($schema);
+		$entity->setObject($this->stored[$id]);
+		return $entity;
+	}//end find()
 }//end class
 
 /**
@@ -145,6 +174,24 @@ class ReDispatchingApFakeObjectService extends ApFakeObjectService {
  * Tests for ExpenseApprovalListener.
  */
 class ExpenseApprovalListenerTest extends TestCase {
+
+	/**
+	 * The deferral double the last-built listener was wired with.
+	 *
+	 * @var RecordingDeferralService|null
+	 */
+	private ?RecordingDeferralService $deferral = null;
+
+	/**
+	 * Clear the shared re-entrancy guard between tests.
+	 *
+	 * @return void
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+		\OCA\Pipelinq\Listener\DeferredWorkGuard::reset();
+	}//end setUp()
+
 	/**
 	 * Build an ObjectEntity double for the given schema and data.
 	 *
@@ -205,6 +252,8 @@ class ExpenseApprovalListenerTest extends TestCase {
 			}
 		);
 
+		$this->deferral = new RecordingDeferralService();
+
 		return new ExpenseApprovalListener(
 			schemaMapService: $schemaMap,
 			apService: $apService,
@@ -212,9 +261,23 @@ class ExpenseApprovalListenerTest extends TestCase {
 			eventDispatcher: $this->createMock(IEventDispatcher::class),
 			container: $container,
 			appConfig: $appConfig,
+			deferral: $this->deferral,
 			logger: $this->createMock(LoggerInterface::class),
 		);
 	}//end listener()
+
+	/**
+	 * Run every entry the listener queued, through the real background job.
+	 *
+	 * @param ExpenseApprovalListener $listener The listener under test.
+	 *
+	 * @return void
+	 */
+	private function drain(ExpenseApprovalListener $listener): void {
+		if ($this->deferral !== null) {
+			DeferredJobDrain::run($this, $this->deferral, $listener);
+		}
+	}//end drain()
 
 	/**
 	 * A non-ObjectCreatedEvent / ObjectUpdatedEvent is ignored.
@@ -307,17 +370,26 @@ class ExpenseApprovalListenerTest extends TestCase {
 		$apService->method('dispatchApEvent')->willReturn(true);
 		$apService->method('now')->willReturn('2026-05-15T14:35:00Z');
 
-		$objects = new ApFakeObjectService();
-		$listener = $this->listener($schemaMap, $apService, $objects);
-
-		$listener->handle(new ObjectCreatedEvent($this->entity('schema-expense', [
+		$expense = [
 			'uuid' => 'exp-1',
 			'title' => 'Hotel',
 			'amount' => 185.50,
 			'status' => 'approved',
 			'approvedBy' => 'alice',
 			'approvedAt' => '2026-05-15T14:30:00Z',
-		])));
+		];
+
+		$objects = new ApFakeObjectService();
+		$objects->stored['exp-1'] = $expense;
+		$listener = $this->listener($schemaMap, $apService, $objects);
+
+		$listener->handle(new ObjectCreatedEvent($this->entity('schema-expense', $expense)));
+
+		// ADR-078: nothing written and nothing dispatched on the request.
+		$this->assertCount(1, $this->deferral->entries);
+		$this->assertCount(0, $objects->saved);
+
+		$this->drain($listener);
 
 		$this->assertArrayHasKey('exp-1', $objects->saved);
 		$this->assertSame('synced', $objects->saved['exp-1']['apSyncStatus']);
@@ -341,17 +413,21 @@ class ExpenseApprovalListenerTest extends TestCase {
 		$notify = $this->createMock(ApSyncNotifier::class);
 		$notify->expects($this->once())->method('notifyFailure');
 
-		$objects = new ApFakeObjectService();
-		$listener = $this->listener($schemaMap, $apService, $objects, $notify);
-
-		$listener->handle(new ObjectCreatedEvent($this->entity('schema-expense', [
+		$expense = [
 			'uuid' => 'exp-1',
 			'title' => 'Catering',
 			'amount' => 78.30,
 			'status' => 'approved',
 			'approvedBy' => 'alice',
 			'approvedAt' => '2026-05-10T11:20:00Z',
-		])));
+		];
+
+		$objects = new ApFakeObjectService();
+		$objects->stored['exp-1'] = $expense;
+		$listener = $this->listener($schemaMap, $apService, $objects, $notify);
+
+		$listener->handle(new ObjectCreatedEvent($this->entity('schema-expense', $expense)));
+		$this->drain($listener);
 
 		$this->assertSame('failed', $objects->saved['exp-1']['apSyncStatus']);
 	}//end testFailedDispatchMarksFailedAndNotifies()
@@ -428,20 +504,31 @@ class ExpenseApprovalListenerTest extends TestCase {
 			}
 		);
 
-		$objects = new ReDispatchingApFakeObjectService();
-		$listener = $this->listener($schemaMap, $apService, $objects);
-
-		$objects->listener = $listener;
-		$objects->entityFactory = fn (array $data): ObjectEntity => $this->entity('schema-expense', $data);
-
-		$listener->handle(new ObjectCreatedEvent($this->entity('schema-expense', [
+		$expense = [
 			'uuid' => 'exp-1',
 			'title' => 'Hotel',
 			'amount' => 185.50,
 			'status' => 'approved',
 			'approvedBy' => 'alice',
 			'approvedAt' => '2026-05-15T14:30:00Z',
-		])));
+		];
+
+		$objects = new ReDispatchingApFakeObjectService();
+		$objects->stored['exp-1'] = $expense;
+		$listener = $this->listener($schemaMap, $apService, $objects);
+
+		$objects->listener = $listener;
+		$objects->entityFactory = fn (array $data): ObjectEntity => $this->entity('schema-expense', $data);
+
+		$listener->handle(new ObjectCreatedEvent($this->entity('schema-expense', $expense)));
+
+		// ADR-078: the approval only QUEUES on the request.
+		$this->assertCount(1, $this->deferral->entries);
+		$this->assertSame(0, $dispatches);
+
+		// The job runs the work — and its writes come straight back through the
+		// dispatcher into handle(), exactly as MagicMapper::update() does.
+		$this->drain($listener);
 
 		// One outbound AP webhook for one approval, however many times our own
 		// write comes back around.
@@ -454,5 +541,12 @@ class ExpenseApprovalListenerTest extends TestCase {
 		// The re-dispatch actually happened — otherwise this test asserts
 		// nothing and would pass with the guard deleted.
 		$this->assertGreaterThan(0, $objects->reDispatches);
+
+		// THE DEFERRED-ERA HALF OF THE SAME BUG: a re-entrant handle() that
+		// deferred again would put a NEW entry on the queue, and cron — which
+		// runs one job per web call — would grind on this expense for ever,
+		// starving every other job. The recorder was emptied by the drain, so a
+		// non-empty list here is that loop.
+		$this->assertCount(0, $this->deferral->entries);
 	}//end testOwnWriteDoesNotReEnterTheListener()
 }//end class

--- a/tests/Unit/Listener/ProjectCreationListenerTest.php
+++ b/tests/Unit/Listener/ProjectCreationListenerTest.php
@@ -3,7 +3,8 @@
 /**
  * Unit tests for ProjectCreationListener.
  *
- * Asserts the listener dispatches a new project to the ledger, records the
+ * Asserts the listener does NO ledger work on the request (ADR-078) but queues
+ * it, and that the queued work dispatches to the ledger, records the
  * synced/failed outcome on the persisted object, is idempotent for an
  * already-synced project, ignores non-project schemas, and no-ops when the
  * integration is unconfigured.
@@ -40,7 +41,7 @@ use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
 
 /**
- * In-memory ObjectService capturing saveObject() calls.
+ * In-memory ObjectService capturing saveObject() calls and serving find().
  */
 class CreationFakeObjectService {
 	/**
@@ -49,6 +50,13 @@ class CreationFakeObjectService {
 	 * @var array<string, array<string, mixed>>
 	 */
 	public array $saved = [];
+
+	/**
+	 * Objects readable by find(), keyed by uuid.
+	 *
+	 * @var array<string, array<string, mixed>>
+	 */
+	public array $stored = [];
 
 	/**
 	 * Capture a saved object.
@@ -63,14 +71,57 @@ class CreationFakeObjectService {
 	 */
 	public function saveObject($object, array $extend = [], string $register = '', string $schema = '', ?string $uuid = null): array {
 		$this->saved[(string)$uuid] = (array)$object;
+		$this->stored[(string)$uuid] = (array)$object;
 		return (array)$object;
 	}//end saveObject()
+
+	/**
+	 * Serve the deferred pass's re-read.
+	 *
+	 * @param string $id The object uuid.
+	 * @param string $register The register id.
+	 * @param string $schema The schema id.
+	 *
+	 * @return ObjectEntity|null
+	 */
+	public function find(string $id, string $register = '', string $schema = ''): ?ObjectEntity {
+		if (isset($this->stored[$id]) === false) {
+			return null;
+		}
+
+		$entity = new ObjectEntity();
+		$entity->setUuid($id);
+		$entity->setSchema($schema);
+		$entity->setObject($this->stored[$id]);
+		return $entity;
+	}//end find()
 }//end class
 
 /**
  * Tests for ProjectCreationListener.
  */
 class ProjectCreationListenerTest extends TestCase {
+
+	/**
+	 * The deferral double the last-built listener was wired with.
+	 *
+	 * @var RecordingDeferralService|null
+	 */
+	private ?RecordingDeferralService $deferral = null;
+
+	/**
+	 * Clear the shared re-entrancy guard between tests.
+	 *
+	 * A key leaked by one test would make the next one silently skip its work
+	 * and still report success.
+	 *
+	 * @return void
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+		\OCA\Pipelinq\Listener\DeferredWorkGuard::reset();
+	}//end setUp()
+
 	/**
 	 * Build an ObjectEntity double for the given schema and data.
 	 *
@@ -129,15 +180,63 @@ class ProjectCreationListenerTest extends TestCase {
 			}
 		);
 
+		$this->deferral = new RecordingDeferralService();
+
 		return new ProjectCreationListener(
 			schemaMapService: $schemaMap,
 			ledgerService: $ledger,
 			notifier: ($notify ?? $this->createMock(LedgerSyncNotifier::class)),
 			container: $container,
 			appConfig: $appConfig,
+			deferral: $this->deferral,
 			logger: $this->createMock(LoggerInterface::class),
 		);
 	}//end listener()
+
+	/**
+	 * Run every entry the listener queued, as the background job would.
+	 *
+	 * @param ProjectCreationListener $listener The listener under test.
+	 *
+	 * @return void
+	 */
+	private function drain(ProjectCreationListener $listener): void {
+		if ($this->deferral !== null) {
+			DeferredJobDrain::run($this, $this->deferral, $listener);
+		}
+	}//end drain()
+
+	/**
+	 * POSITIVE CONTROL: a new project is queued, not dispatched inline.
+	 *
+	 * Every "nothing happened" assertion below is only meaningful because this
+	 * one shows the listener CAN produce an entry.
+	 *
+	 * @return void
+	 */
+	public function testCreationIsQueuedAndNothingIsDispatchedOnTheRequest(): void {
+		$schemaMap = $this->createMock(SchemaMapService::class);
+		$schemaMap->method('resolveEntityType')->willReturn('project');
+
+		$ledger = $this->createMock(ShillinqLedgerService::class);
+		$ledger->method('shouldDispatch')->willReturn(true);
+		$ledger->expects($this->never())->method('dispatchProjectEvent');
+
+		$objects = new CreationFakeObjectService();
+		$listener = $this->listener($schemaMap, $ledger, $objects);
+
+		$listener->handle(new ObjectCreatedEvent($this->entity('schema-project', ['uuid' => 'proj-1', 'name' => 'P'])));
+
+		$this->assertCount(1, $this->deferral->entries);
+		$this->assertSame(ProjectCreationListener::HANDLER_KEY, $this->deferral->entries[0]['handler']);
+		$this->assertSame('proj-1', $this->deferral->entries[0]['uuid']);
+		$this->assertSame(
+			\OCA\Pipelinq\BackgroundJob\DeferredObjectListenerJob::class,
+			$this->deferral->jobClasses[0]
+		);
+		// The whole point: no write and no outbound dispatch on the request.
+		$this->assertCount(0, $objects->saved);
+	}//end testCreationIsQueuedAndNothingIsDispatchedOnTheRequest()
 
 	/**
 	 * A non-ObjectCreatedEvent is ignored.
@@ -152,6 +251,7 @@ class ProjectCreationListenerTest extends TestCase {
 		$listener = $this->listener($this->createMock(SchemaMapService::class), $ledger, $objects);
 
 		$listener->handle(new class extends Event {});
+		$this->assertCount(0, $this->deferral->entries);
 		$this->assertCount(0, $objects->saved);
 	}//end testIgnoresNonObjectCreatedEvent()
 
@@ -171,11 +271,12 @@ class ProjectCreationListenerTest extends TestCase {
 		$listener = $this->listener($schemaMap, $ledger, $objects);
 
 		$listener->handle(new ObjectCreatedEvent($this->entity('schema-lead', ['uuid' => 'lead-1'])));
+		$this->assertCount(0, $this->deferral->entries);
 		$this->assertCount(0, $objects->saved);
 	}//end testIgnoresNonProjectSchema()
 
 	/**
-	 * An unconfigured integration no-ops without persisting.
+	 * An unconfigured integration no-ops without queueing or persisting.
 	 *
 	 * @return void
 	 */
@@ -191,11 +292,12 @@ class ProjectCreationListenerTest extends TestCase {
 		$listener = $this->listener($schemaMap, $ledger, $objects);
 
 		$listener->handle(new ObjectCreatedEvent($this->entity('schema-project', ['uuid' => 'proj-1'])));
+		$this->assertCount(0, $this->deferral->entries);
 		$this->assertCount(0, $objects->saved);
 	}//end testNoopWhenUnconfigured()
 
 	/**
-	 * A successful dispatch marks the project synced.
+	 * A successful deferred dispatch marks the project synced.
 	 *
 	 * @return void
 	 */
@@ -208,9 +310,11 @@ class ProjectCreationListenerTest extends TestCase {
 		$ledger->method('dispatchProjectEvent')->willReturn(true);
 
 		$objects = new CreationFakeObjectService();
+		$objects->stored['proj-1'] = ['uuid' => 'proj-1', 'name' => 'P'];
 		$listener = $this->listener($schemaMap, $ledger, $objects);
 
 		$listener->handle(new ObjectCreatedEvent($this->entity('schema-project', ['uuid' => 'proj-1', 'name' => 'P'])));
+		$this->drain($listener);
 
 		$this->assertArrayHasKey('proj-1', $objects->saved);
 		$this->assertSame('synced', $objects->saved['proj-1']['ledgerSyncStatus']);
@@ -218,7 +322,7 @@ class ProjectCreationListenerTest extends TestCase {
 	}//end testSuccessfulDispatchMarksSynced()
 
 	/**
-	 * A failed dispatch marks the project failed and notifies admins.
+	 * A failed deferred dispatch marks the project failed and notifies admins.
 	 *
 	 * @return void
 	 */
@@ -234,9 +338,11 @@ class ProjectCreationListenerTest extends TestCase {
 		$notify->expects($this->once())->method('notifyFailure');
 
 		$objects = new CreationFakeObjectService();
+		$objects->stored['proj-1'] = ['uuid' => 'proj-1', 'name' => 'P'];
 		$listener = $this->listener($schemaMap, $ledger, $objects, $notify);
 
 		$listener->handle(new ObjectCreatedEvent($this->entity('schema-project', ['uuid' => 'proj-1', 'name' => 'P'])));
+		$this->drain($listener);
 
 		$this->assertSame('failed', $objects->saved['proj-1']['ledgerSyncStatus']);
 	}//end testFailedDispatchMarksFailedAndNotifies()
@@ -260,6 +366,33 @@ class ProjectCreationListenerTest extends TestCase {
 		$entity = $this->entity('schema-project', ['uuid' => 'proj-1', 'ledgerSyncStatus' => 'synced']);
 		$listener->handle(new ObjectCreatedEvent($entity));
 
+		$this->assertCount(0, $this->deferral->entries);
 		$this->assertCount(0, $objects->saved);
 	}//end testIdempotentForAlreadySyncedProject()
+
+	/**
+	 * The project having been deleted before the job runs is a no-op, not an
+	 * error (ADR-078 Rule 7 — at-least-once delivery reconciles against
+	 * current state).
+	 *
+	 * @return void
+	 */
+	public function testDeletedProjectIsAStaleNoOp(): void {
+		$schemaMap = $this->createMock(SchemaMapService::class);
+		$schemaMap->method('resolveEntityType')->willReturn('project');
+
+		$ledger = $this->createMock(ShillinqLedgerService::class);
+		$ledger->method('shouldDispatch')->willReturn(true);
+		$ledger->expects($this->never())->method('dispatchProjectEvent');
+
+		// `stored` deliberately empty: find() returns null.
+		$objects = new CreationFakeObjectService();
+		$listener = $this->listener($schemaMap, $ledger, $objects);
+
+		$listener->handle(new ObjectCreatedEvent($this->entity('schema-project', ['uuid' => 'proj-1'])));
+		$this->assertCount(1, $this->deferral->entries);
+
+		$this->drain($listener);
+		$this->assertCount(0, $objects->saved);
+	}//end testDeletedProjectIsAStaleNoOp()
 }//end class

--- a/tests/Unit/Listener/ProjectPhaseStatusListenerTest.php
+++ b/tests/Unit/Listener/ProjectPhaseStatusListenerTest.php
@@ -89,6 +89,40 @@ class PhaseFakeObjectService {
  * Tests for ProjectPhaseStatusListener.
  */
 class ProjectPhaseStatusListenerTest extends TestCase {
+
+	/**
+	 * The deferral double the last-built listener was wired with.
+	 *
+	 * @var RecordingDeferralService|null
+	 */
+	private ?RecordingDeferralService $deferral = null;
+
+	/**
+	 * Clear the shared re-entrancy guard between tests.
+	 *
+	 * A key leaked by one test would make the next one silently skip its work
+	 * and still report success.
+	 *
+	 * @return void
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+		\OCA\Pipelinq\Listener\DeferredWorkGuard::reset();
+	}//end setUp()
+
+	/**
+	 * Run every entry the listener queued, as the background job would.
+	 *
+	 * @param ProjectPhaseStatusListener $listener The listener under test.
+	 *
+	 * @return void
+	 */
+	private function drain(ProjectPhaseStatusListener $listener): void {
+		if ($this->deferral !== null) {
+			DeferredJobDrain::run($this, $this->deferral, $listener);
+		}
+	}//end drain()
+
 	/**
 	 * Build an ObjectEntity double for the given schema and data.
 	 *
@@ -145,18 +179,26 @@ class ProjectPhaseStatusListenerTest extends TestCase {
 			}
 		);
 
+		$this->deferral = new RecordingDeferralService();
+
 		return new ProjectPhaseStatusListener(
 			schemaMapService: $schemaMap,
 			ledgerService: $ledger,
 			notifier: $this->createMock(LedgerSyncNotifier::class),
 			container: $container,
 			appConfig: $appConfig,
+			deferral: $this->deferral,
 			logger: $this->createMock(LoggerInterface::class),
 		);
 	}//end listener()
 
 	/**
-	 * A status change on a project dispatches and records synced.
+	 * POSITIVE CONTROL: a status change on a project is queued, and the queued
+	 * work dispatches and records synced.
+	 *
+	 * Nothing reaches the ledger during handle() — that is the ADR-078 change.
+	 * Every "no-op" test below is only meaningful because this one shows the
+	 * listener CAN produce an entry and the entry CAN produce the effect.
 	 *
 	 * @return void
 	 */
@@ -172,12 +214,22 @@ class ProjectPhaseStatusListenerTest extends TestCase {
 			->willReturn(true);
 
 		$objects = new PhaseFakeObjectService();
+		$objects->store['proj-1'] = $this->entity('schema-project', ['uuid' => 'proj-1', 'status' => 'in_progress', 'name' => 'P']);
 		$listener = $this->listener($schemaMap, $ledger, $objects);
 
 		$new = $this->entity('schema-project', ['uuid' => 'proj-1', 'status' => 'in_progress', 'name' => 'P']);
 		$old = $this->entity('schema-project', ['uuid' => 'proj-1', 'status' => 'open', 'name' => 'P']);
 
 		$listener->handle(new ObjectUpdatedEvent($new, $old));
+
+		// Queued, and nothing written on the request.
+		$this->assertCount(1, $this->deferral->entries);
+		$this->assertSame('proj-1', $this->deferral->entries[0]['uuid']);
+		$this->assertSame('open', $this->deferral->entries[0]['oldStatus']);
+		$this->assertSame('in_progress', $this->deferral->entries[0]['newStatus']);
+		$this->assertCount(0, $objects->saved);
+
+		$this->drain($listener);
 
 		$this->assertSame('synced', $objects->saved['proj-1']['ledgerSyncStatus']);
 	}//end testProjectStatusChangeDispatches()
@@ -202,6 +254,7 @@ class ProjectPhaseStatusListenerTest extends TestCase {
 		$old = $this->entity('schema-project', ['uuid' => 'proj-1', 'status' => 'open']);
 
 		$listener->handle(new ObjectUpdatedEvent($new, $old));
+		$this->assertCount(0, $this->deferral->entries);
 		$this->assertCount(0, $objects->saved);
 	}//end testNoopWhenStatusUnchanged()
 
@@ -224,6 +277,7 @@ class ProjectPhaseStatusListenerTest extends TestCase {
 		$old = $this->entity('schema-lead', ['uuid' => 'lead-1', 'status' => 'open']);
 
 		$listener->handle(new ObjectUpdatedEvent($new, $old));
+		$this->assertCount(0, $this->deferral->entries);
 		$this->assertCount(0, $objects->saved);
 	}//end testIgnoresUnrelatedSchema()
 
@@ -251,7 +305,43 @@ class ProjectPhaseStatusListenerTest extends TestCase {
 
 		$listener->handle(new ObjectUpdatedEvent($new, $old));
 
+		// The parent-project lookup is a read and now happens in the job, so
+		// the entry carries only the parent's uuid.
+		$this->assertCount(1, $this->deferral->entries);
+		$this->assertSame('parent-proj', $this->deferral->entries[0]['uuid']);
+		$this->assertCount(0, $objects->saved);
+
+		$this->drain($listener);
+
 		$this->assertArrayHasKey('parent-proj', $objects->saved);
 		$this->assertSame('synced', $objects->saved['parent-proj']['ledgerSyncStatus']);
 	}//end testPhaseStatusChangeResolvesParentProject()
+
+	/**
+	 * The project having been deleted before the job runs is a no-op
+	 * (ADR-078 Rule 7).
+	 *
+	 * @return void
+	 */
+	public function testDeletedProjectIsAStaleNoOp(): void {
+		$schemaMap = $this->createMock(SchemaMapService::class);
+		$schemaMap->method('resolveEntityType')->willReturn('project');
+
+		$ledger = $this->createMock(ShillinqLedgerService::class);
+		$ledger->method('shouldDispatch')->willReturn(true);
+		$ledger->expects($this->never())->method('dispatchPhaseChangeEvent');
+
+		// `store` deliberately empty: find() returns null in the job.
+		$objects = new PhaseFakeObjectService();
+		$listener = $this->listener($schemaMap, $ledger, $objects);
+
+		$new = $this->entity('schema-project', ['uuid' => 'proj-1', 'status' => 'in_progress']);
+		$old = $this->entity('schema-project', ['uuid' => 'proj-1', 'status' => 'open']);
+
+		$listener->handle(new ObjectUpdatedEvent($new, $old));
+		$this->assertCount(1, $this->deferral->entries);
+
+		$this->drain($listener);
+		$this->assertCount(0, $objects->saved);
+	}//end testDeletedProjectIsAStaleNoOp()
 }//end class

--- a/tests/Unit/Listener/RecordingDeferralService.php
+++ b/tests/Unit/Listener/RecordingDeferralService.php
@@ -1,0 +1,83 @@
+<?php
+
+/**
+ * Recording double for OpenRegister's ListenerDeferralService.
+ *
+ * @category Test
+ * @package  OCA\Pipelinq\Tests\Unit\Listener
+ *
+ * @author    Conduction <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://github.com/ConductionNL/pipelinq
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Pipelinq\Tests\Unit\Listener;
+
+use OCA\OpenRegister\Service\Deferral\ListenerDeferralService;
+
+/**
+ * Captures what a listener queued, so a test can assert on it and then run it.
+ *
+ * A subclass rather than a PHPUnit mock: the tests here need to BOTH assert the
+ * entry's shape AND replay it through `runDeferredWork()`, which is what the
+ * background job does. Asserting only that `defer()` was called would prove the
+ * listener queued something — never that the queued thing does the work the
+ * listener used to do inline. That gap is exactly how a deferral conversion gets
+ * declared done while the behaviour is gone.
+ *
+ * It does NOT extend the deferral service's buffering or enqueue behaviour;
+ * those belong to OpenRegister and are tested there.
+ */
+class RecordingDeferralService extends ListenerDeferralService {
+
+	/**
+	 * Entries handed to defer(), in order.
+	 *
+	 * @var array<int, array<string, mixed>>
+	 */
+	public array $entries = [];
+
+	/**
+	 * Job classes handed to defer(), in order.
+	 *
+	 * @var array<int, string>
+	 */
+	public array $jobClasses = [];
+
+	/**
+	 * Dedupe keys handed to defer(), in order.
+	 *
+	 * @var array<int, string|null>
+	 */
+	public array $dedupeKeys = [];
+
+	/**
+	 * Record one deferral instead of enqueueing it.
+	 *
+	 * @param string $jobClass FQCN of the ActorForwardedJob subclass.
+	 * @param array<string, mixed> $entry Entry payload.
+	 * @param int $chunkSize Maximum entries per enqueued job.
+	 * @param string|null $dedupeKey Optional coalescing key.
+	 *
+	 * @return void
+	 */
+	public function defer(
+		string $jobClass,
+		array $entry,
+		int $chunkSize = self::DEFAULT_CHUNK_SIZE,
+		?string $dedupeKey = null,
+	): void {
+		$this->jobClasses[] = $jobClass;
+		$this->entries[] = $entry;
+		$this->dedupeKeys[] = $dedupeKey;
+	}//end defer()
+}//end class

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -166,3 +166,14 @@ if (file_exists(__DIR__ . '/Unit/Service/Portal/FakePortalObjectRepository.php')
 if (file_exists(__DIR__ . '/Unit/Service/Portal/FakeMainRegisterReader.php') === true) {
 	require_once __DIR__ . '/Unit/Service/Portal/FakeMainRegisterReader.php';
 }
+
+// ADR-078 deferral test helpers — same reason as the portal doubles above:
+// the Tests namespace has no PSR-4 mapping, and PHPUnit only auto-loads files
+// whose name ends in `Test.php`.
+if (file_exists(__DIR__ . '/Unit/Listener/RecordingDeferralService.php') === true) {
+	require_once __DIR__ . '/Unit/Listener/RecordingDeferralService.php';
+}
+
+if (file_exists(__DIR__ . '/Unit/Listener/DeferredJobDrain.php') === true) {
+	require_once __DIR__ . '/Unit/Listener/DeferredJobDrain.php';
+}


### PR DESCRIPTION
## gate-61 listener-work-placement — pipelinq

**8 findings, one shape.** Every one was a listener on `ObjectCreatedEvent` /
`ObjectUpdatedEvent` that filters by schema, computes something, and writes it
back through `ObjectService::saveObject()` — a second write nested inside the
user's first one. Three of them (`ProjectCreationListener`,
`ProjectPhaseStatusListener`, `ExpenseApprovalListener`) sandwich an **outbound
HTTP dispatch with its own retry budget** between two of those writes, so
Shillinq's latency was the user's latency and Shillinq's outage was the user's
slow save.

A post-`*ed` event cannot influence the write it observes (ADR-078), so none of
that work needed to be on the request.

### Before / after — the gate's OWN script

`openregister/vendor/conduction/hydra-gates/hydra-gates/scripts/lib/check_listener_placement.py <repo> --all`

| | findings | post-event registrations checked | exit |
|---|---|---|---|
| before | **8** | **13** | 1 |
| after | **0** | **13** | 0 |

File count stated per §2 L3 — the run inspected **13** registrations, not zero.

### What lands

- **`DeferredObjectWork`** — the interface a converted listener implements.
- **`DeferredObjectListenerJob`** — one `ActorForwardedJob` for all seven
  listeners, so one request's worth of work coalesces into one job row. The
  handler key from the persisted job row resolves through a **hardcoded
  allow-list**; passing a class name from a job row to the container would be an
  instantiate-anything primitive.
- **`DeferredWorkGuard`** — the part that is easy to get wrong; see below.
- **`openspec/specs/event-listener-work-placement/spec.md`** — the three
  requirements: one actor-forwarded job with an allow-list,
  reconcile-against-current-state, and the re-queue guard.

### 🔴 The guard is load-bearing, not defensive — read this bit

`saveObject()` makes `MagicMapper::update()` dispatch `ObjectUpdatedEvent`, which
**re-enters the same listeners** with an object that satisfies their entry
conditions. `ExpenseApprovalListener` already carried a static in-flight guard
for exactly this, and its own comment records that `silent: true` does not help
(`$silent` gates the audit trail and inverse relations, not the lifecycle
dispatch).

**Deferral makes that worse, not better.** A re-entrant `handle()` would enqueue
*another* job, whose write re-enters again — and `cron.php` runs **one job per
web call**, so the loop moves off one request's stack and onto the cron queue,
starving every other job on the instance. `SlaObjectUpdatedListener` is the
clearest case: it writes `slaStatus.lastEvaluatedAt = now` unconditionally and
has **no idempotency check at all**.

So the deferred pass claims `<handler>|<uuid>` for its duration, and a listener
that finds its own pair claimed returns without deferring.

### Behavioural changes reviewers should weigh

- **Post-event effects are now eventually consistent**, bounded by the cron
  interval — the consequence ADR-078 accepts. `slaStatus` is armed shortly after
  the create response rather than before it, and its timestamps come from the
  deferred pass's `now` (which is when the clock actually starts).
- **`DealUpdatedListener`'s `forecast_category` revert is RE-DECIDED, not
  replayed.** The deferred pass re-runs `validateTransition()` against the
  *current* value; replaying the captured revert would overwrite a value someone
  had since corrected. That is ADR-078 Rule 7 applied to a compensating write.
- Every deferred pass re-reads its object; a deleted object is a stale no-op.

### Verification

- **Revert control on the loop**: with the guard test removed from
  `ExpenseApprovalListener::handle()`, `testOwnWriteDoesNotReEnterTheListener`
  **fails** on the new assertion (`actual size 1 matches expected size 0`) — the
  deferred write re-enters and queues a second entry. Restored, byte-identical,
  and re-run green.
- Tests drain through the **real `DeferredObjectListenerJob`**, not a direct call
  to `runDeferredWork()`. Calling it directly would run the work with the guard
  *not* held — the one condition production never has — and would report success
  for a listener whose deferral loops for ever in cron.
- `ExpenseApprovalListenerTest` + `ProjectCreationListenerTest` +
  `ProjectPhaseStatusListenerTest`: **21/21 pass, 71 assertions**. Positive
  control first in each file.
- `tests/Integration/ExpenseApSyncTest`: **4/4 pass, 40 assertions**, now
  asserting the request path does *nothing* and the job does everything.
- `composer phpcs` on all ten changed/added PHP files: **0 errors**.
- gate-16 spec-coverage: **0 findings**. gate-46 spec-anchor-existence: **empty
  log** for the changed files. ⚠️ gate-46 **exits 0 either way** — read
  `/tmp/hydra-gate-spec-anchors.log`, not the exit code; it is how I caught my
  own `@spec` pointing at a spec file that did not exist yet.
- gate-19: **no new findings** — the new spec carries a file-level `@e2e exclude`
  naming the real reason (backend work placement has no browser surface; the
  observable behaviour is asserted by the PHPUnit above).

### ⚠️ Baseline for parity (§2 L6) — the board's table is stale for this repo

`development` has moved to **`1df56acd3`**, run **31937326006**, which is red on
**psalm, phpmd, phpstan and all six PHPUnit cells** — the same
`refactor/adr-084-type-hint-the-contract` shape R1 is chasing in softwarecatalog
and shillinq. pipelinq PR **#835** is the third repo hit.

Reproduced off-CI on a detached `origin/development` worktree at that sha:
`Tests: 2232, Errors: 613`. Cause: production now type-hints
`OCA\OpenRegister\Contract\{ObjectEntity,ObjectService}Interface` while
`tests/Stubs/Contract/` has no mirror, and pipelinq maps `OCA\OpenRegister\` to
`tests/Stubs/` via autoload-dev. **Not this PR's doing, and deliberately not
fixed here** — R1 owns it.

For a like-for-like comparison I placed faithful copies of the two real
interfaces in `tests/Stubs/Contract/` **locally only** (they are not in this
commit) and ran both trees with them:

| | Tests | Errors | Failures |
|---|---|---|---|
| `origin/development` @ `1df56acd3` | 2232 | 381 | 53 |
| this branch | 2235 | 381 | 53 |

**Same error and failure counts, three tests added.** The four
`ExpenseApSyncTest` errors that briefly appeared while I was converting are
fixed in this commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)