### PR TITLE
fix(tests): ADR-084 residue — the ObjectService stub, and nine shifted call sites

### DIFF
--- a/tests/Integration/OutboundMessagingContractTest.php
+++ b/tests/Integration/OutboundMessagingContractTest.php
@@ -127,9 +127,9 @@ class OutboundMessagingContractTest extends TestCase {
 		);
 
 		$contactmomentService = new ContactmomentService(
-			new TicketService($this->container, $appConfig, $logger,
-			objectService: $this->createMock(ObjectServiceInterface::class),
-		),
+			new TicketService($appConfig, $logger,
+				objectService: $this->createMock(ObjectServiceInterface::class),
+			),
 			$this->createMock(IGroupManager::class),
 			$logger,
 			objectService: $this->createMock(ObjectServiceInterface::class),
@@ -265,9 +265,9 @@ class OutboundMessagingContractTest extends TestCase {
 		$store = $this->objectService;
 		$container = $this->createMock(ContainerInterface::class);
 		$contactmomentService = new ContactmomentService(
-			new TicketService($container, $appConfig, $logger,
-			objectService: $this->createMock(ObjectServiceInterface::class),
-		),
+			new TicketService($appConfig, $logger,
+				objectService: $this->createMock(ObjectServiceInterface::class),
+			),
 			$this->createMock(IGroupManager::class),
 			$logger,
 			objectService: $this->createMock(ObjectServiceInterface::class),

--- a/tests/Stubs/Service/ObjectService.php
+++ b/tests/Stubs/Service/ObjectService.php
@@ -11,9 +11,29 @@
  * ("OCA\\OpenRegister\\" => "tests/Stubs/") and is a no-op when the real
  * openregister app is present (class_exists guard).
  *
- * Only a minimal surface is declared — the real ObjectService has more.
- * PHPUnit's createMock() generates a full mock regardless; the declarations
- * here only exist to satisfy the type system.
+ * IT MUST IMPLEMENT ObjectServiceInterface, AND ITS SIGNATURES MUST MATCH.
+ *
+ * The guard reads "no-op when the real app is present", but that is not what
+ * happens under PHPUnit: this file is reachable through pipelinq's OWN
+ * autoload-dev mapping, so it is loaded BEFORE anything pulls in the real
+ * class, `class_exists()` is false at that moment, and the stub wins. Every
+ * `createMock(ObjectService::class)` in this repo therefore mocks THIS class,
+ * not OpenRegister's.
+ *
+ * The real ObjectService implements ObjectServiceInterface (ADR-084,
+ * openregister#2498). While this stub did not, every mock of it failed the
+ * contract type hints that ADR-084 introduced:
+ *
+ *   TypeError: ...::__construct(): Argument #N ($objectService) must be of type
+ *   OCA\OpenRegister\Contract\ObjectServiceInterface, MockObject_ObjectService given
+ *
+ * A stub that stands in for a class must carry that class's method surface AND
+ * its interfaces, or it is a different type wearing the same name.
+ *
+ * The bodies are deliberately inert — every caller mocks them. The three that
+ * must return a non-nullable ObjectEntityInterface throw instead of
+ * fabricating one, because a double that quietly returns the wrong shape is
+ * worse than one that says it was not configured.
  *
  * @category Test
  * @package  OCA\Pipelinq\Tests\Stubs\Service
@@ -27,87 +47,45 @@ declare(strict_types=1);
 
 namespace OCA\OpenRegister\Service;
 
+use LogicException;
+use OCA\OpenRegister\Contract\ObjectEntityInterface;
+use OCA\OpenRegister\Contract\ObjectServiceInterface;
+use OCP\IUser;
+
 if (class_exists(ObjectService::class) === false) {
 	/**
 	 * Stub class for ObjectService — used only in standalone unit tests.
 	 *
 	 * Replaced by the real implementation when the openregister app is installed.
 	 */
-	class ObjectService {
+	class ObjectService implements ObjectServiceInterface {
 		/**
-		 * Find a single object by ID.
+		 * Message used by the three methods that cannot honour their return type inertly.
 		 *
-		 * @param string $id The object UUID.
-		 * @param string $register Register slug or ID.
-		 * @param string $schema Schema slug or ID.
-		 *
-		 * @return array<string, mixed>|object|null
+		 * @var string
 		 */
-		public function find(string $id, string $register = '', string $schema = ''): array|object|null {
-			return null;
-		}//end find()
+		private const NOT_CONFIGURED = 'ObjectService test stub: this method returns an ObjectEntityInterface and has no inert value. Configure it on the mock.';
 
 		/**
-		 * Find all objects matching the given configuration.
+		 * Persist an object.
 		 *
-		 * Mirrors the real OR ObjectService signature so test mocks that call
-		 * `findAll(config: ['filters' => ...])` (the documented form used by
-		 * pipelinq services) do not blow up with "Unknown named parameter".
+		 * @param array<string, mixed>       $object         The data to persist.
+		 * @param array<string, mixed>|null  $extend         Additional field values.
+		 * @param string|int|null            $register       Register slug or ID.
+		 * @param string|int|null            $schema         Schema slug or ID.
+		 * @param string|null                $uuid           UUID for update; null for create.
+		 * @param boolean                    $_rbac          Whether to enforce RBAC checks.
+		 * @param boolean                    $_multitenancy  Whether to enforce tenant scoping.
+		 * @param boolean                    $silent         Whether to suppress side-effects.
+		 * @param boolean                    $_validation    Whether to validate against the schema.
+		 * @param array<string, mixed>|null  $uploadedFiles  Files to attach.
+		 * @param IUser|null                 $currentUser    Acting user for folder access.
+		 * @param boolean                    $failIfExists   Whether a duplicate is an error.
 		 *
-		 * `$_rbac` / `$_multitenancy` are the system-context escape hatches used
-		 * by repair steps, CLI commands and cron: those run with no user session,
-		 * so an RBAC-scoped read resolves the actor to 'Anonymous' and returns
-		 * nothing. They are part of the real signature and must be declared here,
-		 * or a caller passing them by name throws "Unknown named parameter".
-		 *
-		 * @param array<string, mixed> $config Configuration with `filters`, `sort`, etc.
-		 * @param bool $_rbac Whether to enforce RBAC scoping.
-		 * @param bool $_multitenancy Whether to enforce tenant scoping.
-		 *
-		 * @return array<int, mixed>
-		 */
-		public function findAll(array $config = [], bool $_rbac = true, bool $_multitenancy = true): array {
-			return [];
-		}//end findAll()
-
-		/**
-		 * Count objects matching the given configuration.
-		 *
-		 * Mirrors the real OR ObjectService signature so test mocks that call
-		 * `count(config: ['filters' => ...])` (the form used by pipelinq query
-		 * pushdown) do not blow up with "Unknown named parameter".
-		 *
-		 * @param array<string, mixed> $config Configuration with `filters`, etc.
-		 *
-		 * @return int
-		 */
-		public function count(array $config = []): int {
-			return 0;
-		}//end count()
-
-		/**
-		 * Save (create or update) an object.
-		 *
-		 * Mirrors the real OR ObjectService signature (parameter is `$object`,
-		 * not `$objectOrArray`) so test mocks that use the named-arg form
-		 * (`saveObject(object: ..., register: ..., schema: ..., uuid: ...)`)
-		 * do not blow up with "Unknown named parameter".
-		 *
-		 * @param array<string, mixed>|object $object The data to persist.
-		 * @param array<string, mixed>|null $extend Additional field values.
-		 * @param string|int|null $register Register slug or ID.
-		 * @param string|int|null $schema Schema slug or ID.
-		 * @param string|null $uuid UUID for update; null for create.
-		 * @param bool $_rbac Whether to enforce RBAC checks.
-		 * @param bool $_multitenancy Whether to enforce tenant scoping.
-		 * @param bool $silent Whether to suppress side-effects.
-		 * @param array<string, mixed>|null $uploadedFiles Files to attach.
-		 * @param object|null $currentUser Acting user for folder access.
-		 *
-		 * @return array<string, mixed>|object
+		 * @return ObjectEntityInterface
 		 */
 		public function saveObject(
-			array|object $object,
+			array $object,
 			?array $extend = [],
 			string|int|null $register = null,
 			string|int|null $schema = null,
@@ -115,10 +93,12 @@ if (class_exists(ObjectService::class) === false) {
 			bool $_rbac = true,
 			bool $_multitenancy = true,
 			bool $silent = false,
+			bool $_validation = true,
 			?array $uploadedFiles = null,
-			?object $currentUser = null,
-		): array|object {
-			return [];
+			?IUser $currentUser = null,
+			bool $failIfExists = false,
+		): ObjectEntityInterface {
+			throw new LogicException(self::NOT_CONFIGURED);
 		}//end saveObject()
 
 		/**
@@ -133,6 +113,52 @@ if (class_exists(ObjectService::class) === false) {
 		}//end setRegister()
 
 		/**
+		 * Find a single object.
+		 *
+		 * @param integer|string            $id            The object id or UUID.
+		 * @param array<string, mixed>|null $_extend       Properties to expand.
+		 * @param boolean                   $files         Whether to include files.
+		 * @param string|int|null           $register      Register slug or ID.
+		 * @param string|int|null           $schema        Schema slug or ID.
+		 * @param boolean                   $_rbac         Whether to enforce RBAC checks.
+		 * @param boolean                   $_multitenancy Whether to enforce tenant scoping.
+		 * @param boolean                   $_render       Whether to render the result.
+		 * @param boolean                   $_audit        Whether to write an audit trail.
+		 *
+		 * @return ObjectEntityInterface|null
+		 */
+		public function find(
+			int|string $id,
+			?array $_extend = [],
+			bool $files = false,
+			string|int|null $register = null,
+			string|int|null $schema = null,
+			bool $_rbac = true,
+			bool $_multitenancy = true,
+			bool $_render = true,
+			bool $_audit = true,
+		): ?ObjectEntityInterface {
+			return null;
+		}//end find()
+
+		/**
+		 * Find all objects matching the given configuration.
+		 *
+		 * @param array<string, mixed> $config        The query configuration.
+		 * @param boolean              $_rbac         Whether to enforce RBAC checks.
+		 * @param boolean              $_multitenancy Whether to enforce tenant scoping.
+		 *
+		 * @return array<int, mixed>
+		 */
+		public function findAll(
+			array $config = [],
+			bool $_rbac = true,
+			bool $_multitenancy = true,
+		): array {
+			return [];
+		}//end findAll()
+
+		/**
 		 * Set the active schema for subsequent calls (fluent API).
 		 *
 		 * @param string|int $schema Schema slug or ID.
@@ -144,16 +170,370 @@ if (class_exists(ObjectService::class) === false) {
 		}//end setSchema()
 
 		/**
+		 * Search objects.
+		 *
+		 * @param array<string, mixed>    $query         The search query.
+		 * @param boolean                 $_rbac         Whether to enforce RBAC checks.
+		 * @param boolean                 $_multitenancy Whether to enforce tenant scoping.
+		 * @param array<int, mixed>|null  $ids           Restrict to these ids.
+		 * @param string|null             $uses          Restrict to objects using this one.
+		 * @param array<int, mixed>|null  $views         Views to apply.
+		 *
+		 * @return array<int, mixed>|int
+		 */
+		public function searchObjects(
+			array $query = [],
+			bool $_rbac = true,
+			bool $_multitenancy = true,
+			?array $ids = null,
+			?string $uses = null,
+			?array $views = null,
+		): array|int {
+			return [];
+		}//end searchObjects()
+
+		/**
 		 * Delete an object by UUID.
 		 *
-		 * @param string $uuid The object UUID.
-		 * @param string|null $register Register slug or ID (optional, overrides setRegister).
-		 * @param string|null $schema Schema slug or ID (optional, overrides setSchema).
+		 * @param string          $uuid            The object UUID.
+		 * @param string|int|null $register        Register slug or ID.
+		 * @param string|int|null $schema          Schema slug or ID.
+		 * @param boolean         $_rbac           Whether to enforce RBAC checks.
+		 * @param boolean         $_multitenancy   Whether to enforce tenant scoping.
+		 * @param boolean         $_retentionSweep Whether this is a retention sweep.
+		 * @param IUser|null      $currentUser     Acting user.
+		 * @param boolean         $permanent       Whether to delete permanently.
 		 *
-		 * @return bool
+		 * @return boolean
 		 */
-		public function deleteObject(string $uuid, string|int|null $register = null, string|int|null $schema = null): bool {
+		public function deleteObject(
+			string $uuid,
+			string|int|null $register = null,
+			string|int|null $schema = null,
+			bool $_rbac = true,
+			bool $_multitenancy = true,
+			bool $_retentionSweep = false,
+			?IUser $currentUser = null,
+			bool $permanent = false,
+		): bool {
 			return true;
 		}//end deleteObject()
+
+		/**
+		 * Search objects with pagination.
+		 *
+		 * @param array<string, mixed>   $query         The search query.
+		 * @param boolean                $_rbac         Whether to enforce RBAC checks.
+		 * @param boolean                $_multitenancy Whether to enforce tenant scoping.
+		 * @param boolean                $deleted       Whether to include deleted objects.
+		 * @param array<int, mixed>|null $ids           Restrict to these ids.
+		 * @param string|null            $uses          Restrict to objects using this one.
+		 * @param array<int, mixed>|null $views         Views to apply.
+		 *
+		 * @return array<string, mixed>
+		 */
+		public function searchObjectsPaginated(
+			array $query = [],
+			bool $_rbac = true,
+			bool $_multitenancy = true,
+			bool $deleted = false,
+			?array $ids = null,
+			?string $uses = null,
+			?array $views = null,
+		): array {
+			return [];
+		}//end searchObjectsPaginated()
+
+		/**
+		 * Search objects by register and schema slug.
+		 *
+		 * @param string               $registerSlug  The register slug.
+		 * @param string               $schemaSlug    The schema slug.
+		 * @param array<string, mixed> $filters       Filters to apply.
+		 * @param boolean              $_rbac         Whether to enforce RBAC checks.
+		 * @param boolean              $_multitenancy Whether to enforce tenant scoping.
+		 *
+		 * @return array<int, mixed>|int
+		 */
+		public function searchObjectsBySlug(
+			string $registerSlug,
+			string $schemaSlug,
+			array $filters = [],
+			bool $_rbac = true,
+			bool $_multitenancy = true,
+		): array|int {
+			return [];
+		}//end searchObjectsBySlug()
+
+		/**
+		 * Clear the current register/schema selection.
+		 *
+		 * @return void
+		 */
+		public function clearCurrents(): void {
+		}//end clearCurrents()
+
+		/**
+		 * Build a search query from request parameters.
+		 *
+		 * @param array<string, mixed>              $requestParams The request parameters.
+		 * @param integer|string|array<int,mixed>|null $register   Register slug(s) or ID(s).
+		 * @param integer|string|array<int,mixed>|null $schema     Schema slug(s) or ID(s).
+		 * @param array<int, mixed>|null            $ids           Restrict to these ids.
+		 *
+		 * @return array<string, mixed>
+		 */
+		public function buildSearchQuery(
+			array $requestParams,
+			int|string|array|null $register = null,
+			int|string|array|null $schema = null,
+			?array $ids = null,
+		): array {
+			return [];
+		}//end buildSearchQuery()
+
+		/**
+		 * Persist many objects at once.
+		 *
+		 * @param array<int, mixed> $objects         The objects to persist.
+		 * @param string|int|null   $register        Register slug or ID.
+		 * @param string|int|null   $schema          Schema slug or ID.
+		 * @param boolean           $_rbac           Whether to enforce RBAC checks.
+		 * @param boolean           $_multitenancy   Whether to enforce tenant scoping.
+		 * @param boolean           $validation      Whether to validate.
+		 * @param boolean           $events          Whether to emit events.
+		 * @param boolean           $deduplicateIds  Whether to deduplicate ids.
+		 * @param boolean           $enrich          Whether to enrich the results.
+		 * @param boolean           $_audit          Whether to write an audit trail.
+		 *
+		 * @return array<int, mixed>
+		 */
+		public function saveObjects(
+			array $objects,
+			string|int|null $register = null,
+			string|int|null $schema = null,
+			bool $_rbac = true,
+			bool $_multitenancy = true,
+			bool $validation = false,
+			bool $events = false,
+			bool $deduplicateIds = true,
+			bool $enrich = true,
+			bool $_audit = true,
+		): array {
+			return [];
+		}//end saveObjects()
+
+		/**
+		 * Run an operation in the system context.
+		 *
+		 * @param callable $operation The operation to run.
+		 *
+		 * @return mixed
+		 */
+		public function runAsSystem(callable $operation) {
+			return $operation();
+		}//end runAsSystem()
+
+		/**
+		 * Count objects matching the given configuration.
+		 *
+		 * @param array<string, mixed> $config The query configuration.
+		 *
+		 * @return integer
+		 */
+		public function count(array $config = []): int {
+			return 0;
+		}//end count()
+
+		/**
+		 * Release a lock on an object.
+		 *
+		 * @param string|int $identifier The object identifier.
+		 * @param boolean    $advisory   Whether the lock is advisory.
+		 *
+		 * @return boolean
+		 */
+		public function unlockObject(string|int $identifier, bool $advisory = false): bool {
+			return true;
+		}//end unlockObject()
+
+		/**
+		 * Take a lock on an object.
+		 *
+		 * @param string       $identifier The object identifier.
+		 * @param string|null  $process    The process taking the lock.
+		 * @param integer|null $duration   Lock duration in seconds.
+		 * @param boolean      $advisory   Whether the lock is advisory.
+		 *
+		 * @return array<string, mixed>
+		 */
+		public function lockObject(
+			string $identifier,
+			?string $process = null,
+			?int $duration = null,
+			bool $advisory = false,
+		): array {
+			return [];
+		}//end lockObject()
+
+		/**
+		 * Delete many objects at once.
+		 *
+		 * @param array<int, string> $uuids         The object UUIDs.
+		 * @param boolean            $_rbac         Whether to enforce RBAC checks.
+		 * @param boolean            $_multitenancy Whether to enforce tenant scoping.
+		 *
+		 * @return array<int, mixed>
+		 */
+		public function deleteObjects(
+			array $uuids = [],
+			bool $_rbac = true,
+			bool $_multitenancy = true,
+		): array {
+			return [];
+		}//end deleteObjects()
+
+		/**
+		 * Return the audit log for an object.
+		 *
+		 * @param string               $uuid          The object UUID.
+		 * @param array<string, mixed> $filters       Filters to apply.
+		 * @param boolean              $_rbac         Whether to enforce RBAC checks.
+		 * @param boolean              $_multitenancy Whether to enforce tenant scoping.
+		 *
+		 * @return array<int, mixed>
+		 */
+		public function getLogs(
+			string $uuid,
+			array $filters = [],
+			bool $_rbac = true,
+			bool $_multitenancy = true,
+		): array {
+			return [];
+		}//end getLogs()
+
+		/**
+		 * Update an object.
+		 *
+		 * @param string               $objectId      The object id.
+		 * @param array<string, mixed> $data          The new data.
+		 * @param boolean              $_rbac         Whether to enforce RBAC checks.
+		 * @param boolean              $_multitenancy Whether to enforce tenant scoping.
+		 *
+		 * @return ObjectEntityInterface
+		 */
+		public function updateObject(
+			string $objectId,
+			array $data,
+			bool $_rbac = true,
+			bool $_multitenancy = true,
+		): ObjectEntityInterface {
+			throw new LogicException(self::NOT_CONFIGURED);
+		}//end updateObject()
+
+		/**
+		 * Return the objects this object uses.
+		 *
+		 * @param string               $objectId      The object id.
+		 * @param array<string, mixed> $query         The query.
+		 * @param boolean              $_rbac         Whether to enforce RBAC checks.
+		 * @param boolean              $_multitenancy Whether to enforce tenant scoping.
+		 *
+		 * @return array<int, mixed>
+		 */
+		public function getObjectUses(
+			string $objectId,
+			array $query = [],
+			bool $_rbac = true,
+			bool $_multitenancy = true,
+		): array {
+			return [];
+		}//end getObjectUses()
+
+		/**
+		 * Return the objects that use this object.
+		 *
+		 * @param string               $objectId      The object id.
+		 * @param array<string, mixed> $query         The query.
+		 * @param boolean              $_rbac         Whether to enforce RBAC checks.
+		 * @param boolean              $_multitenancy Whether to enforce tenant scoping.
+		 *
+		 * @return array<int, mixed>
+		 */
+		public function getObjectUsedBy(
+			string $objectId,
+			array $query = [],
+			bool $_rbac = true,
+			bool $_multitenancy = true,
+		): array {
+			return [];
+		}//end getObjectUsedBy()
+
+		/**
+		 * Find objects by their relations.
+		 *
+		 * @param string  $search       The search term.
+		 * @param boolean $partialMatch Whether to match partially.
+		 *
+		 * @return array<int, mixed>
+		 */
+		public function findByRelations(string $search, bool $partialMatch = true): array {
+			return [];
+		}//end findByRelations()
+
+		/**
+		 * Find a single object without audit or rendering side-effects.
+		 *
+		 * @param string                    $id            The object id.
+		 * @param array<string, mixed>|null $_extend       Properties to expand.
+		 * @param boolean                   $files         Whether to include files.
+		 * @param string|int|null           $register      Register slug or ID.
+		 * @param string|int|null           $schema        Schema slug or ID.
+		 * @param boolean                   $_rbac         Whether to enforce RBAC checks.
+		 * @param boolean                   $_multitenancy Whether to enforce tenant scoping.
+		 *
+		 * @return ObjectEntityInterface
+		 */
+		public function findSilent(
+			string $id,
+			?array $_extend = [],
+			bool $files = false,
+			string|int|null $register = null,
+			string|int|null $schema = null,
+			bool $_rbac = true,
+			bool $_multitenancy = true,
+		): ObjectEntityInterface {
+			throw new LogicException(self::NOT_CONFIGURED);
+		}//end findSilent()
+
+		/**
+		 * Count the objects a search would return.
+		 *
+		 * @param array<string, mixed>   $query         The search query.
+		 * @param boolean                $_rbac         Whether to enforce RBAC checks.
+		 * @param boolean                $_multitenancy Whether to enforce tenant scoping.
+		 * @param array<int, mixed>|null $ids           Restrict to these ids.
+		 * @param string|null            $uses          Restrict to objects using this one.
+		 *
+		 * @return integer
+		 */
+		public function countSearchObjects(
+			array $query = [],
+			bool $_rbac = true,
+			bool $_multitenancy = true,
+			?array $ids = null,
+			?string $uses = null,
+		): int {
+			return 0;
+		}//end countSearchObjects()
+
+		/**
+		 * Return the currently selected object.
+		 *
+		 * @return ObjectEntityInterface|null
+		 */
+		public function getObject(): ?ObjectEntityInterface {
+			return null;
+		}//end getObject()
 	}//end class
 }//end if

--- a/tests/Unit/Controller/BrpControllerTest.php
+++ b/tests/Unit/Controller/BrpControllerTest.php
@@ -951,7 +951,6 @@ class BrpControllerTest extends TestCase {
 			$this->createMock(BsnAuditService::class),
 			$this->createMock(OptOutService::class),
 			$listener,
-			$this->createMock(ContainerInterface::class),
 			$logger,
 			objectService: $objectService,
 		);

--- a/tests/Unit/Controller/ContactSyncControllerTest.php
+++ b/tests/Unit/Controller/ContactSyncControllerTest.php
@@ -649,13 +649,12 @@ class ContactSyncControllerTest extends TestCase {
 		$container->method('get')->willReturn($objectService);
 
 		return new ContactSyncService($contactsManager,
-			new ContactImportService($appConfig, $container, new ContactDataBuilder(),
-			objectService: $objectService,
-		),
+			new ContactImportService($appConfig, new ContactDataBuilder(),
+				objectService: $objectService,
+			),
 			$this->createMock(ContactVcardService::class),
 			$this->createMock(ContactLinkedUidsService::class),
 			$appConfig,
-			$container,
 			objectService: $objectService,
 		);
 	}//end realSyncService()

--- a/tests/Unit/Controller/PosCustomerControllerTest.php
+++ b/tests/Unit/Controller/PosCustomerControllerTest.php
@@ -563,8 +563,7 @@ class PosCustomerControllerTest extends TestCase {
 		$l10n = $this->createMock(IL10N::class);
 		$l10n->method('t')->willReturnArgument(0);
 
-		$service = new PosCustomerLinkService($container,
-			$appConfig,
+		$service = new PosCustomerLinkService($appConfig,
 			$this->createMock(LoggerInterface::class),
 			objectService: $objectService,
 		);

--- a/tests/Unit/Controller/ProductCatalogControllerTest.php
+++ b/tests/Unit/Controller/ProductCatalogControllerTest.php
@@ -170,8 +170,7 @@ class ProductCatalogControllerTest extends TestCase {
 		$policy = $this->createMock(PosAccessPolicy::class);
 		$policy->method('isPosUser')->willReturn(true);
 
-		$service = new ProductCatalogService($this->createMock(ContainerInterface::class),
-			$this->createMock(IAppConfig::class),
+		$service = new ProductCatalogService($this->createMock(IAppConfig::class),
 			$this->createMock(LoggerInterface::class),
 			objectService: $this->createMock(ObjectServiceInterface::class),
 		);

--- a/tests/Unit/Service/AppointmentEmailServiceTest.php
+++ b/tests/Unit/Service/AppointmentEmailServiceTest.php
@@ -132,8 +132,7 @@ class AppointmentEmailServiceTest extends TestCase {
 	 * @return AppointmentEmailService
 	 */
 	private function buildService(): AppointmentEmailService {
-		return new AppointmentEmailService($this->container,
-			$this->appConfig,
+		return new AppointmentEmailService($this->appConfig,
 			$this->mailer,
 			$this->urlGenerator,
 			$this->l10n,

--- a/tests/Unit/Service/CashShiftServiceTest.php
+++ b/tests/Unit/Service/CashShiftServiceTest.php
@@ -29,6 +29,7 @@ declare(strict_types=1);
 namespace OCA\Pipelinq\Tests\Unit\Service;
 
 use OCA\OpenRegister\Contract\ObjectServiceInterface;
+use OCA\OpenRegister\Service\WebhookService;
 use OCA\Pipelinq\Lifecycle\PosAccessPolicy;
 use OCA\Pipelinq\Service\CashShiftService;
 use OCP\AppFramework\OCS\OCSBadRequestException;
@@ -100,7 +101,7 @@ class CashFakeObjectService {
 /**
  * A fake WebhookService capturing dispatched CloudEvents.
  */
-class CashFakeWebhookService {
+class CashFakeWebhookService extends WebhookService {
 	/** @var array<int, array{eventName: string, payload: array<string, mixed>}> */
 	public array $events = [];
 
@@ -209,10 +210,10 @@ class CashShiftServiceTest extends TestCase {
 			throw new \RuntimeException('unknown service ' . $id);
 		});
 
-		$this->service = new CashShiftService($container,
-			$this->appConfig,
+		$this->service = new CashShiftService($this->appConfig,
 			$policy,
 			$this->createMock(LoggerInterface::class),
+			webhookService: $this->webhooks,
 			objectService: $key,
 			aggregationRunner: $this->createMock(AggregationRunner::class),
 		);

--- a/tests/Unit/Service/PosRefundServiceTest.php
+++ b/tests/Unit/Service/PosRefundServiceTest.php
@@ -31,6 +31,7 @@ namespace OCA\Pipelinq\Tests\Unit\Service;
 use OCA\OpenRegister\Contract\ObjectServiceInterface;
 use OCA\OpenRegister\Lifecycle\GuardResult;
 use OCA\OpenRegister\Service\Lifecycle\TransitionEngine;
+use OCA\OpenRegister\Service\WebhookService;
 use OCA\Pipelinq\Lifecycle\PosAccessPolicy;
 use OCA\Pipelinq\Lifecycle\PosRefundManagerGuard;
 use OCA\Pipelinq\Service\PosRefundService;
@@ -98,7 +99,7 @@ class FakeObjectService {
 /**
  * A fake WebhookService capturing dispatched CloudEvents.
  */
-class FakeWebhookService {
+class FakeWebhookService extends WebhookService {
 	/** @var array<int, array{eventName: string, payload: array<string, mixed>}> */
 	public array $events = [];
 
@@ -254,9 +255,9 @@ class PosRefundServiceTest extends TestCase {
 			throw new \RuntimeException('unknown service ' . $id);
 		});
 
-		$this->service = new PosRefundService($container,
-			$this->appConfig,
+		$this->service = new PosRefundService($this->appConfig,
 			$logger,
+			webhookService: $this->webhooks,
 			objectService: $key,
 			transitionEngine: $this->createMock(TransitionEngine::class),
 		);

--- a/tests/Unit/Service/ProductCatalogServiceTest.php
+++ b/tests/Unit/Service/ProductCatalogServiceTest.php
@@ -56,7 +56,7 @@ class ProductCatalogServiceTest extends TestCase {
 		$appConfig = $this->createMock(IAppConfig::class);
 		$logger = $this->createMock(LoggerInterface::class);
 
-		$this->service = new ProductCatalogService($container, $appConfig, $logger,
+		$this->service = new ProductCatalogService($appConfig, $logger,
 			objectService: $this->createMock(ObjectServiceInterface::class),
 		);
 	}//end setUp()

--- a/tests/Unit/Service/QuotaServiceTest.php
+++ b/tests/Unit/Service/QuotaServiceTest.php
@@ -52,7 +52,7 @@ class QuotaServiceTest extends TestCase {
 		$container = $this->createMock(ContainerInterface::class);
 		$logger = $this->createMock(LoggerInterface::class);
 
-		$this->service = new QuotaService(container: $container, appConfig: $appConfig, logger: $logger,
+		$this->service = new QuotaService(appConfig: $appConfig, logger: $logger,
 			objectService: $d,
 		);
 	}//end setUp()


### PR DESCRIPTION
`development` is at **381 PHPUnit errors**, all residue from the ADR-084 rollout. This clears the two largest causes; see the bottom for what is left.

## 1. The stub did not implement the contract it stands for

`tests/Stubs/Service/ObjectService.php` carries a `class_exists` guard and a comment saying it is a no-op when the real openregister app is present. That is not what happens under PHPUnit: `tests/bootstrap-unit.php` maps `OCA\OpenRegister\\` at `tests/Stubs/` and requires the file behind its own guard, so it is defined before anything pulls in the real class. **Every `createMock(ObjectService::class)` in this repo mocks the stub.**

The real `ObjectService` implements `ObjectServiceInterface`. The stub did not, so its mocks failed every contract type hint:

```
TypeError: Cannot assign MockObject_ObjectService to property $objectService
of type OCA\OpenRegister\Contract\ObjectServiceInterface
```

It now implements the interface with all 25 methods at the contract's own signatures — mirroring what `tests/Stubs/Db/ObjectEntity.php` already does for `ObjectEntityInterface`. Bodies stay inert because callers mock them; the three that must return a non-nullable `ObjectEntityInterface` throw rather than fabricate one.

This also fixes `LoyaltyObjectStoreFake`, which extends `ObjectService` and becomes an `ObjectServiceInterface` with it.

## 2. Nine call sites passed the service twice

```
Error: Named parameter $objectService overwrites previous argument
```

Always the same shape: ADR-084 removed a `ContainerInterface` parameter and appended an `ObjectServiceInterface` one; the call site kept the container in slot 1; every positional argument shifted left; the last landed on `$objectService`, where the named argument collided. The collision is what PHP reports — the shifted arguments underneath it are the real defect and would otherwise have been silent type errors.

Fixed in `ProductCatalogService` (×2), `PosCustomerLinkService`, `ContactSyncService`, `ContactImportService`, `AppointmentEmailService`, `TicketService` (×2) and `BrpController`, plus four constructors that no longer declare a container at all (`QuotaService`, `PosRefundService`, `CashShiftService`). `PosRefundService` and `CashShiftService` also gained a `WebhookService` parameter the tests were still resolving through the container, so their webhook fakes now extend the stub they stand in for and are injected directly.

A detector for both shapes now reports **0** remaining.

## Still open on this app

Not fixed here, and worth their own pass:

- Anonymous `new class { ... }` object-service doubles (`ScheduledTaskServiceTest`, `NaviService`, `WorklistService`, `AnalyticsService` tests) do not implement the contract. They should extend the stub, which means aligning their overrides to the contract's signatures.
- Standalone fakes — `FakeObjectService`, `FakeIngestObjectService`, `FakePvmObjectService`, `FakeRenewalObjectService`, `FakeAuditObjectService` — same treatment.
- Helper return types still declared as `OCA\OpenRegister\Service\ObjectService` while returning a `MockObject_ObjectServiceInterface` (`TicketServiceTest`, `BerichtenboxServiceTest`).
- `ScheduledTaskServiceTest::makeService()` references an undefined `$stub`; it used to reach the double through the container.
- `AbstractPaymentAdapter` constructor arguments not passed — unrelated to ADR-084.