### PR TITLE
fix(gates): mark the four dormant capabilities pipelinq#764 already decided

### DIFF
--- a/lib/Service/External/Berichtenbox/LogBerichtenboxAdapter.php
+++ b/lib/Service/External/Berichtenbox/LogBerichtenboxAdapter.php
@@ -173,6 +173,10 @@ class LogBerichtenboxAdapter implements BerichtenboxAdapterInterface {
 	 * @param string $bsn 9-digit Burgerservicenummer.
 	 *
 	 * @return BerichtenboxResult The mailbox-status outcome.
+	 *
+	 * @orphan-auth exclude belongs to the log-only Berichtenbox adapter, the stand-in used until a real
+	 * mailbox integration lands; the method is the shape that integration will
+	 * call. Pending in pipelinq#764.
 	 */
 	public function checkMailbox(string $bsn): BerichtenboxResult {
 		$reference = 'bbk-mbox-log-' . bin2hex(random_bytes(6));

--- a/lib/Service/Portal/PortalTenantService.php
+++ b/lib/Service/Portal/PortalTenantService.php
@@ -288,6 +288,11 @@ class PortalTenantService {
 	 * @param string $tenantId The tenant id.
 	 *
 	 * @return bool True when self-signup is allowed.
+	 *
+	 * @orphan-auth exclude reads a live schema field for a self-signup flow that is not built yet. The
+	 * fix is to BUILD that flow and call this from it — never to invent an
+	 * account-creation endpoint just to give the predicate a caller. Decision
+	 * pending in pipelinq#764.
 	 */
 	public function isSelfSignupAllowed(string $tenantId): bool {
 		$config = $this->getConfig(tenantId: $tenantId);

--- a/lib/Service/WalkInQueueService.php
+++ b/lib/Service/WalkInQueueService.php
@@ -146,6 +146,15 @@ class WalkInQueueService {
 	 * @throws RuntimeException If OpenRegister is unavailable.
 	 *
 	 * @spec openspec/specs/appointment-booking/spec.md
+	 *
+	 * @orphaned-write-capability exclude redundant, not missing —
+	 * src/components/bookings/WalkInQueuePanel.vue reads and writes walkInTicket
+	 * objects DIRECTLY against OpenRegister (ADR-022), so this wrapper has no
+	 * caller by design rather than by omission. callNext, callTicket,
+	 * serveTicket and abandonTicket are equally caller-less; only rebalance()
+	 * is live. Deleting the five wrappers is the agreed remedy and means
+	 * deleting their unit tests too, which is not a change to make on a gate's
+	 * say-so — pipelinq#764 item 5 carries that decision.
 	 */
 	public function createTicket(array $data): string {
 		$displayName = trim((string)($data['displayName'] ?? ''));

--- a/lib/Service/Zgw/ZgwCoexistenceValidator.php
+++ b/lib/Service/Zgw/ZgwCoexistenceValidator.php
@@ -91,6 +91,11 @@ class ZgwCoexistenceValidator {
 	 * @return void
 	 *
 	 * @throws DoubleWritePathException When both ZGW + StUF are write-enabled.
+	 *
+	 * @orphan-auth exclude guards against two write paths being active for one gemeente at once. It
+	 * throws rather than returning, so wiring it changes behaviour on a live
+	 * ZGW/StUF coexistence path and is a decision, not a refactor. Pending in
+	 * pipelinq#764.
 	 */
 	public function validateWritePath(string $municipalityCode): void {
 		if ($municipalityCode === '') {


### PR DESCRIPTION
gate-6 (3) and gate-57 (1) were flagging capabilities already investigated, written up per-finding and assigned an owner in #764. The findings are correct; the response isn't mine to make.

Until now only the gate-57 half could say so — gate-6 had no exclusion at all, so identical findings behind it kept failing the build. That asymmetry is fixed in ConductionNL/.github#479.

Each now carries a reason. `WalkInQueueService::createTicket` is redundant rather than missing: `WalkInQueuePanel.vue` writes `walkInTicket` objects directly against OpenRegister per ADR-022, and #764 item 5 already records that deleting the five wrappers means deleting their unit tests too — not a change to make on a gate's say-so.