### PR TITLE
fix(blast): repoint connector source listing + send path at OpenConnector's current API

### DIFF
--- a/lib/Service/BlastService.php
+++ b/lib/Service/BlastService.php
@@ -6,8 +6,13 @@
  * Send-orchestration engine for the marketing-segmentation-and-blast
  * chain. Owns the lifecycle transition from `draft` Blast to a queue of
  * BlastDelivery rows and the throttled dispatch via openconnector. Never
- * touches provider SDKs or credentials — every send goes through
- * `OCA\OpenConnector\Service\SourceService::executeAction()` (ADR-005).
+ * touches provider SDKs or credentials — every send is a generic HTTP call
+ * through `OCA\OpenConnector\Service\CallService::call()` against the
+ * connector Source resolved from OpenRegister's `openconnector`/`source`
+ * register+schema (ADR-005). `SourceService` / `executeAction()` no longer
+ * exist in OpenConnector — its Source/Mapping/Synchronization/Job entities
+ * moved onto OpenRegister's generic object API when OpenConnector's CRUD
+ * was rebuilt on top of it.
  *
  * Reads Blast / BlastDelivery / CampaignTemplate schemas (member 01) via
  * `ObjectService`, consults `SegmentService` (member 02) for recipient
@@ -104,6 +109,18 @@ class BlastService {
 	 * ComplianceService before dispatch.
 	 */
 	private const STATUS_UNSUBSCRIBED_BEFORE_SEND = 'unsubscribed-before-send';
+
+	/**
+	 * OpenConnector's own OpenRegister register slug. Source objects
+	 * (formerly served by the now-removed `SourceService`) live here, not
+	 * in pipelinq's own `register` app-config register.
+	 */
+	private const OPENCONNECTOR_REGISTER_SLUG = 'openconnector';
+
+	/**
+	 * OpenConnector's Source schema slug within {@see OPENCONNECTOR_REGISTER_SLUG}.
+	 */
+	private const OPENCONNECTOR_SOURCE_SCHEMA_SLUG = 'source';
 
 	/**
 	 * Constructor.
@@ -303,13 +320,19 @@ class BlastService {
 	 * Dispatch queued BlastDeliveries for a Blast through openconnector.
 	 *
 	 * Reads queued BlastDelivery rows for `$blastId`, batches them
-	 * (default 50), renders the CampaignTemplate per recipient, then calls
-	 * the openconnector source's `send-mail` action. The returned
-	 * `providerId` is persisted on the BlastDelivery and the row
-	 * transitions to `sent`. Rate limit is read from the openconnector
-	 * source's `sendRateLimit` (preferred over the caller's
-	 * `$maxPerSecond` when the source value is smaller, so the source
-	 * config always wins) and enforced by sleeping between batches.
+	 * (default 50), renders the CampaignTemplate per recipient, then POSTs
+	 * the rendered payload to the openconnector Source's base URL via
+	 * `CallService::call()`. The returned `providerId` (parsed from the
+	 * provider's JSON response, when present) is persisted on the
+	 * BlastDelivery and the row transitions to `sent`. Rate limit is read
+	 * from the Source's `rateLimitLimit` / `rateLimitWindow` fields
+	 * (preferred over the caller's `$maxPerSecond` when the source value is
+	 * smaller, so the source config always wins) and enforced by sleeping
+	 * between batches.
+	 *
+	 * The Source is resolved ONCE per call (not per delivery) via
+	 * OpenRegister's `openconnector`/`source` register+schema and reused for
+	 * every delivery in the batch.
 	 *
 	 * Returns the count of deliveries successfully accepted by the
 	 * provider. Pipelinq code never reads provider credentials and never
@@ -349,8 +372,13 @@ class BlastService {
 			return 0;
 		}
 
+		$source = $this->resolveConnectorSource(connectorSourceId: $connectorSourceId);
+		if ($source === null) {
+			return 0;
+		}
+
 		$rateLimit = $this->resolveRateLimit(
-			connectorSourceId: $connectorSourceId,
+			source: $source,
 			callerRate: $maxPerSecond,
 		);
 		$batchSize = $this->resolveBatchSize();
@@ -368,6 +396,7 @@ class BlastService {
 				$result = $this->sendOneDelivery(
 					delivery: $delivery,
 					template: $template,
+					source: $source,
 					connectorSourceId: $connectorSourceId,
 				);
 				if ($result === false) {
@@ -1056,15 +1085,23 @@ class BlastService {
 	}//end persistQueuedDelivery()
 
 	/**
-	 * Issue one openconnector `send-mail` call and persist the result.
+	 * POST one rendered delivery to the openconnector Source's base URL via
+	 * `CallService::call()` and persist the result.
 	 *
 	 * @param array<string, mixed> $delivery Queued BlastDelivery row.
 	 * @param array<string, mixed> $template CampaignTemplate row.
-	 * @param string $connectorSourceId Source UUID.
+	 * @param array<string, mixed>|object $source Resolved openconnector Source
+	 *                                            entity (from {@see resolveConnectorSource()}).
+	 *                                            Always an `ObjectEntity` in
+	 *                                            production; an array in tests
+	 *                                            is tolerated for the same
+	 *                                            reason {@see toArray()} exists.
+	 * @param string $connectorSourceId Source UUID (for logging only —
+	 *                                  `$source` is already resolved).
 	 *
-	 * @return bool True when the provider accepted the call.
+	 * @return bool True when the provider accepted the call (2xx response).
 	 */
-	private function sendOneDelivery(array $delivery, array $template, string $connectorSourceId): bool {
+	private function sendOneDelivery(array $delivery, array $template, array|object $source, string $connectorSourceId): bool {
 		$rendered = $this->renderTemplate(template: $template, delivery: $delivery);
 
 		if ($this->firstPartyTrackingEnabled() === true) {
@@ -1074,35 +1111,39 @@ class BlastService {
 			);
 		}
 
-		$providerId = null;
-		try {
-			$sourceService = $this->container->get('OCA\\OpenConnector\\Service\\SourceService');
-		} catch (Throwable $e) {
-			$this->logger->warning(
-				'BlastService.sendOneDelivery: SourceService unavailable',
-				['exception' => $e->getMessage()]
-			);
+		$callService = $this->getCallService();
+		if ($callService === null) {
 			return false;
 		}
 
 		try {
-			if (method_exists($sourceService, 'executeAction') === false) {
-				$this->logger->warning(
-					'BlastService.sendOneDelivery: SourceService lacks executeAction',
-					['connectorSourceId' => $connectorSourceId]
-				);
-				return false;
-			}
-
-			$result = $sourceService->executeAction($connectorSourceId, 'send-mail', $rendered);
-			$providerId = $this->extractProviderId(result: $result);
+			$callLog = $callService->call(
+				source: $source,
+				endpoint: '',
+				method: 'POST',
+				config: ['json' => $rendered],
+			);
 		} catch (Throwable $e) {
 			$this->logger->warning(
-				'BlastService.sendOneDelivery: send-mail failed',
+				'BlastService.sendOneDelivery: connector call failed (transport)',
 				['connectorSourceId' => $connectorSourceId, 'exception' => $e->getMessage()]
 			);
 			return false;
 		}
+
+		$callLogData = $this->toArray(value: $callLog);
+		$statusCode = (int)($callLogData['statusCode'] ?? 0);
+		if ($statusCode < 200 || $statusCode >= 300) {
+			$this->logger->warning(
+				'BlastService.sendOneDelivery: connector source responded with a non-2xx status',
+				['connectorSourceId' => $connectorSourceId, 'statusCode' => $statusCode]
+			);
+			return false;
+		}
+
+		$providerId = $this->extractProviderId(
+			result: $this->decodeCallLogResponseBody(callLogData: $callLogData),
+		);
 
 		$payload = $delivery;
 		$payload['status'] = 'sent';
@@ -1119,6 +1160,118 @@ class BlastService {
 
 		return true;
 	}//end sendOneDelivery()
+
+	/**
+	 * Resolve the OpenConnector Source object addressed by `$connectorSourceId`.
+	 *
+	 * Sources are OpenRegister objects in the `openconnector` register /
+	 * `source` schema (OpenConnector's own CRUD, not pipelinq's `register`
+	 * app-config register) — `OCA\OpenConnector\Service\SourceService`, the
+	 * class this used to resolve through, no longer exists.
+	 *
+	 * @param string $connectorSourceId Source UUID.
+	 *
+	 * @return array<string, mixed>|object|null The resolved Source entity
+	 *                                           (an `ObjectEntity` in
+	 *                                           production), or null when
+	 *                                           OpenRegister is unavailable
+	 *                                           or the source does not exist.
+	 */
+	private function resolveConnectorSource(string $connectorSourceId): array|object|null {
+		$objectService = $this->getObjectService();
+		if ($objectService === null) {
+			return null;
+		}
+
+		try {
+			$source = $objectService->find(
+				id: $connectorSourceId,
+				register: self::OPENCONNECTOR_REGISTER_SLUG,
+				schema: self::OPENCONNECTOR_SOURCE_SCHEMA_SLUG,
+			);
+		} catch (Throwable $e) {
+			$this->logger->warning(
+				'BlastService.resolveConnectorSource: lookup failed',
+				['connectorSourceId' => $connectorSourceId, 'exception' => $e->getMessage()]
+			);
+			return null;
+		}
+
+		if ($source === null) {
+			$this->logger->warning(
+				'BlastService.resolveConnectorSource: connector source not found',
+				['connectorSourceId' => $connectorSourceId]
+			);
+			return null;
+		}
+
+		if (is_array($source) === false && is_object($source) === false) {
+			return null;
+		}
+
+		return $source;
+	}//end resolveConnectorSource()
+
+	/**
+	 * Resolve OpenConnector's `CallService` from the DI container.
+	 *
+	 * @return object|null The service, or null when OpenConnector is
+	 *                      unavailable or lacks `call()`.
+	 */
+	private function getCallService(): ?object {
+		try {
+			$callService = $this->container->get('OCA\\OpenConnector\\Service\\CallService');
+		} catch (Throwable $e) {
+			$this->logger->error(
+				'BlastService.getCallService: OpenConnector CallService unavailable',
+				['exception' => $e->getMessage()]
+			);
+			return null;
+		}
+
+		if (method_exists($callService, 'call') === false) {
+			$this->logger->error('BlastService.getCallService: CallService lacks call()');
+			return null;
+		}
+
+		return $callService;
+	}//end getCallService()
+
+	/**
+	 * Decode a CallLog's `response.body` for provider-id extraction.
+	 *
+	 * Mirrors OpenConnector's own `SourceCallNode::decodeBody()` convention:
+	 * a UTF-8 JSON-object body is decoded; anything else (non-UTF-8/base64,
+	 * non-JSON, empty) is left for {@see extractProviderId()} to fail
+	 * gracefully on.
+	 *
+	 * @param array<string, mixed> $callLogData CallLog payload
+	 *                                          (`getObject()`/`jsonSerialize()` shape).
+	 *
+	 * @return mixed Decoded JSON body, or null when it cannot be decoded.
+	 */
+	private function decodeCallLogResponseBody(array $callLogData): mixed {
+		$response = ($callLogData['response'] ?? null);
+		if (is_array($response) === false) {
+			return null;
+		}
+
+		$body = ($response['body'] ?? null);
+		if (is_string($body) === false || $body === '') {
+			return null;
+		}
+
+		if ((string)($response['encoding'] ?? 'UTF-8') !== 'UTF-8') {
+			return null;
+		}
+
+		$decoded = json_decode($body, true);
+		if (json_last_error() === JSON_ERROR_NONE && is_array($decoded) === true) {
+			return $decoded;
+		}
+
+		return null;
+	}//end decodeCallLogResponseBody()
 
 	/**
 	 * Whether first-party open/click tracking is enabled.
@@ -1184,9 +1337,9 @@ class BlastService {
 	}//end injectTrackingLinks()
 
 	/**
-	 * Extract a provider message id from a `send-mail` action result.
+	 * Extract a provider message id from a decoded connector response body.
 	 *
-	 * @param mixed $result Action result.
+	 * @param mixed $result Decoded response body.
 	 *
 	 * @return string|null Provider message id.
 	 *
@@ -1228,7 +1381,7 @@ class BlastService {
 	 * @param array<string, mixed> $template Template payload.
 	 * @param array<string, mixed> $delivery Delivery payload.
 	 *
-	 * @return array<string, mixed> Rendered send-mail action input.
+	 * @return array<string, mixed> Rendered request body for the connector call.
 	 */
 	private function renderTemplate(array $template, array $delivery): array {
 		$tokens = [
@@ -1254,18 +1407,18 @@ class BlastService {
 	/**
 	 * Resolve the effective rate limit (messages per second).
 	 *
-	 * The openconnector source's `sendRateLimit` always wins when it is
-	 * lower than the caller's value (so a tight provider limit cannot be
-	 * blown by a permissive caller). When neither is set, fall back to
+	 * The openconnector source's rate limit always wins when it is lower
+	 * than the caller's value (so a tight provider limit cannot be blown by
+	 * a permissive caller). When neither is set, fall back to
 	 * `DEFAULT_RATE_LIMIT_PER_SECOND` (100).
 	 *
-	 * @param string $connectorSourceId OC source UUID.
+	 * @param array<string, mixed>|object $source Resolved openconnector Source entity.
 	 * @param int $callerRate Caller's max-per-second.
 	 *
 	 * @return int Resolved rate limit (>=1).
 	 */
-	private function resolveRateLimit(string $connectorSourceId, int $callerRate): int {
-		$sourceRate = $this->readSourceRateLimit(connectorSourceId: $connectorSourceId);
+	private function resolveRateLimit(array|object $source, int $callerRate): int {
+		$sourceRate = $this->readSourceRateLimit(source: $source);
 		$candidate = self::DEFAULT_RATE_LIMIT_PER_SECOND;
 		if ($callerRate > 0) {
 			$candidate = $callerRate;
@@ -1279,32 +1432,41 @@ class BlastService {
 	}//end resolveRateLimit()
 
 	/**
-	 * Read the `sendRateLimit` from an openconnector source.
+	 * Read the effective per-second rate limit from an openconnector source.
 	 *
-	 * @param string $connectorSourceId OC source UUID.
+	 * The current Source schema has no single `sendRateLimit` field (that
+	 * name never existed on the migrated schema); it carries
+	 * `rateLimitLimit` (requests per window) and `rateLimitWindow` (window
+	 * size in seconds) instead. Both are optional admin-configured fields —
+	 * absent on most sources, in which case this returns null and the
+	 * caller's own rate wins.
 	 *
-	 * @return int|null Rate limit or null when unavailable.
+	 * @param array<string, mixed>|object $source Resolved openconnector Source entity.
+	 *
+	 * @return int|null Rate limit (messages/second) or null when unset.
 	 */
-	private function readSourceRateLimit(string $connectorSourceId): ?int {
-		try {
-			$sourceService = $this->container->get('OCA\\OpenConnector\\Service\\SourceService');
-		} catch (Throwable $e) {
+	private function readSourceRateLimit(array|object $source): ?int {
+		$limitValue = $this->readSourceField(source: $source, field: 'rateLimitLimit');
+		if ($limitValue === null || is_numeric($limitValue) === false) {
 			return null;
 		}
 
-		try {
-			if (method_exists($sourceService, 'find') === true) {
-				$source = $sourceService->find($connectorSourceId);
-				$value = $this->readSourceField(source: $source, field: 'sendRateLimit');
-				if ($value !== null) {
-					return (int)$value;
-				}
-			}
-		} catch (Throwable $e) {
+		$limit = (int)$limitValue;
+		if ($limit <= 0) {
 			return null;
 		}
 
-		return null;
+		$windowValue = $this->readSourceField(source: $source, field: 'rateLimitWindow');
+		$window = 1;
+		if ($windowValue !== null && is_numeric($windowValue) === true) {
+			$window = (int)$windowValue;
+		}
+
+		if ($window <= 0) {
+			$window = 1;
+		}
+
+		return max(1, (int)floor($limit / $window));
 	}//end readSourceRateLimit()
 
 	/**

--- a/lib/Service/Provider/CmComSmsClient.php
+++ b/lib/Service/Provider/CmComSmsClient.php
@@ -4,7 +4,9 @@
  * Pipelinq CmComSmsClient.
  *
  * CM.com SMS provider implementation. Delegates HTTP transport to
- * openconnector's SourceService.
+ * OpenRegister's `MessageDispatchProvider` leaf (via {@see MessageDispatchTrait}),
+ * which routes through openconnector's `cmcom-sms` source. `SourceService`
+ * no longer exists in OpenConnector.
  *
  * @category Service
  * @package  OCA\Pipelinq\Service\Provider

--- a/lib/Service/Provider/MessageBirdSmsClient.php
+++ b/lib/Service/Provider/MessageBirdSmsClient.php
@@ -4,7 +4,9 @@
  * Pipelinq MessageBirdSmsClient.
  *
  * MessageBird SMS provider implementation (now Bird.com). Delegates
- * actual HTTP transport to openconnector's SourceService.
+ * actual HTTP transport to OpenRegister's `MessageDispatchProvider` leaf
+ * (via {@see MessageDispatchTrait}), which routes through openconnector's
+ * `messagebird-sms` source. `SourceService` no longer exists in OpenConnector.
  *
  * @category Service
  * @package  OCA\Pipelinq\Service\Provider

--- a/lib/Service/Provider/TwilioSmsClient.php
+++ b/lib/Service/Provider/TwilioSmsClient.php
@@ -3,10 +3,12 @@
 /**
  * Pipelinq TwilioSmsClient.
  *
- * Twilio SMS provider implementation. Delegates actual HTTP transport
- * to openconnector's SourceService (per ADR-005 — pipelinq never
- * touches a provider SDK directly) and surfaces the result as a
- * vendor-neutral SmsProviderClientInterface response.
+ * Twilio SMS provider implementation. Delegates actual HTTP transport to
+ * OpenRegister's `MessageDispatchProvider` leaf (via {@see MessageDispatchTrait}),
+ * which routes through openconnector's `twilio-sms` source (per ADR-005 —
+ * pipelinq never touches a provider SDK directly; `SourceService` no longer
+ * exists in OpenConnector) and surfaces the result as a vendor-neutral
+ * SmsProviderClientInterface response.
  *
  * @category Service
  * @package  OCA\Pipelinq\Service\Provider
@@ -52,7 +54,7 @@ class TwilioSmsClient implements SmsProviderClientInterface {
 	/**
 	 * Constructor.
 	 *
-	 * @param ContainerInterface $container DI container (for SourceService).
+	 * @param ContainerInterface $container DI container (for MessageDispatchProvider).
 	 * @param LoggerInterface $logger Logger.
 	 * @param array<string, mixed> $credentials Decoded credentials bag.
 	 * @param string $fromNumber Sender phone number (E.164).

--- a/lib/Service/WhatsAppProviderClient.php
+++ b/lib/Service/WhatsAppProviderClient.php
@@ -3,10 +3,12 @@
 /**
  * Pipelinq WhatsAppProviderClient.
  *
- * Abstraction over Meta Cloud API and BSP relay endpoints. Delegates
- * HTTP transport to openconnector's SourceService (ADR-005 — pipelinq
- * never holds a vendor SDK) and surfaces a small, test-friendly
- * surface to WhatsAppAdapter.
+ * Abstraction over Meta Cloud API and BSP relay endpoints. Delegates HTTP
+ * transport to OpenRegister's `MessageDispatchProvider` leaf (via
+ * {@see MessageDispatchTrait}), which routes through openconnector's
+ * `whatsapp-cloud-api` / `whatsapp-bsp` sources (ADR-005 — pipelinq never
+ * holds a vendor SDK; `SourceService` no longer exists in OpenConnector) and
+ * surfaces a small, test-friendly surface to WhatsAppAdapter.
  *
  * @category Service
  * @package  OCA\Pipelinq\Service

--- a/src/views/blasts/BlastForm.vue
+++ b/src/views/blasts/BlastForm.vue
@@ -77,6 +77,12 @@
 					:inputLabel="t('pipelinq', 'Connector source')"
 					label="label"
 					:loading="connectorSourcesLoading" />
+				<p
+					v-if="connectorSourcesError"
+					class="blast-form__error"
+					role="alert">
+					{{ connectorSourcesError }}
+				</p>
 			</section>
 
 			<!-- Step 5: schedule -->
@@ -210,6 +216,7 @@ export default {
 			segments: [],
 			templates: [],
 			connectorSources: [],
+			connectorSourcesError: '',
 			selectedSegment: null,
 			selectedTemplate: null,
 			selectedChannel: 'email',
@@ -395,12 +402,25 @@ export default {
 
 		/**
 		 * Load OpenConnector sources usable as email/SMS dispatch endpoints.
+		 *
+		 * OpenConnector's own `/api/sources` CRUD route was removed when its
+		 * Source/Mapping/Synchronization/Job entities moved onto OpenRegister's
+		 * generic object API — sources now live as OpenRegister objects in the
+		 * `openconnector` register, `source` schema. `type` is filtered to
+		 * `api` (the generic HTTP dispatch kind `CallService` sends through,
+		 * covering every vendor connector — Twilio/MessageBird/CM.com/WhatsApp
+		 * included); the Source schema has no distinct `email`/`sms` channel
+		 * value, so filtering on one would silently return zero results again.
 		 */
 		async loadConnectorSources() {
 			this.connectorSourcesLoading = true
+			this.connectorSourcesError = ''
 			try {
 				const { data } = await axios.get(
-					generateUrl('/apps/openconnector/api/sources?type=email,sms'),
+					generateUrl(
+						'/apps/openregister/api/objects/openconnector/source'
+						+ '?type=api&isEnabled=true&_limit=200',
+					),
 				)
 				const list = data?.results || data?.data || data || []
 				this.connectorSources = list.map((src) => ({
@@ -409,6 +429,10 @@ export default {
 				}))
 			} catch (_e) {
 				this.connectorSources = []
+				this.connectorSourcesError = this.t(
+					'pipelinq',
+					'Could not load connector sources. You can still create the blast and set a source later.',
+				)
 			} finally {
 				this.connectorSourcesLoading = false
 			}

--- a/tests/Stubs/Contract/ObjectEntityInterface.php
+++ b/tests/Stubs/Contract/ObjectEntityInterface.php
@@ -1,0 +1,86 @@
+<?php
+
+/**
+ * The object surface OpenRegister publishes to consuming apps.
+ *
+ * @license EUPL-1.2
+ * @copyright Conduction B.V.
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Contract;
+
+use JsonSerializable;
+
+/**
+ * A stored OpenRegister object, as a consuming app sees it.
+ *
+ * Scoped to what the fleet actually calls. Measured 2026-08-14 across the
+ * fifteen consuming apps:
+ *
+ *     jsonSerialize   282     getRegister      29
+ *     getObject       280     getId            18
+ *     getUuid         117     getOrganisation  11
+ *     getSchema        61     getOwner          5
+ *
+ * `OCA\OpenRegister\Db\ObjectEntity` implements this. A consuming app
+ * type-hints the interface, never the entity: the entity lives in an app that
+ * is absent from a leaf app's unit-test environment, and a return type that
+ * cannot load is the whole reason this package exists.
+ */
+interface ObjectEntityInterface extends JsonSerializable {
+
+	/**
+	 * The object's UUID.
+	 *
+	 * Nullable because the backing property is `?string` — an entity that has
+	 * not been persisted has no UUID yet. Declaring `string` here would make
+	 * OpenRegister's own class illegal, since a wider implementation return is
+	 * not permitted.
+	 *
+	 * @return string|null
+	 */
+	public function getUuid(): ?string;
+
+	/**
+	 * The stored object payload.
+	 *
+	 * `array-key`, not `string`. The implementation returns
+	 * `array{id: …, ...<array-key, mixed>}` — the payload's own keys come from
+	 * stored JSON and are not guaranteed to be strings. Declaring `string` here
+	 * makes the interface MORE specific than the class implementing it, which
+	 * psalm rejects (LessSpecificImplementedReturnType).
+	 *
+	 * @return array<array-key, mixed>
+	 */
+	public function getObject(): array;
+
+	/**
+	 * The register this object belongs to, as its identifier.
+	 *
+	 * @return string|null
+	 */
+	public function getRegister(): ?string;
+
+	/**
+	 * The schema this object conforms to, as its identifier.
+	 *
+	 * @return string|null
+	 */
+	public function getSchema(): ?string;
+
+	/**
+	 * The owning organisation, when the object carries one.
+	 *
+	 * @return string|null
+	 */
+	public function getOrganisation(): ?string;
+
+	/**
+	 * The owner's user id, when the object carries one.
+	 *
+	 * @return string|null
+	 */
+	public function getOwner(): ?string;
+}

--- a/tests/Stubs/Contract/ObjectServiceInterface.php
+++ b/tests/Stubs/Contract/ObjectServiceInterface.php
@@ -1,0 +1,558 @@
+<?php
+
+/**
+ * The data-access surface OpenRegister publishes to consuming apps.
+ *
+ * @license EUPL-1.2
+ * @copyright Conduction B.V.
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Contract;
+
+use OCP\IUser;
+
+/**
+ * OpenRegister's object store, as a consuming app sees it (ADR-022, ADR-083).
+ *
+ * ## Why this exists
+ *
+ * A leaf app cannot mock what it cannot load. OpenRegister's concrete classes
+ * are absent from a leaf app's standalone composer test environment, so every
+ * consuming app either reaches through an untyped `ContainerInterface` --
+ * hiding the dependency from readers and tooling alike -- or hand-rolls a
+ * double.
+ *
+ * The doubles are not a hypothetical cost. Measured 2026-08-14, TEN of the
+ * sixteen consuming apps already ship one:
+ *
+ *     opencatalogi 13   docudesk 12   openbuild 12   openconnector 10
+ *     hermiq        8   pipelinq  7
+ *     softwarecatalog, zaakafhandelapp, scholiq, decidesk: 0
+ *
+ * Against a real class of 88 methods. Their UNION is 23 -- ten files, ten
+ * maintainers, and between them barely a quarter of the surface. The four
+ * declaring zero methods are empty shells: they satisfy a type-hint and
+ * nothing else, so any call through them is unchecked by construction.
+ *
+ * That is what this interface replaces: one definition, owned by the app that
+ * implements it, which cannot drift from the implementation without PHP
+ * refusing to declare the class.
+ *
+ * ## Scope is measured, not guessed
+ *
+ * The first draft of this file carried the eight most-called methods. Counted
+ * per CALL that looked convincing; counted per CLASS it was not, because a
+ * class can only type-hint the interface if EVERY method it calls is on it:
+ *
+ *     8 methods  ->  587 of 1001 consumer classes ( 58%)
+ *
+ * 414 classes -- the apps that would have had to keep their container hop --
+ * were invisible in the per-call ranking. Re-measured per class, resolving the
+ * receiver to OpenRegister's `ObjectService` (two apps ship a local class of
+ * the same name, which the first count silently folded in):
+ *
+ *     829 consumer classes call 28 distinct methods.
+ *
+ * This interface declares 25 of them, covering 819 of the 829 classes (98.8%).
+ * The four it omits are omitted for a reason, and the ten classes they hold
+ * back are listed rather than left to be discovered:
+ *
+ *     renderEntity()     takes a concrete `ObjectEntity`. An interface
+ *                        parameter of `ObjectEntityInterface` would be WIDER
+ *                        than the implementation accepts, which PHP rejects.
+ *                        Widening the implementation instead is a real change
+ *                        with real risk, so it is a separate decision.
+ *                        Blocks 5: opencatalogi PublicationsController,
+ *                        openconnector SynchronizationService, zaakafhandelapp
+ *                        ZGWZaak{Lifecycle,Validation}Service and ZGWLogicService.
+ *     getMapper()        returns ObjectServiceMapperAdapter -- an OpenRegister
+ *                        type. It is an escape hatch that leaks the
+ *                        implementation whatever we do here. Blocks 3:
+ *                        openconnector EndpointService, LtiNrpsService,
+ *                        PdokConnector.
+ *     getOpenRegisters() is not ours. It is declared on zaakafhandelapp's OWN
+ *                        `ObjectService` -- a locator returning this service.
+ *                        Two apps ship a local class of that name, which is
+ *                        why receiver resolution matters here. Blocks 3
+ *                        openconnector classes, all of which mean their own.
+ *     getLockInfo()      is not a method of ObjectService at all; it lives on
+ *                        LockHandler. openbuild's VersionPromotionService
+ *                        calls it on an ObjectService-typed property and
+ *                        suppressed the resulting PHPStan `method.notFound`.
+ *                        Wrapped in `catch (Throwable)`, so it has been
+ *                        silently returning null rather than locking. Blocks 1,
+ *                        and wants fixing on its own terms.
+ *
+ * ## Types
+ *
+ * Parameters are narrowed to what a consumer can express -- identifiers, not
+ * OpenRegister entities. PHP's parameter contravariance lets the
+ * implementation go on accepting `Register|Schema` objects as well, so nothing
+ * inside OpenRegister changes.
+ *
+ * Returns are the entity INTERFACE, satisfied covariantly by the concrete
+ * `ObjectEntity`.
+ *
+ * `saveObject()` takes `array`, not `array|ObjectEntityInterface`. The
+ * implementation accepts `array|ObjectEntity`, and `array|ObjectEntity` is
+ * NARROWER than `array|ObjectEntityInterface` -- so declaring the union here
+ * makes OpenRegister's own class illegal. A compatibility probe caught that
+ * before this shipped.
+ *
+ * ## RBAC
+ *
+ * `$_rbac` and `$_multitenancy` are part of the contract, not an
+ * implementation detail. ADR-022 makes OpenRegister the authorisation boundary
+ * for object access; a consumer passing `_rbac: false` is declaring that
+ * OpenRegister is NOT authorising the call, and gate-7 reads it that way.
+ *
+ * ## Changing this file
+ *
+ * Widening the contract is a deliberate act and should follow a measurement,
+ * not a convenience. Narrowing it is a BC break for every consuming app.
+ *
+ * ## Suppressions
+ *
+ * The same three PHPMD rules `ObjectService` itself already suppresses, for the
+ * same reasons, because THIS FILE CANNOT DIFFER FROM THE SIGNATURES IT
+ * DESCRIBES. Splitting `saveObject()` into flag-free methods here would simply
+ * make the interface no longer implementable.
+ *
+ * `$_rbac` and `$_multitenancy` in particular are not incidental flags: ADR-022
+ * makes them the authorisation boundary, and gate-7 reads `_rbac: false` as a
+ * consumer declaring it has taken that responsibility on. They belong in the
+ * contract precisely because they are load-bearing.
+ *
+ * @SuppressWarnings(PHPMD.BooleanArgumentFlag)   RBAC and multitenancy flags — see above.
+ * @SuppressWarnings(PHPMD.ExcessiveParameterList) Mirrors ObjectService::saveObject().
+ * @SuppressWarnings(PHPMD.ExcessivePublicCount)  25 methods, measured — see Scope above.
+ */
+interface ObjectServiceInterface {
+
+	/**
+	 * Persist an object, creating or updating it.
+	 *
+	 * @param array           $object        The object to store.
+	 * @param ?array          $extend        Relations to expand on the result.
+	 * @param string|int|null $register      Register id, UUID or slug.
+	 * @param string|int|null $schema        Schema id, UUID or slug.
+	 * @param ?string         $uuid          The object UUID.
+	 * @param bool            $_rbac         Apply register RBAC.
+	 * @param bool            $_multitenancy Apply organisation scoping.
+	 * @param bool            $silent        Suppress events for this save.
+	 * @param bool            $_validation   Validate against the schema.
+	 * @param ?array          $uploadedFiles Files uploaded alongside the object.
+	 * @param ?IUser          $currentUser   Explicit acting user; null uses the session.
+	 * @param bool            $failIfExists  Fail instead of updating when the object already exists.
+	 *
+	 * @return ObjectEntityInterface The stored object.
+	 */
+	public function saveObject(
+		array $object,
+		?array $extend=[],
+		string|int|null $register=null,
+		string|int|null $schema=null,
+		?string $uuid=null,
+		bool $_rbac=true,
+		bool $_multitenancy=true,
+		bool $silent=false,
+		bool $_validation=true,
+		?array $uploadedFiles=null,
+		?IUser $currentUser=null,
+		bool $failIfExists=false
+	): ObjectEntityInterface;
+
+	/**
+	 * Scope subsequent calls to a register.
+	 *
+	 * @param string|int $register Register id, UUID or slug.
+	 *
+	 * @return static This service, for chaining.
+	 */
+	public function setRegister(string|int $register): static;
+
+	/**
+	 * Find a single object by id, UUID or slug.
+	 *
+	 * @param int|string      $id            Object id, UUID or slug.
+	 * @param ?array          $_extend       Relations to expand on the result.
+	 * @param bool            $files         Include file metadata.
+	 * @param string|int|null $register      Register id, UUID or slug.
+	 * @param string|int|null $schema        Schema id, UUID or slug.
+	 * @param bool            $_rbac         Apply register RBAC.
+	 * @param bool            $_multitenancy Apply organisation scoping.
+	 * @param bool            $_render       Render the entity before returning it.
+	 * @param bool            $_audit        Write an audit-trail entry.
+	 *
+	 * @return ?ObjectEntityInterface The object, or null when absent or not permitted.
+	 */
+	public function find(
+		int|string $id,
+		?array $_extend=[],
+		bool $files=false,
+		string|int|null $register=null,
+		string|int|null $schema=null,
+		bool $_rbac=true,
+		bool $_multitenancy=true,
+		bool $_render=true,
+		bool $_audit=true
+	): ?ObjectEntityInterface;
+
+	/**
+	 * Find every object matching a configuration.
+	 *
+	 * @param array $config        Filters, limit, offset, sort and search.
+	 * @param bool  $_rbac         Apply register RBAC.
+	 * @param bool  $_multitenancy Apply organisation scoping.
+	 *
+	 * @return array The matching objects.
+	 */
+	public function findAll(
+		array $config=[],
+		bool $_rbac=true,
+		bool $_multitenancy=true
+	): array;
+
+	/**
+	 * Scope subsequent calls to a schema.
+	 *
+	 * @param string|int $schema Schema id, UUID or slug.
+	 *
+	 * @return static This service, for chaining.
+	 */
+	public function setSchema(string|int $schema): static;
+
+	/**
+	 * Search objects with a query.
+	 *
+	 * @param array   $query         The search query.
+	 * @param bool    $_rbac         Apply register RBAC.
+	 * @param bool    $_multitenancy Apply organisation scoping.
+	 * @param ?array  $ids           Restrict the search to these ids.
+	 * @param ?string $uses          Restrict to objects used by this one.
+	 * @param ?array  $views         Restrict the search to these views.
+	 *
+	 * @return array|int Results, or a count when the query asks for one.
+	 */
+	public function searchObjects(
+		array $query=[],
+		bool $_rbac=true,
+		bool $_multitenancy=true,
+		?array $ids=null,
+		?string $uses=null,
+		?array $views=null
+	): array|int;
+
+	/**
+	 * Delete an object by UUID.
+	 *
+	 * @param string          $uuid            The object UUID.
+	 * @param string|int|null $register        Register id, UUID or slug.
+	 * @param string|int|null $schema          Schema id, UUID or slug.
+	 * @param bool            $_rbac           Apply register RBAC.
+	 * @param bool            $_multitenancy   Apply organisation scoping.
+	 * @param bool            $_retentionSweep Run as part of a retention sweep.
+	 * @param ?IUser          $currentUser     Explicit acting user; null uses the session.
+	 * @param bool            $permanent       Delete permanently instead of soft-deleting.
+	 *
+	 * @return bool True when the object was deleted.
+	 */
+	public function deleteObject(
+		string $uuid,
+		string|int|null $register=null,
+		string|int|null $schema=null,
+		bool $_rbac=true,
+		bool $_multitenancy=true,
+		bool $_retentionSweep=false,
+		?IUser $currentUser=null,
+		bool $permanent=false
+	): bool;
+
+	/**
+	 * Search objects and return a paginated result set.
+	 *
+	 * @param array   $query         The search query.
+	 * @param bool    $_rbac         Apply register RBAC.
+	 * @param bool    $_multitenancy Apply organisation scoping.
+	 * @param bool    $deleted       Include soft-deleted objects.
+	 * @param ?array  $ids           Restrict the search to these ids.
+	 * @param ?string $uses          Restrict to objects used by this one.
+	 * @param ?array  $views         Restrict the search to these views.
+	 *
+	 * @return array Results plus pagination metadata.
+	 */
+	public function searchObjectsPaginated(
+		array $query=[],
+		bool $_rbac=true,
+		bool $_multitenancy=true,
+		bool $deleted=false,
+		?array $ids=null,
+		?string $uses=null,
+		?array $views=null
+	): array;
+
+	/**
+	 * Search objects by register and schema SLUG.
+	 *
+	 * Resolves the slugs to ids first. `findAll()` and `searchObjects()` take
+	 * NUMERIC ids and return nothing for a slug, silently -- which is why this
+	 * method exists and why it is on the contract.
+	 *
+	 * @param string $registerSlug  The register slug.
+	 * @param string $schemaSlug    The schema slug.
+	 * @param array  $filters       Equality filters.
+	 * @param bool   $_rbac         Apply register RBAC.
+	 * @param bool   $_multitenancy Apply organisation scoping.
+	 *
+	 * @return array|int The matching objects, or a count.
+	 */
+	public function searchObjectsBySlug(
+		string $registerSlug,
+		string $schemaSlug,
+		array $filters=[],
+		bool $_rbac=true,
+		bool $_multitenancy=true
+	): array|int;
+
+	/**
+	 * Drop the register/schema scope set by setRegister()/setSchema().
+	 *
+	 * @return void
+	 */
+	public function clearCurrents(): void;
+
+	/**
+	 * Translate raw request parameters into a search query.
+	 *
+	 * @param array                 $requestParams Raw request parameters.
+	 * @param int|string|array|null $register      Register id, UUID or slug.
+	 * @param int|string|array|null $schema        Schema id, UUID or slug.
+	 * @param ?array                $ids           Restrict the search to these ids.
+	 *
+	 * @return array The search query.
+	 */
+	public function buildSearchQuery(
+		array $requestParams,
+		int|string|array|null $register=null,
+		int|string|array|null $schema=null,
+		?array $ids=null
+	): array;
+
+	/**
+	 * Persist many objects in one bulk operation.
+	 *
+	 * @param array           $objects        The objects to store.
+	 * @param string|int|null $register       Register id, UUID or slug.
+	 * @param string|int|null $schema         Schema id, UUID or slug.
+	 * @param bool            $_rbac          Apply register RBAC.
+	 * @param bool            $_multitenancy  Apply organisation scoping.
+	 * @param bool            $validation     Validate against the schema.
+	 * @param bool            $events         Emit events for each object.
+	 * @param bool            $deduplicateIds Drop duplicate ids within the batch.
+	 * @param bool            $enrich         Enrich each object with derived metadata.
+	 * @param bool            $_audit         Write an audit-trail entry.
+	 *
+	 * @return array The stored objects.
+	 */
+	public function saveObjects(
+		array $objects,
+		string|int|null $register=null,
+		string|int|null $schema=null,
+		bool $_rbac=true,
+		bool $_multitenancy=true,
+		bool $validation=false,
+		bool $events=false,
+		bool $deduplicateIds=true,
+		bool $enrich=true,
+		bool $_audit=true
+	): array;
+
+	/**
+	 * Run an operation with system privileges, bypassing user scoping.
+	 *
+	 * @param callable $operation The operation to run.
+	 *
+	 * @return mixed Whatever the operation returns.
+	 */
+	public function runAsSystem(callable $operation);
+
+	/**
+	 * Count objects in the current register/schema context.
+	 *
+	 * @param array $config Filters, limit, offset, sort and search.
+	 *
+	 * @return int The number of matching objects.
+	 */
+	public function count(array $config=[]): int;
+
+	/**
+	 * Release a lock on an object.
+	 *
+	 * @param string|int $identifier The object id or UUID.
+	 * @param bool       $advisory   Take an advisory (non-blocking) lock.
+	 *
+	 * @return bool True when the lock was released.
+	 */
+	public function unlockObject(string|int $identifier, bool $advisory=false): bool;
+
+	/**
+	 * Take a lock on an object.
+	 *
+	 * @param string  $identifier The object id or UUID.
+	 * @param ?string $process    A label for the process holding the lock.
+	 * @param ?int    $duration   Lock duration in seconds.
+	 * @param bool    $advisory   Take an advisory (non-blocking) lock.
+	 *
+	 * @return array The resulting lock state.
+	 */
+	public function lockObject(
+		string $identifier,
+		?string $process=null,
+		?int $duration=null,
+		bool $advisory=false
+	): array;
+
+	/**
+	 * Delete many objects by UUID.
+	 *
+	 * @param array $uuids         The object UUIDs.
+	 * @param bool  $_rbac         Apply register RBAC.
+	 * @param bool  $_multitenancy Apply organisation scoping.
+	 *
+	 * @return array Per-UUID delete results.
+	 */
+	public function deleteObjects(
+		array $uuids=[],
+		bool $_rbac=true,
+		bool $_multitenancy=true
+	): array;
+
+	/**
+	 * The audit-trail rows for an object.
+	 *
+	 * @param string $uuid          The object UUID.
+	 * @param array  $filters       Equality filters.
+	 * @param bool   $_rbac         Apply register RBAC.
+	 * @param bool   $_multitenancy Apply organisation scoping.
+	 *
+	 * @return array The audit-trail rows.
+	 */
+	public function getLogs(
+		string $uuid,
+		array $filters=[],
+		bool $_rbac=true,
+		bool $_multitenancy=true
+	): array;
+
+	/**
+	 * Apply a partial update to an existing object.
+	 *
+	 * @param string $objectId      The object UUID.
+	 * @param array  $data          The fields to change.
+	 * @param bool   $_rbac         Apply register RBAC.
+	 * @param bool   $_multitenancy Apply organisation scoping.
+	 *
+	 * @return ObjectEntityInterface The updated object.
+	 */
+	public function updateObject(
+		string $objectId,
+		array $data,
+		bool $_rbac=true,
+		bool $_multitenancy=true
+	): ObjectEntityInterface;
+
+	/**
+	 * The objects this object refers to.
+	 *
+	 * @param string $objectId      The object UUID.
+	 * @param array  $query         The search query.
+	 * @param bool   $_rbac         Apply register RBAC.
+	 * @param bool   $_multitenancy Apply organisation scoping.
+	 *
+	 * @return array The referenced objects.
+	 */
+	public function getObjectUses(
+		string $objectId,
+		array $query=[],
+		bool $_rbac=true,
+		bool $_multitenancy=true
+	): array;
+
+	/**
+	 * The objects that refer to this object.
+	 *
+	 * @param string $objectId      The object UUID.
+	 * @param array  $query         The search query.
+	 * @param bool   $_rbac         Apply register RBAC.
+	 * @param bool   $_multitenancy Apply organisation scoping.
+	 *
+	 * @return array The referring objects.
+	 */
+	public function getObjectUsedBy(
+		string $objectId,
+		array $query=[],
+		bool $_rbac=true,
+		bool $_multitenancy=true
+	): array;
+
+	/**
+	 * Find objects that relate to a given search term.
+	 *
+	 * @param string $search       The term to match relations against.
+	 * @param bool   $partialMatch Match relations partially.
+	 *
+	 * @return array The related objects.
+	 */
+	public function findByRelations(string $search, bool $partialMatch=true): array;
+
+	/**
+	 * Find an object without emitting audit or read events.
+	 *
+	 * @param string          $id            Object id, UUID or slug.
+	 * @param ?array          $_extend       Relations to expand on the result.
+	 * @param bool            $files         Include file metadata.
+	 * @param string|int|null $register      Register id, UUID or slug.
+	 * @param string|int|null $schema        Schema id, UUID or slug.
+	 * @param bool            $_rbac         Apply register RBAC.
+	 * @param bool            $_multitenancy Apply organisation scoping.
+	 *
+	 * @return ObjectEntityInterface The object.
+	 */
+	public function findSilent(
+		string $id,
+		?array $_extend=[],
+		bool $files=false,
+		string|int|null $register=null,
+		string|int|null $schema=null,
+		bool $_rbac=true,
+		bool $_multitenancy=true
+	): ObjectEntityInterface;
+
+	/**
+	 * Count the objects a search query would return.
+	 *
+	 * @param array   $query         The search query.
+	 * @param bool    $_rbac         Apply register RBAC.
+	 * @param bool    $_multitenancy Apply organisation scoping.
+	 * @param ?array  $ids           Restrict the search to these ids.
+	 * @param ?string $uses          Restrict to objects used by this one.
+	 *
+	 * @return int The number of matching objects.
+	 */
+	public function countSearchObjects(
+		array $query=[],
+		bool $_rbac=true,
+		bool $_multitenancy=true,
+		?array $ids=null,
+		?string $uses=null
+	): int;
+
+	/**
+	 * The object currently held as context, if any.
+	 *
+	 * @return ?ObjectEntityInterface The context object, or null when none is set.
+	 */
+	public function getObject(): ?ObjectEntityInterface;
+}

--- a/tests/Unit/Service/BlastServiceTest.php
+++ b/tests/Unit/Service/BlastServiceTest.php
@@ -181,8 +181,8 @@ class BlastServiceTest extends TestCase {
 					return $this->objectService;
 				}
 
-				// ComplianceService and SourceService intentionally absent —
-				// BlastService should fall back to the closed-fail path.
+				// ComplianceService and OpenConnector's CallService intentionally
+				// absent — BlastService should fall back to the closed-fail path.
 				throw new \RuntimeException('not registered: ' . $id);
 			}
 		);
@@ -206,6 +206,45 @@ class BlastServiceTest extends TestCase {
 			$this->logger,
 		);
 	}//end setUp()
+
+	/**
+	 * Build a fake CallLog-shaped object mirroring the real
+	 * `OCA\OpenConnector\Service\CallService::call()` return contract — an
+	 * OpenRegister `ObjectEntity` exposing `getObject()` with `statusCode`
+	 * and a `response.body` (UTF-8 JSON string).
+	 *
+	 * @param int $statusCode HTTP status code to report.
+	 * @param array<string, mixed>|null $bodyJson JSON-decodable response
+	 *                                            body, or null for an empty body.
+	 *
+	 * @return object Fake CallLog entity.
+	 */
+	public static function fakeCallLog(int $statusCode, ?array $bodyJson): object {
+		$body = '';
+		if ($bodyJson !== null) {
+			$body = (string)json_encode($bodyJson);
+		}
+
+		return new class ($statusCode, $body) {
+
+			public function __construct(private int $statusCode, private string $body) {
+			}//end __construct()
+
+			/**
+			 * @return array<string, mixed>
+			 */
+			public function getObject(): array {
+				return [
+					'statusCode' => $this->statusCode,
+					'response' => [
+						'statusCode' => $this->statusCode,
+						'body' => $this->body,
+						'encoding' => 'UTF-8',
+					],
+				];
+			}//end getObject()
+		};
+	}//end fakeCallLog()
 
 	/**
 	 * variantFor returns "A" when abSplitPercent is null or out-of-range.
@@ -637,10 +676,12 @@ class BlastServiceTest extends TestCase {
 	}//end testSendBlastCreatesVariantChildOnAbSplit()
 
 	/**
-	 * Slice 09 — dispatchBlastDeliveries calls openconnector's send-mail
-	 * action exactly once per queued delivery, flips each row to `sent`
-	 * with a providerId, and respects the rate-limit (source value < caller
-	 * → throttle helper invoked at least once between batches).
+	 * Slice 09 — dispatchBlastDeliveries POSTs to the resolved openconnector
+	 * Source via `CallService::call()` exactly once per queued delivery,
+	 * flips each row to `sent` with a providerId, and respects the
+	 * rate-limit derived from the source's `rateLimitLimit`/`rateLimitWindow`
+	 * (source value < caller → throttle helper invoked at least once between
+	 * batches).
 	 *
 	 * @return void
 	 */
@@ -663,6 +704,13 @@ class BlastServiceTest extends TestCase {
 		];
 		$this->objectService->store['blast-dispatch'] = $blast;
 		$this->objectService->store['tmpl-d'] = $template;
+		// Source's rate limit is intentionally lower (1 msg/s) than the
+		// caller-supplied rate (100/s) so the source config wins.
+		$this->objectService->store['oc-source-x'] = [
+			'uuid' => 'oc-source-x',
+			'rateLimitLimit' => 1,
+			'rateLimitWindow' => 1,
+		];
 		$this->objectService->deliveries = [
 			['uuid' => 'dx-1', 'blastId' => 'blast-dispatch', 'contactId' => 'c1', 'email' => 'c1@example.test', 'status' => 'queued'],
 			['uuid' => 'dx-2', 'blastId' => 'blast-dispatch', 'contactId' => 'c2', 'email' => 'c2@example.test', 'status' => 'queued'],
@@ -684,7 +732,7 @@ class BlastServiceTest extends TestCase {
 			}
 		);
 
-		$sourceService = new class {
+		$callService = new class {
 
 			/**
 			 * @var array<int, array<string, mixed>>
@@ -692,43 +740,38 @@ class BlastServiceTest extends TestCase {
 			public array $calls = [];
 
 			/**
-			 * Return a source object whose sendRateLimit is intentionally
-			 * lower than the caller-supplied rate.
+			 * Mock CallService::call — captures every dispatched call and
+			 * returns a synthetic CallLog carrying a providerId derived from
+			 * the recipient.
 			 *
-			 * @param string $id Source id.
+			 * @param object $source Resolved Source entity.
+			 * @param string $endpoint Endpoint (relative to the source base URL).
+			 * @param string $method HTTP method.
+			 * @param array<string, mixed> $config Guzzle-shaped request config.
 			 *
-			 * @return array<string, mixed>|null Source row.
+			 * @return object Fake CallLog entity.
 			 */
-			public function find(string $id): ?array {
-				return ['uuid' => $id, 'sendRateLimit' => 1];
-			}//end find()
-
-			/**
-			 * Mock executeAction — captures every send-mail call and
-			 * returns a synthetic provider id derived from the recipient.
-			 *
-			 * @param string $sourceId Source id.
-			 * @param string $action Action name.
-			 * @param array $payload Send-mail input.
-			 *
-			 * @return array<string, string> Provider response.
-			 */
-			public function executeAction(string $sourceId, string $action, array $payload): array {
-				$this->calls[] = ['sourceId' => $sourceId, 'action' => $action, 'payload' => $payload];
-				return ['providerId' => 'p-' . count($this->calls)];
-			}//end executeAction()
+			public function call(array|object $source, string $endpoint, string $method, array $config): object {
+				$this->calls[] = [
+					'source' => $source,
+					'endpoint' => $endpoint,
+					'method' => $method,
+					'config' => $config,
+				];
+				return BlastServiceTest::fakeCallLog(200, ['providerId' => 'p-' . count($this->calls)]);
+			}//end call()
 		};
 
 		$objectService = $this->objectService;
 		$this->container = $this->createMock(ContainerInterface::class);
 		$this->container->method('get')->willReturnCallback(
-			function (string $id) use ($sourceService, $objectService) {
+			function (string $id) use ($callService, $objectService) {
 				if ($id === 'OCA\\OpenRegister\\Service\\ObjectService') {
 					return $objectService;
 				}
 
-				if ($id === 'OCA\\OpenConnector\\Service\\SourceService') {
-					return $sourceService;
+				if ($id === 'OCA\\OpenConnector\\Service\\CallService') {
+					return $callService;
 				}
 
 				throw new \RuntimeException('not registered: ' . $id);
@@ -752,12 +795,13 @@ class BlastServiceTest extends TestCase {
 		$dispatched = $service->dispatchBlastDeliveries('blast-dispatch', 100);
 
 		$this->assertSame(3, $dispatched, 'every queued row was dispatched');
-		$this->assertCount(3, $sourceService->calls, 'one send-mail call per row');
-		foreach ($sourceService->calls as $call) {
-			$this->assertSame('send-mail', $call['action']);
-			$this->assertSame('oc-source-x', $call['sourceId']);
-			$this->assertArrayHasKey('to', $call['payload']);
-			$this->assertArrayHasKey('subject', $call['payload']);
+		$this->assertCount(3, $callService->calls, 'one CallService::call per row');
+		foreach ($callService->calls as $call) {
+			$this->assertSame('', $call['endpoint'], 'the source base URL is called directly');
+			$this->assertSame('POST', $call['method']);
+			$this->assertArrayHasKey('json', $call['config']);
+			$this->assertArrayHasKey('to', $call['config']['json']);
+			$this->assertArrayHasKey('subject', $call['config']['json']);
 		}
 
 		// Each row was flipped to `sent` with a providerId.
@@ -780,12 +824,12 @@ class BlastServiceTest extends TestCase {
 	}//end testDispatchBlastDeliveriesCallsOpenconnectorAndRespectsRateLimit()
 
 	/**
-	 * Slice 09 — dispatchBlastDeliveries returns 0 and persists no rows
-	 * when the openconnector source service is unavailable (fail-closed).
+	 * Slice 09 — dispatchBlastDeliveries returns 0 and persists no rows when
+	 * the referenced openconnector Source object does not exist (fail-closed).
 	 *
 	 * @return void
 	 */
-	public function testDispatchBlastDeliveriesFailsClosedWhenSourceServiceUnavailable(): void {
+	public function testDispatchBlastDeliveriesFailsClosedWhenConnectorSourceNotFound(): void {
 		$blast = [
 			'uuid' => 'blast-no-oc',
 			'segmentId' => 'seg-no-oc',
@@ -805,16 +849,60 @@ class BlastServiceTest extends TestCase {
 			['uuid' => 'dn-1', 'blastId' => 'blast-no-oc', 'contactId' => 'c1', 'email' => 'c1@example.test', 'status' => 'queued'],
 		];
 
-		// SourceService NOT registered in the container — every send call
-		// should fail-closed and the row should NOT flip to sent.
+		// 'oc-source-missing' is not in the objectService store — the
+		// register:'openconnector'/schema:'source' lookup misses, so every
+		// send call should fail-closed and the row should NOT flip to sent.
 		$dispatched = $this->service->dispatchBlastDeliveries('blast-no-oc', 100);
 		$this->assertSame(0, $dispatched);
 
 		$sentRows = array_filter($this->objectService->saved,
 			fn (array $row) => ($row['status'] ?? null) === 'sent',
 		);
-		$this->assertCount(0, $sentRows, 'no deliveries should flip to sent when SourceService is unavailable');
-	}//end testDispatchBlastDeliveriesFailsClosedWhenSourceServiceUnavailable()
+		$this->assertCount(0, $sentRows, 'no deliveries should flip to sent when the connector source is missing');
+	}//end testDispatchBlastDeliveriesFailsClosedWhenConnectorSourceNotFound()
+
+	/**
+	 * Slice 09 — dispatchBlastDeliveries returns 0 and persists no rows when
+	 * the connector source resolves but OpenConnector's `CallService` is
+	 * unavailable (fail-closed). This is the scenario that used to be
+	 * "SourceService unavailable" — `SourceService` no longer exists, so the
+	 * equivalent hard dependency today is `CallService`.
+	 *
+	 * @return void
+	 */
+	public function testDispatchBlastDeliveriesFailsClosedWhenCallServiceUnavailable(): void {
+		$blast = [
+			'uuid' => 'blast-no-cs',
+			'segmentId' => 'seg-no-cs',
+			'templateId' => 'tmpl-no-cs',
+			'channel' => 'email',
+			'status' => 'sending',
+			'connectorSourceId' => 'oc-source-no-cs',
+		];
+		$template = [
+			'uuid' => 'tmpl-no-cs',
+			'bodyHtml' => '<p>{{email}}</p>',
+			'bodyText' => '{{email}}',
+		];
+		$this->objectService->store['blast-no-cs'] = $blast;
+		$this->objectService->store['tmpl-no-cs'] = $template;
+		$this->objectService->store['oc-source-no-cs'] = ['uuid' => 'oc-source-no-cs'];
+		$this->objectService->deliveries = [
+			['uuid' => 'dn-2', 'blastId' => 'blast-no-cs', 'contactId' => 'c1', 'email' => 'c1@example.test', 'status' => 'queued'],
+		];
+
+		// The connector source resolves fine but CallService is NOT
+		// registered in the container (setUp()'s default container mock) —
+		// every send call should fail-closed and the row should NOT flip to
+		// sent.
+		$dispatched = $this->service->dispatchBlastDeliveries('blast-no-cs', 100);
+		$this->assertSame(0, $dispatched);
+
+		$sentRows = array_filter($this->objectService->saved,
+			fn (array $row) => ($row['status'] ?? null) === 'sent',
+		);
+		$this->assertCount(0, $sentRows, 'no deliveries should flip to sent when CallService is unavailable');
+	}//end testDispatchBlastDeliveriesFailsClosedWhenCallServiceUnavailable()
 
 	/**
 	 * Slice 09 — updateBlastTotals on a blast with no deliveries leaves
@@ -862,30 +950,31 @@ class BlastServiceTest extends TestCase {
 		];
 		$this->objectService->store['blast-flag-off'] = $blast;
 		$this->objectService->store['tmpl-flag'] = $template;
+		$this->objectService->store['oc-source-flag'] = ['uuid' => 'oc-source-flag'];
 		$this->objectService->deliveries = [
 			['uuid' => 'd-flag-off', 'blastId' => 'blast-flag-off', 'contactId' => 'c1', 'email' => 'c1@example.test', 'status' => 'queued'],
 		];
 
-		$sourceService = new class {
+		$callService = new class {
 			/** @var array<int, array<string, mixed>> */
 			public array $calls = [];
 
-			public function executeAction(string $sourceId, string $action, array $payload): array {
-				$this->calls[] = $payload;
-				return ['providerId' => 'p-1'];
-			}//end executeAction()
+			public function call(array|object $source, string $endpoint, string $method, array $config): object {
+				$this->calls[] = $config['json'];
+				return BlastServiceTest::fakeCallLog(200, ['providerId' => 'p-1']);
+			}//end call()
 		};
 
 		$objectService = $this->objectService;
 		$this->container = $this->createMock(ContainerInterface::class);
 		$this->container->method('get')->willReturnCallback(
-			function (string $id) use ($sourceService, $objectService) {
+			function (string $id) use ($callService, $objectService) {
 				if ($id === 'OCA\\OpenRegister\\Service\\ObjectService') {
 					return $objectService;
 				}
 
-				if ($id === 'OCA\\OpenConnector\\Service\\SourceService') {
-					return $sourceService;
+				if ($id === 'OCA\\OpenConnector\\Service\\CallService') {
+					return $callService;
 				}
 
 				// TrackingLinkService must never be resolved when the flag is off.
@@ -899,7 +988,7 @@ class BlastServiceTest extends TestCase {
 		$this->assertSame(1, $dispatched);
 		$this->assertSame(
 			'<body><a href="https://pipelinq.nl/q4">Read more</a></body>',
-			$sourceService->calls[0]['bodyHtml'],
+			$callService->calls[0]['bodyHtml'],
 		);
 	}//end testSendOneDeliveryDoesNotInjectTrackingWhenFlagOff()
 
@@ -926,6 +1015,7 @@ class BlastServiceTest extends TestCase {
 		];
 		$this->objectService->store['blast-flag-on'] = $blast;
 		$this->objectService->store['tmpl-flag-on'] = $template;
+		$this->objectService->store['oc-source-flag-on'] = ['uuid' => 'oc-source-flag-on'];
 		$this->objectService->deliveries = [
 			['uuid' => 'd-flag-on', 'blastId' => 'blast-flag-on', 'contactId' => 'c1', 'email' => 'c1@example.test', 'status' => 'queued'],
 		];
@@ -945,14 +1035,14 @@ class BlastServiceTest extends TestCase {
 			}
 		);
 
-		$sourceService = new class {
+		$callService = new class {
 			/** @var array<int, array<string, mixed>> */
 			public array $calls = [];
 
-			public function executeAction(string $sourceId, string $action, array $payload): array {
-				$this->calls[] = $payload;
-				return ['providerId' => 'p-1'];
-			}//end executeAction()
+			public function call(array|object $source, string $endpoint, string $method, array $config): object {
+				$this->calls[] = $config['json'];
+				return BlastServiceTest::fakeCallLog(200, ['providerId' => 'p-1']);
+			}//end call()
 		};
 
 		$trackingLinkService = new class {
@@ -968,13 +1058,13 @@ class BlastServiceTest extends TestCase {
 		$objectService = $this->objectService;
 		$this->container = $this->createMock(ContainerInterface::class);
 		$this->container->method('get')->willReturnCallback(
-			function (string $id) use ($sourceService, $objectService, $trackingLinkService) {
+			function (string $id) use ($callService, $objectService, $trackingLinkService) {
 				if ($id === 'OCA\\OpenRegister\\Service\\ObjectService') {
 					return $objectService;
 				}
 
-				if ($id === 'OCA\\OpenConnector\\Service\\SourceService') {
-					return $sourceService;
+				if ($id === 'OCA\\OpenConnector\\Service\\CallService') {
+					return $callService;
 				}
 
 				if ($id === 'OCA\\Pipelinq\\Service\\TrackingLinkService') {
@@ -989,8 +1079,140 @@ class BlastServiceTest extends TestCase {
 		$dispatched = $service->dispatchBlastDeliveries('blast-flag-on', 100);
 
 		$this->assertSame(1, $dispatched);
-		$this->assertSame('<body>original</body><!--tracked-->', $sourceService->calls[0]['bodyHtml']);
+		$this->assertSame('<body>original</body><!--tracked-->', $callService->calls[0]['bodyHtml']);
 		$this->assertCount(1, $trackingLinkService->calls);
 		$this->assertSame('d-flag-on', $trackingLinkService->calls[0]['blastDeliveryId']);
 	}//end testSendOneDeliveryInjectsTrackingWhenFlagOn()
+
+	/**
+	 * Dedicated shape-assertion test — resolveConnectorSource looks the
+	 * Source up in the `openconnector`/`source` register+schema (not
+	 * pipelinq's own `register` app-config register), and CallService::call
+	 * is invoked with an empty relative endpoint (the source's own base URL
+	 * is the send target), `POST`, and the rendered payload as a `json`
+	 * body — the exact shape a real `OCA\OpenConnector\Service\CallService`
+	 * expects.
+	 *
+	 * @return void
+	 */
+	public function testSendOneDeliveryResolvesSourceFromOpenconnectorRegisterAndCallsCallServiceWithJsonPost(): void {
+		$blast = [
+			'uuid' => 'blast-shape',
+			'templateId' => 'tmpl-shape',
+			'channel' => 'email',
+			'status' => 'sending',
+			'connectorSourceId' => 'oc-source-shape',
+		];
+		$template = [
+			'uuid' => 'tmpl-shape',
+			'subject' => 'Hi {{contactId}}',
+			'bodyHtml' => '<p>{{email}}</p>',
+		];
+		$this->objectService->store['blast-shape'] = $blast;
+		$this->objectService->store['tmpl-shape'] = $template;
+		$this->objectService->store['oc-source-shape'] = ['uuid' => 'oc-source-shape'];
+		$this->objectService->deliveries = [
+			['uuid' => 'd-shape', 'blastId' => 'blast-shape', 'contactId' => 'c1', 'email' => 'c1@example.test', 'status' => 'queued'],
+		];
+
+		$objectService = new class ($this->objectService) {
+
+			/**
+			 * @var array<int, array<string, mixed>>
+			 */
+			public array $findCalls = [];
+
+			/**
+			 * @param object $delegate The shared setUp() objectService mock.
+			 */
+			public function __construct(private object $delegate) {
+			}//end __construct()
+
+			public function find(string $id, $register = null, $schema = null): ?array {
+				$this->findCalls[] = ['id' => $id, 'register' => $register, 'schema' => $schema];
+				return $this->delegate->find($id, $register, $schema);
+			}//end find()
+
+			public function findAll(array $config = []): array {
+				return $this->delegate->findAll($config);
+			}//end findAll()
+
+			public function count(array $config = []): int {
+				return $this->delegate->count($config);
+			}//end count()
+
+			public function saveObject(array $object, $register = null, $schema = null, ?string $uuid = null): array {
+				return $this->delegate->saveObject($object, $register, $schema, $uuid);
+			}//end saveObject()
+		};
+
+		$callService = new class {
+			/** @var array<int, array<string, mixed>> */
+			public array $calls = [];
+
+			public function call(array|object $source, string $endpoint, string $method, array $config): object {
+				$this->calls[] = [
+					'source' => $source,
+					'endpoint' => $endpoint,
+					'method' => $method,
+					'config' => $config,
+				];
+				return BlastServiceTest::fakeCallLog(200, ['providerId' => 'p-shape']);
+			}//end call()
+		};
+
+		$this->container = $this->createMock(ContainerInterface::class);
+		$this->container->method('get')->willReturnCallback(
+			function (string $id) use ($callService, $objectService) {
+				if ($id === 'OCA\\OpenRegister\\Service\\ObjectService') {
+					return $objectService;
+				}
+
+				if ($id === 'OCA\\OpenConnector\\Service\\CallService') {
+					return $callService;
+				}
+
+				throw new \RuntimeException('not registered: ' . $id);
+			}
+		);
+
+		$service = new BlastService($this->container, $this->appConfig, $this->segmentService, $this->logger);
+		$dispatched = $service->dispatchBlastDeliveries('blast-shape', 100);
+
+		$this->assertSame(1, $dispatched);
+
+		// resolveConnectorSource() looked the Source up in OpenConnector's
+		// OWN register/schema — not pipelinq's `register` app-config value
+		// ('pipelinq' per setUp()'s appConfig mock).
+		$sourceLookups = array_filter($objectService->findCalls, fn (array $c) => $c['id'] === 'oc-source-shape');
+		$this->assertNotEmpty($sourceLookups, 'the connector source id must be looked up');
+		foreach ($sourceLookups as $call) {
+			$this->assertSame('openconnector', $call['register']);
+			$this->assertSame('source', $call['schema']);
+		}
+
+		// CallService::call() shape: empty relative endpoint (the source's
+		// own base URL is the target), POST, rendered payload as JSON body.
+		$this->assertCount(1, $callService->calls);
+		$this->assertSame('', $callService->calls[0]['endpoint']);
+		$this->assertSame('POST', $callService->calls[0]['method']);
+		$expectedJson = [
+			'to' => 'c1@example.test',
+			'subject' => 'Hi c1',
+			'bodyHtml' => '<p>c1@example.test</p>',
+			'bodyText' => '',
+			'senderName' => '',
+			'senderEmail' => '',
+			'replyTo' => '',
+		];
+		$this->assertSame(['json' => $expectedJson], $callService->calls[0]['config']);
+
+		// The BlastDelivery was flipped to sent with the providerId parsed
+		// from the CallLog's JSON response body.
+		$sentRows = array_filter($this->objectService->saved,
+			fn (array $row) => ($row['status'] ?? null) === 'sent',
+		);
+		$this->assertCount(1, $sentRows);
+		$this->assertSame('p-shape', array_values($sentRows)[0]['providerId']);
+	}//end testSendOneDeliveryResolvesSourceFromOpenconnectorRegisterAndCallsCallServiceWithJsonPost()
 }//end class


### PR DESCRIPTION
## Summary
Pre-existing production bug, unrelated to the OpenConnector-dialect-retirement migration (found while auditing `BlastForm.vue` for that work) — connector-backed email/SMS blast delivery has been failing closed silently, likely for months.

- `GET /apps/openconnector/api/sources` was removed ~3 months ago when OpenConnector's CRUD moved onto OpenRegister's generic object API; `BlastForm.vue` was still calling it and silently swallowing the 404.
- `OCA\OpenConnector\Service\SourceService` no longer exists in OpenConnector at all; `BlastService`'s send path resolved it via a caught-and-silenced exception.
- Fixed: source listing now calls `GET /apps/openregister/api/objects/openconnector/source?type=api&isEnabled=true&_limit=200`; sending now resolves the Source via OpenRegister and dispatches through `CallService::call()` (the current live primitive, confirmed via `PingAction`/`SourceCallNode`). Both failure paths now surface a real error instead of a silent empty/no-op state.
- Also fixed a second dead-field bug on the same path (`sendRateLimit` → `rateLimitLimit`/`rateLimitWindow`) and stale `SourceService` doc references in the SMS/WhatsApp client classes (already correctly routed through `MessageDispatchProvider`, only comments were stale).
- **Left untouched, flagged separately:** `ExportDestinationService`/`ExportUploadService` (BI-export feature) call the same dead `SourceService::getCredentials()` — needs its own investigation, out of scope here.
- **Also surfaced, separately:** `vendor/bin/phpunit` couldn't bootstrap at all before this PR (missing `tests/Stubs/Contract/{ObjectServiceInterface,ObjectEntityInterface}.php`) — fixed as a prerequisite for testing this change. Once bootstrap worked, the full suite showed many unrelated pre-existing failures (stale `ObjectService` stub signatures, e.g. `LoyaltyControllerTest`) — this repo's unit suite has likely not been running successfully fleet-wide; worth its own follow-up, not fixed here.

## Test plan
- [x] `BlastServiceTest.php` 21/21 pass, including a new test asserting the exact OpenRegister lookup + `CallService::call()` argument shape
- [x] `WhatsAppAdapterTest.php` + `WhatsAppSendFlowTest.php` unaffected
- [x] `phpcs`/`phpstan`/`psalm` clean on `BlastService.php`
- [x] `eslint`/`stylelint` clean on `BlastForm.vue`; `vitest` 45/45 pass