### PR TITLE
fix(security): public availability leaked services the portal never offers

### DIFF
--- a/lib/Service/BookingService.php
+++ b/lib/Service/BookingService.php
@@ -340,6 +340,17 @@ class BookingService {
 			return [];
 		}
 
+		// A service that is not offered online has no public availability to
+		// report. The portal's `services()` list already filters on
+		// `bookableOnline: true`, and `createBookingFromPortal()` refuses a
+		// service without it -- but this path did neither, so an anonymous
+		// caller who supplied any serviceId could read the free/busy pattern
+		// of a service the portal never offers. Same check its two siblings
+		// make, applied here.
+		if (($service['bookableOnline'] ?? false) !== true) {
+			return [];
+		}
+
 		$duration = (int)($service['durationMinutes'] ?? 0);
 		if ($duration <= 0) {
 			return [];

--- a/tests/Unit/Service/BookingServiceTest.php
+++ b/tests/Unit/Service/BookingServiceTest.php
@@ -70,6 +70,11 @@ class BookingServiceTest extends TestCase {
 		'cancellationPolicy' => 'free',
 		'cancellationHoursBefore' => 24,
 		'status' => 'active',
+		// The portal only ever offers services carrying this flag. It was
+		// absent here, which is part of why getAvailableSlots() could go so
+		// long without checking it: no fixture distinguished a service the
+		// public may see from one it may not.
+		'bookableOnline' => true,
 	];
 
 	/**
@@ -953,6 +958,50 @@ class BookingServiceTest extends TestCase {
 		$this->assertNotContains(needle: 'res-c', haystack: $resourceIds);
 
 	}//end testGetAvailableSlotsDelegatesToAvailabilityService()
+
+	/**
+	 * A service that is not offered online has no public availability.
+	 *
+	 * `GET /portal/availability` is `@PublicPage` and takes `serviceId`
+	 * straight from the caller, so without this check an anonymous request
+	 * naming any service id could read that service's free/busy pattern —
+	 * including services the portal's own `services()` list, which filters on
+	 * `bookableOnline: true`, deliberately never shows. The booking path
+	 * already refused such a service; this path did not.
+	 *
+	 * The assertion is that the resources are never even consulted: a refusal
+	 * that still computed availability and then discarded it would leak the
+	 * same information through timing, and would pass a count-only test.
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/specs/appointment-booking/spec.md
+	 */
+	public function testGetAvailableSlotsRefusesAServiceNotBookableOnline(): void {
+		$offline = self::SERVICE_FREE_HAIRCUT;
+		$offline['bookableOnline'] = false;
+
+		$object = $this->createMock(originalClassName: ObjectServiceInterface::class);
+		$object->method('find')->willReturn($offline);
+
+		$eligibility = $this->createMock(originalClassName: EligibilityService::class);
+		$eligibility->expects($this->never())->method('getEligibleResources');
+
+		$availability = $this->createMock(originalClassName: AvailabilityService::class);
+		$availability->expects($this->never())->method('computeAvailability');
+
+		[$service] = $this->buildService(
+			objectService: $object,
+			availability: $availability,
+			eligibility: $eligibility
+		);
+
+		$this->assertSame(
+			expected: [],
+			actual: $service->getAvailableSlots(serviceId: 'svc-haircut', date: '2026-06-15')
+		);
+
+	}//end testGetAvailableSlotsRefusesAServiceNotBookableOnline()
 
 	/**
 	 * A confirmed-from-creation Booking pushes a VEVENT through the calendar


### PR DESCRIPTION
`GET /portal/availability` is `#[PublicPage]` and reads `serviceId` straight
from the request, passing it unscoped into `BookingService::getAvailableSlots()`.
That method loaded the service and computed its free slots **without checking
whether the service is offered online**.

Both of its siblings make that check:

| | check |
|---|---|
| `listBookableServices()` | filters `findAll()` on `'bookableOnline' => true` — the public list never shows such a service |
| `createBookingFromPortal()` | throws `Service is not bookable online` before creating anything |

So an anonymous caller supplying any `serviceId` — the portal's own list is
public and ids are guessable slugs — could read the free/busy pattern of a
service the portal deliberately never offers. Not a booking, and not the
object's contents, but a real disclosure of internal scheduling.

Found by **gate-7**, reported as `publicpage-unscoped-object-lookup`. This is
the finding that gate exists for, and it was sitting behind two other gate-7
findings in this fleet that turned out to be false positives — which is the
argument for triaging them one by one rather than waiving the category.

### The fixture is part of the story

`SERVICE_FREE_HAIRCUT` carried no `bookableOnline` key at all, so no test
distinguished a service the public may see from one it may not, and the missing
check could not fail anything.

It now carries the flag, and a new test asserts a service without it yields no
slots **and that the eligibility and availability services are never consulted** —
a refusal that still computed availability and then discarded it would leak the
same information through timing and would pass a count-only assertion.
