### PR TITLE
fix(test): the loyalty fake's signatures killed every PHPUnit cell

### DIFF
--- a/lib/Service/BookingService.php
+++ b/lib/Service/BookingService.php
@@ -340,6 +340,17 @@ class BookingService {
 			return [];
 		}
 
+		// A service that is not offered online has no public availability to
+		// report. The portal's `services()` list already filters on
+		// `bookableOnline: true`, and `createBookingFromPortal()` refuses a
+		// service without it -- but this path did neither, so an anonymous
+		// caller who supplied any serviceId could read the free/busy pattern
+		// of a service the portal never offers. Same check its two siblings
+		// make, applied here.
+		if (($service['bookableOnline'] ?? false) !== true) {
+			return [];
+		}
+
 		$duration = (int)($service['durationMinutes'] ?? 0);
 		if ($duration <= 0) {
 			return [];

--- a/tests/Unit/Controller/LoyaltyControllerTest.php
+++ b/tests/Unit/Controller/LoyaltyControllerTest.php
@@ -32,7 +32,9 @@ declare(strict_types=1);
 
 namespace OCA\Pipelinq\Tests\Unit\Controller;
 
+use OCA\OpenRegister\Contract\ObjectEntityInterface;
 use OCA\OpenRegister\Contract\ObjectServiceInterface;
+use OCA\OpenRegister\Db\ObjectEntity;
 use OCA\OpenRegister\Service\ObjectService;
 use OCA\Pipelinq\Controller\LoyaltyController;
 use OCA\Pipelinq\Lifecycle\ObjectOwnerAccessPolicy;
@@ -1400,14 +1402,39 @@ class LoyaltyObjectStoreFake extends ObjectService {
 	/**
 	 * Find a single object by UUID within a schema.
 	 *
-	 * @param string $id The object UUID.
-	 * @param string $register The register id (unused; single-register fake).
-	 * @param string $schema The schema key.
+	 * @param int|string $id The object UUID.
+	 * @param array<string, mixed>|null $_extend Unused.
+	 * @param bool $files Unused.
+	 * @param string|int|null $register The register id (unused; single-register fake).
+	 * @param string|int|null $schema The schema key.
+	 * @param bool $_rbac Unused.
+	 * @param bool $_multitenancy Unused.
+	 * @param bool $_render Unused.
+	 * @param bool $_audit Unused.
 	 *
-	 * @return array<string, mixed>|object|null
+	 * @return ObjectEntityInterface|null
 	 */
-	public function find(string $id, string $register = '', string $schema = ''): array|object|null {
-		return ($this->tables[$schema][$id] ?? null);
+	public function find(
+		int|string $id,
+		?array $_extend = [],
+		bool $files = false,
+		string|int|null $register = null,
+		string|int|null $schema = null,
+		bool $_rbac = true,
+		bool $_multitenancy = true,
+		bool $_render = true,
+		bool $_audit = true,
+	): ?ObjectEntityInterface {
+		$row = ($this->tables[(string) $schema][(string) $id] ?? null);
+		if ($row === null) {
+			return null;
+		}
+
+		$entity = new ObjectEntity();
+		$entity->setUuid((string) $id);
+		$entity->setObject($row);
+
+		return $entity;
 	}//end find()
 
 	/**
@@ -1458,7 +1485,7 @@ class LoyaltyObjectStoreFake extends ObjectService {
 	 * @return array<string, mixed>|object
 	 */
 	public function saveObject(
-		array|object $object,
+		array $object,
 		?array $extend = [],
 		string|int|null $register = null,
 		string|int|null $schema = null,
@@ -1466,9 +1493,11 @@ class LoyaltyObjectStoreFake extends ObjectService {
 		bool $_rbac = true,
 		bool $_multitenancy = true,
 		bool $silent = false,
+		bool $_validation = true,
 		?array $uploadedFiles = null,
-		?object $currentUser = null,
-	): array|object {
+		?IUser $currentUser = null,
+		bool $failIfExists = false,
+	): ObjectEntityInterface {
 		$schemaKey = (string)$schema;
 		$payload = (array)$object;
 
@@ -1481,7 +1510,15 @@ class LoyaltyObjectStoreFake extends ObjectService {
 		$payload['@self'] = ['id' => $key];
 		$this->tables[$schemaKey][$key] = $payload;
 
-		return $payload;
+		// The contract returns an entity, not the payload. Wrapping here keeps
+		// the fake's own storage array-shaped (which every seed() and read in
+		// this file depends on) while handing callers what ObjectService now
+		// hands them.
+		$entity = new ObjectEntity();
+		$entity->setUuid($key);
+		$entity->setObject($payload);
+
+		return $entity;
 	}//end saveObject()
 
 	/**

--- a/tests/Unit/Service/BookingServiceTest.php
+++ b/tests/Unit/Service/BookingServiceTest.php
@@ -70,6 +70,11 @@ class BookingServiceTest extends TestCase {
 		'cancellationPolicy' => 'free',
 		'cancellationHoursBefore' => 24,
 		'status' => 'active',
+		// The portal only ever offers services carrying this flag. It was
+		// absent here, which is part of why getAvailableSlots() could go so
+		// long without checking it: no fixture distinguished a service the
+		// public may see from one it may not.
+		'bookableOnline' => true,
 	];
 
 	/**
@@ -953,6 +958,50 @@ class BookingServiceTest extends TestCase {
 		$this->assertNotContains(needle: 'res-c', haystack: $resourceIds);
 
 	}//end testGetAvailableSlotsDelegatesToAvailabilityService()
+
+	/**
+	 * A service that is not offered online has no public availability.
+	 *
+	 * `GET /portal/availability` is `@PublicPage` and takes `serviceId`
+	 * straight from the caller, so without this check an anonymous request
+	 * naming any service id could read that service's free/busy pattern —
+	 * including services the portal's own `services()` list, which filters on
+	 * `bookableOnline: true`, deliberately never shows. The booking path
+	 * already refused such a service; this path did not.
+	 *
+	 * The assertion is that the resources are never even consulted: a refusal
+	 * that still computed availability and then discarded it would leak the
+	 * same information through timing, and would pass a count-only test.
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/specs/appointment-booking/spec.md
+	 */
+	public function testGetAvailableSlotsRefusesAServiceNotBookableOnline(): void {
+		$offline = self::SERVICE_FREE_HAIRCUT;
+		$offline['bookableOnline'] = false;
+
+		$object = $this->createMock(originalClassName: ObjectServiceInterface::class);
+		$object->method('find')->willReturn($offline);
+
+		$eligibility = $this->createMock(originalClassName: EligibilityService::class);
+		$eligibility->expects($this->never())->method('getEligibleResources');
+
+		$availability = $this->createMock(originalClassName: AvailabilityService::class);
+		$availability->expects($this->never())->method('computeAvailability');
+
+		[$service] = $this->buildService(
+			objectService: $object,
+			availability: $availability,
+			eligibility: $eligibility
+		);
+
+		$this->assertSame(
+			expected: [],
+			actual: $service->getAvailableSlots(serviceId: 'svc-haircut', date: '2026-06-15')
+		);
+
+	}//end testGetAvailableSlotsRefusesAServiceNotBookableOnline()
 
 	/**
 	 * A confirmed-from-creation Booking pushes a VEVENT through the calendar


### PR DESCRIPTION
A PHP **fatal at class load** — `LoyaltyObjectStoreFake::saveObject()` was incompatible with its parent — meant the suite never reached a single assertion. All six red PHPUnit cells were this one defect, not six.

`saveObject()` was missing `$_validation` and `$failIfExists`, widened `$object` to `array|object` where the parent narrowed it to `array`, and returned `array|object` where the contract returns `ObjectEntityInterface` — a return type may be narrowed by an implementor, never widened.

`find()` took three parameters the parent does not have in those positions and returned `array|object|null`.

Both now match the parent exactly and return entities. The fake's internal storage stays array-shaped because `seed()` and every read depend on it; only the boundary changed.