### PR TITLE
fix(gate-66): establish OpenRegister availability before each container lookup

### DIFF
--- a/lib/BackgroundJob/AvailabilityCacheRefreshJob.php
+++ b/lib/BackgroundJob/AvailabilityCacheRefreshJob.php
@@ -338,6 +338,14 @@ class AvailabilityCacheRefreshJob extends TimedJob {
 	 * @throws RuntimeException If OpenRegister is not available.
 	 */
 	private function getObjectService(): object {
+		// Availability established before the reach (ADR-083) — the lookup names
+		// OpenRegister only as a string, so without this the dependency is
+		// declared nowhere a reader or a gate can see it. Converting to a typed
+		// constructor property is the ADR's preferred shape: pipelinq#1160.
+		if (class_exists('\OCA\OpenRegister\Service\ObjectService') === false) {
+			throw new RuntimeException('The OpenRegister app is not installed');
+		}
+
 		try {
 			return $this->container->get('OCA\\OpenRegister\\Service\\ObjectService');
 		} catch (Throwable $e) {

--- a/lib/Controller/ActivityTimelineController.php
+++ b/lib/Controller/ActivityTimelineController.php
@@ -90,6 +90,16 @@ class ActivityTimelineController extends Controller {
 	 * @return bool Whether the object could be verified.
 	 */
 	private function objectAccessible(string $entityId, string $userId): bool {
+		// Availability established before the reach (ADR-083) — the lookup names
+		// OpenRegister only as a string, so without this the dependency is
+		// declared nowhere a reader or a gate can see it. This path already
+		// treats an unavailable OpenRegister as "cannot verify" and denies, so
+		// the absent case returns false rather than throwing. Converting to a
+		// typed constructor property is the ADR's preferred shape: pipelinq#1160.
+		if (class_exists('\OCA\OpenRegister\Service\ObjectService') === false) {
+			return false;
+		}
+
 		try {
 			$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
 			$object = $objectService->find($entityId, []);

--- a/lib/Service/AppointmentCalendarLeafProvider.php
+++ b/lib/Service/AppointmentCalendarLeafProvider.php
@@ -851,6 +851,14 @@ class AppointmentCalendarLeafProvider {
 	 * @throws RuntimeException If OpenRegister is not available.
 	 */
 	private function getObjectService(): object {
+		// Availability established before the reach (ADR-083) — the lookup names
+		// OpenRegister only as a string, so without this the dependency is
+		// declared nowhere a reader or a gate can see it. Converting to a typed
+		// constructor property is the ADR's preferred shape: pipelinq#1160.
+		if (class_exists('\OCA\OpenRegister\Service\ObjectService') === false) {
+			throw new RuntimeException('The OpenRegister app is not installed');
+		}
+
 		try {
 			return $this->container->get('OCA\\OpenRegister\\Service\\ObjectService');
 		} catch (Throwable $e) {

--- a/lib/Service/CtiDispositionService.php
+++ b/lib/Service/CtiDispositionService.php
@@ -200,6 +200,16 @@ class CtiDispositionService {
 			return null;
 		}
 
+		// Availability established before the reach (ADR-083) — the lookup names
+		// OpenRegister only as a string, so without this the dependency is
+		// declared nowhere a reader or a gate can see it. This method already
+		// returns null when it cannot record a disposition, so the absent case
+		// takes that path. Converting to a typed constructor property is the
+		// ADR's preferred shape: pipelinq#1160.
+		if (class_exists('\OCA\OpenRegister\Service\ObjectService') === false) {
+			return null;
+		}
+
 		try {
 			$objectService = $this->container->get('OCA\\OpenRegister\\Service\\ObjectService');
 			$saved = $objectService->saveObject(

--- a/lib/Service/KccWerkplekService.php
+++ b/lib/Service/KccWerkplekService.php
@@ -97,6 +97,16 @@ class KccWerkplekService {
 	 * @spec openspec/changes/kcc-werkplek/tasks.md#task-2
 	 */
 	private function getObjectService(): \OCA\OpenRegister\Contract\ObjectServiceInterface {
+		// Availability established before the reach (ADR-083). The container
+		// lookup below names OpenRegister only as a string, so without this the
+		// dependency is declared nowhere a reader or a gate can see it — and a
+		// missing app is indistinguishable from a container that failed for
+		// some other reason. See pipelinq#1160: the ADR's preferred shape is a
+		// typed constructor property, which is a larger change than this one.
+		if (class_exists('\OCA\OpenRegister\Service\ObjectService') === false) {
+			throw new RuntimeException('The OpenRegister app is not installed');
+		}
+
 		try {
 			return $this->container->get('OCA\\OpenRegister\\Service\\ObjectService');
 		} catch (\Throwable $e) {

--- a/lib/Service/PosPaymentService.php
+++ b/lib/Service/PosPaymentService.php
@@ -1123,6 +1123,14 @@ class PosPaymentService {
 			throw new OCSNotFoundException('Transaction not found');
 		}
 
+		// Availability established before the reach (ADR-083) — the lookup names
+		// OpenRegister only as a string, so without this the dependency is
+		// declared nowhere a reader or a gate can see it. Converting to a typed
+		// constructor property is the ADR's preferred shape: pipelinq#1160.
+		if (class_exists('\OCA\OpenRegister\Service\ObjectService') === false) {
+			throw new OCSNotFoundException('Transaction storage unavailable');
+		}
+
 		try {
 			$objectService = $this->container->get('OCA\\OpenRegister\\Service\\ObjectService');
 		} catch (Throwable $e) {

--- a/lib/Service/PosTenderService.php
+++ b/lib/Service/PosTenderService.php
@@ -1095,6 +1095,14 @@ class PosTenderService {
 	 * @throws RuntimeException When OR is not available.
 	 */
 	private function getObjectService(): object {
+		// Availability established before the reach (ADR-083) — the lookup names
+		// OpenRegister only as a string, so without this the dependency is
+		// declared nowhere a reader or a gate can see it. Converting to a typed
+		// constructor property is the ADR's preferred shape: pipelinq#1160.
+		if (class_exists('\OCA\OpenRegister\Service\ObjectService') === false) {
+			throw new RuntimeException('The OpenRegister app is not installed');
+		}
+
 		try {
 			return $this->container->get('OCA\\OpenRegister\\Service\\ObjectService');
 		} catch (Throwable $e) {

--- a/lib/Service/PosTransactionService.php
+++ b/lib/Service/PosTransactionService.php
@@ -1446,6 +1446,14 @@ class PosTransactionService {
 	 * @spec openspec/changes/pos-transaction-core/tasks.md#2.1
 	 */
 	private function getObjectService(): object {
+		// Availability established before the reach (ADR-083) — the lookup names
+		// OpenRegister only as a string, so without this the dependency is
+		// declared nowhere a reader or a gate can see it. Converting to a typed
+		// constructor property is the ADR's preferred shape: pipelinq#1160.
+		if (class_exists('\OCA\OpenRegister\Service\ObjectService') === false) {
+			throw new RuntimeException('The OpenRegister app is not installed');
+		}
+
 		try {
 			return $this->container->get('OCA\OpenRegister\Service\ObjectService');
 		} catch (\Throwable $e) {


### PR DESCRIPTION
Ten lookups across eight classes named OpenRegister only as a string. Each now checks `class_exists()` first and takes its own existing absent path.

**This is the weaker of the gate's two accepted remedies.** ADR-083 rule 1 is a typed constructor property; the guard makes the dependency visible but does not give it a type. The trade is explained in #1160, which carries the conversion per-file — the short version is that eight classes are built by nine test files, on a suite whose real baseline was minutes old after a class-load fatal was cleared.